### PR TITLE
Clarify/update Manual Provisioning docs

### DIFF
--- a/htmldocs/config-manual.html
+++ b/htmldocs/config-manual.html
@@ -76,7 +76,7 @@
             Juju provides a feature called "manual provisioning" that enables you to deploy Juju, and charms, to existing systems. This is useful if you have groups of machines that you want to use for Juju but don't want to add the complexity of a new OpenStack or MAAS setup. It is also useful as a means of deploying workloads to VPS providers and other cheap hosting options. We will describe in this section how to configure an environment using this feature.</p>
 
             <h2>Prerequisites</h2>
-            <p>Manual provisioning enables you to run Juju on systems that have a supported operating system installed. You will need to ensure that you have both SSH access and sudo rights. It is not necessary to <a href="https://help.ubuntu.com/community/SSH/OpenSSH/Keys">have a password-less login</a>, however it will improve the experience by reducing the need for repeated logins.</p>
+            <p>Manual provisioning enables you to run Juju on systems that have a supported operating system installed. You will need to ensure that you have both SSH access and sudo rights.</p>
 
             <h2>Configuration</h2>
             <p>You should start by generating a generic configuration file for Juju and then switching to the Manual provider by using the command:
@@ -122,7 +122,7 @@ juju bootstrap
 </pre>
             <p>The <code>juju bootstrap</code> command will connect to <code>bootstrap-host</code> via SSH, and copy across and install the Juju agent.</p>
 
-            <p class="note"><strong>Note:</strong> Automated destruction of manual environments is currently unimplemented. To remove Juju from the <code>bootstrap-host</code>, you will need to manually stop and remove the upstart jobs (<code>/etc/init/juju*</code>).</p>
+            <p>When bootstrapping, Juju will create the "ubuntu" user if it does not already exist. To eliminate the need for repeated password prompts, Juju will configure password-less ssh and sudo for the ubuntu user.</p>
 
             <h2>Adding machines</h2>
             <p>To add another machine into a manual environment, you must use a variant of the <code>juju add-machine</code> command, such as follows:</p>
@@ -135,13 +135,15 @@ juju add-machine ssh:otheruser@10.1.1.3
 
 <p>As with bootstrapping, <code>juju add-machine ssh:...</code> will connect to the machine via SSH to install the Juju agent. Machines added in this way may be removed in the usual manner, with <code>juju destroy-machine</code>.</p>
 
+<p>The username specified in <code>juju add-machine ssh:[user@]host</code> is only used when initially connecting to the machine. Thereafter, the "ubuntu" user will be used as described in the Bootstrapping section above.</p>
+
             <h2>Considerations and caveats</h2>
             <p>As is implied by its name, the manual provider does not attempt to control all aspects of the environment, and leaves much to the user. There are several additional things to consider:</p>
             <ul>
                 <li>All machines added with <code>juju add-machine ssh:...</code> must be able to address and communicate directly with the <code>bootstrap-host</code>, and vice-versa.</li>
                 <li>Sudo access is required on all manually provisioned machines, to install the Juju upstart services.</li>
                 <li>Manually provisioned machines must be running a supported version of Ubuntu (12.04+).</li>
-                <li>It is not currently possible to manually provision machines into non-manual provider environments.</li>
+                <li>It is possible to manually provision machines into non-manual provider environments, however the machine must be placed on the same private subnet as the other machines in the environment.</li>
                 <li>Since adding machines is a manual step, using the manual provider doesn't have the "instant elasticity" benefits of using a proper provider; if you're an IaaS provider and want to help us natively support you, <a href="https://juju.ubuntu.com/community/">please contact us</a>.</li> 
             </ul>
 


### PR DESCRIPTION
- manual now sets up passwordless ssh/sudo for you
- `juju destroy-environment` has been implemented
- you can manually provision machines into non-manual environments, albeit with some rather stringent requirements
