### PR TITLE
Corrected a casing issue with vagrant init not matching the boxname

### DIFF
--- a/htmldocs/config-vagrant.html
+++ b/htmldocs/config-vagrant.html
@@ -161,7 +161,7 @@ The URL can be from the list above or a local file if you have already downloade
           <div class="step">
           <h2>Initialise and start</h2>
 <p>Initialize this environment by running:</p>
-<pre class="prettyprint lang-bash">vagrant init JujuQuickstart</pre>
+<pre class="prettyprint lang-bash">vagrant init JujuQuickStart</pre>
 
 <p>Then start it with:</p> 
 <pre class="prettyprint lang-bash">vagrant up</pre>


### PR DESCRIPTION
This was confusing new users, so fix the casing on the command so it matches the boxname being imported.
