### PR TITLE
Added doc about configuring juju to use proxies.

### DIFF
--- a/htmldocs/howto-proxies.html
+++ b/htmldocs/howto-proxies.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html> 
+<html>
+<!--Head-->
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<title>Juju Documentation</title>
+		<script src="/wp-content/themes/ubuntu/library/js/all-yui.js"></script>
+		<link href="https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic|Ubuntu+Mono" rel="stylesheet" type="text/css" />
+		<link rel="stylesheet" type="text/css" media="screen" href="https://juju.ubuntu.com/wp-content/themes/juju-website/css/reset.css" />
+ 		<link rel="shortcut icon" href="//assets.ubuntu.com/sites/ubuntu/latest/u/img/favicon.ico" />
+		<link rel="stylesheet" type="text/css" media="screen" href="//assets.ubuntu.com/sites/guidelines/css/latest/ubuntu-styles.css" />
+		<link rel="stylesheet" type="text/css" media="screen" href="//assets.ubuntu.com/sites/ubuntu/latest/u/css/global.css" />
+		<link rel="stylesheet" type="text/css" media="screen" href="https://juju.ubuntu.com/wp-content/themes/juju-website/css/960.css" />
+		<link rel="stylesheet" type="text/css" media="screen" href="https://juju.ubuntu.com/wp-content/themes/juju-website/css/home-new.css" />
+		<link rel="stylesheet" id="stacktack-css" href="https://juju.ubuntu.com/wp-content/plugins/stacktack/css/stacktack.min.css?ver=3.4.2" type="text/css" media="all" />
+		<link href="./css/main.css" rel="stylesheet" type="text/css" />
+		
+		<!--[if lt IE 9]>
+		<script type="text/javascript" src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+		<![endif]-->
+	</head>
+<!--End-Head-->
+
+
+
+
+
+
+
+
+  <body class="resources">
+  	
+<!--Header-->
+
+	<header class="banner global" role="banner">
+		<nav role="navigation" class="nav-primary nav-right">
+			<div class="logo">
+				<a class="logo-ubuntu" href="https://juju.ubuntu.com/">
+					<img width="118" height="27" src="//assets.ubuntu.com/sites/ubuntu/latest/u/img/logo.png" alt="Juju logo" />
+					<span>Juju</span>
+				</a>
+			</div>
+			<ul>
+				<li class="accessibility-aid"><a accesskey="s" href="#main-content">Jump to content</a></li>
+				<li class="page_item page-item-8"><a href="https://juju.ubuntu.com/charms/">Charms</a></li>
+				<li class="page_item page-item-10"><a href="https://juju.ubuntu.com/features/">Features</a></li>
+				<li class="page_item page-item-12"><a href="https://juju.ubuntu.com/deployment/">Deploy</a></li>
+				<li class="page_item page-item-14"><a href="https://juju.ubuntu.com/resources/">Resources</a></li>
+				<li class="page_item page-item-16"><a href="https://juju.ubuntu.com/community/">Community</a></li>
+				<li class="page_item page-item-18"><a href="https://juju.ubuntu.com/download/">Install Juju</a></li>
+			</ul>
+			<div id="box-search">
+				<form class="search-form" method="get" id="searchform" action="https://juju.ubuntu.com/">
+					<label class="off-left" for="s">Search:</label>
+					<input class="form-text" type="text" value="" name="s" id="s" />
+					<button class="off-left form-submit" type="submit" id="searchsubmit">Search</button>
+				</form>		
+			</div>
+		</nav>	
+	</header>
+<!--End-Header-->
+<!--Preamble-->
+<div class="wrapper">
+  <div id="main-content" class="inner-wrapper" role="main">
+    <div class="row no-border">
+     <div class="header-navigation-secondary"></div>
+     <h2 class="pagetitle">Juju documentation</h2>
+    </div>
+    <section id="content" class="container-12">
+      <div class="grid-12 doc-container">
+        <div id="navlinks" class="grid-3 doc-navigation">LINKS</div>
+        <div class="grid-9 doc-content">
+<!--End-Preamble-->
+          <article>
+            <section id="howto-proxies">
+              <h1>Configure Proxy Access</h1>
+              <p>Juju supports proxies and has special support for proxying apt. Proxies can be configured for the providers in the environments.yaml file, or added to an existing environment using <code>juju set-env</code> The configuration options are:</p>
+              <ul>
+                <li>http-proxy</li>
+                <li>https-proxy</li>
+                <li>ftp-proxy</li>
+                <li>no-proxy</li>
+              </ul>
+              <p>Each protocol-specific option accepts a URL. The <code>no-proxy</code> option is a list of host names and addresses that services can directly connect to. For example:</p>
+              <pre class="prettyprint yaml">
+                http-proxy: http://proxy.example.com:9000
+                https-proxy: https://user@10.0.0.1
+                no-proxy: localhost,10.0.3.1
+              </pre>
+              <p>There are three additional proxy options specific to apt. Juju's default behaviour is to use the protocol-specific proxy options, but you can specify exceptions for cases where the network has a local apt mirror.</p>
+              <ul>
+                <li>apt-http-proxy</li>
+                <li>apt-https-proxy</li>
+                <li>apt-ftp-proxy</li>
+              </ul>
+              <p>For example, with a squid-deb-proxy running on a laptop, you can specify the apt-http-proxy to use it for the containers by specifying the host machine’s network-bridge:</p>
+              <pre class="prettyprint yaml">
+                apt-http-proxy: http://10.0.3.1:8000
+              </pre>
+              <p>The proxy options are exported in all hook execution contexts, and also available in the shell through <code>juju ssh</code> or <code>juju run</code>.</p>
+            </section>
+          </article>
+<!--Postamble-->
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+<!--End-Postamble-->
+<!--Footer-->
+	<footer class="global clearfix" role="contentinfo">
+		<nav role="navigation">
+			<div class="footer-a">
+				<div class="clearfix">
+					<ul>
+						<li>
+							<h2><a href="/">Juju</a></h2>
+							<ul>
+								<li><a href="/charms">Charms</a></li>
+								<li><a href="/features">Features</a></li>
+								<li><a href="/deployment">Deployment</a></li>
+							</ul>
+						</li>
+						<li>
+							<h2><a href="/resources">Resources</a></h2>
+							<ul>
+								<li><a href="/resources/juju-overview/">Overview</a></li>
+								<li><a href="/docs/">Documentation</a></li>
+								<li><a href="/resources/the-juju-gui/">The Juju web UI</a></li>
+								<li><a href="/docs/authors-charm-store.html">The charm store</a></li>
+								<li><a href="/docs/getting-started.html#test">Tutorial</a></li>
+								<li><a href="/resources/videos/">Videos</a></li>
+								<li><a href="/resources/easy-tasks-for-new-developers/">Easy tasks for new developers</a></li>
+							</ul>
+						</li>
+						<li>
+							<h2><a href="/community">Community</a></h2>
+							<ul>
+								<li><a href="/community/blog/">Juju Blog</a></li>
+								<li><a href="/events/">Events</a></li>
+								<li><a href="/community/weekly-charm-meeting/">Weekly charm meeting</a></li>
+								<li><a href="/community/charmers/">Charmers</a></li>
+								<li><a href="/docs/authors-charm-writing.html">Write a charm</a></li>
+								<li><a href="/docs/contributing.html">Help with documentation</a></li>
+								<li><a href="https://bugs.launchpad.net/juju-core/+filebug">File a bug</a></li> <li><a href="/labs/">Juju Labs</a></li>
+							</ul>
+						</li>
+						<li>
+							<h2><a href="https://jujucharms.com/sidebar/">Try Juju</a></h2>
+							<ul>
+								<li><a href="https://jujucharms.com/">Charm store</a></li>
+								<li><a href="/download/">Download Juju</a></li>
+							</ul>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</nav>
+		<div class="legal clearfix">
+			<p>&copy; 2013-2014 Canonical Ltd. Ubuntu and Canonical are registered trademarks of <a href="http://canonical.com">Canonical Ltd</a>.</p>
+		</div>
+	</footer>
+
+<!--End-Footer-->
+
+
+
+<!--Scripts-->
+    <script src="//google-code-prettify.googlecode.com/svn/loader/run_prettify.js?skin=sunburst"></script>
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.14/jquery-ui.min.js"></script>
+    <script src="//d38yea5fb4e2oh.cloudfront.net/jquery.stacktack.min.js"></script>    
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.9.1.js"></script>
+    <script type="text/javascript" src="./js/main.js"></script>
+    <script type="text/javascript" src="./js/jquery.details.js"></script>
+    <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/core.js"></script>
+    <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/global.js"></script>
+    <!-- google analytics -->
+    <script>
+   var _gaq = _gaq || [];
+   _gaq.push(['_setAccount', 'UA-1018242-41']);
+   _gaq.push(['_trackPageview']);
+  
+   (function() {
+   var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+   ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+   })();
+    </script>
+<!--End-Scripts-->
+
+
+
+
+
+
+
+</body></html>

--- a/htmldocs/navigation.html
+++ b/htmldocs/navigation.html
@@ -26,6 +26,7 @@
               <li class=" sub"><a href="howto-rails.html">Test and deploy on Rails</a></li>
               <li class=" sub"><a href="howto-gui-management.html">Manage Juju with the GUI</a></li>
               <li class=" sub"><a href="howto-privatecloud.html">Set up a Private Cloud</a></li>
+              <li class=" sub"><a href="howto-proxies.html">Configure Proxy Access</a></li>
               <li class="sub"><a href="howto-vagrant-workflow.html">Vagrant Workflow</a></li>
               <li class=""><a href="troubleshooting-local.html">Troubleshooting</a></li>
             </ul>
@@ -66,6 +67,6 @@
               <li class="sub"><a href="commands.html">Juju commands</a></li>
               <li class="sub"><a href="reference-constraints.html">Juju constraints</a></li>
               <li class="sub"><a href="glossary.html">Glossary</a></li>
-	      <li class="sub"><a href="reference-reviewers.html">Charm Review Criteria</a></li>
+              <li class="sub"><a href="reference-reviewers.html">Charm Review Criteria</a></li>
               <li class="sub"><a href="contributing.html">Contribute to the Docs!</a></li>
             </ul>

--- a/htmldocs/navigation.json
+++ b/htmldocs/navigation.json
@@ -36,28 +36,26 @@
         "Test and deploy on Rails": "howto-rails.html",
         "Manage Juju with the GUI": "howto-gui-management.html",
         "Set up a Private Cloud": "howto-privatecloud.html",
+        "Configure Proxy Access": "howto-proxies.html",
         "Vagrant Workflow": "howto-vagrant-workflow.html"
       }
     },
     "Troubleshooting": {
       "link": "troubleshooting-local.html"
     }
-
-
   },
   "Additional Tools": {
-    "Charm-tools": "tools-charm-tools.html"
+    "Charm-tools": "tools-charm-tools.html",
     "Amulet": "tools-amulet.html"
   },
   "Charm Authors": {
-
     "Getting started": {
      "link": "authors-intro.html"
     },
     "Components of a charm": {
       "link": "authors-charm-components.html",
       "children": {
-    	"metadata.yaml": "authors-charm-metadata.html",
+        "metadata.yaml": "authors-charm-metadata.html",
         "hooks": "authors-hook-kinds.html",
         "config.yaml": "authors-charm-config.html"
 
@@ -66,7 +64,7 @@
     "Writing a Charm": {
       "link": "authors-charm-writing.html",
       "children": {
-    	"How hooks are run": "authors-hook-environment.html",
+        "How hooks are run": "authors-hook-environment.html",
         "Relations lifecycle": "authors-charm-interfaces.html",
         "Implementing interfaces": "authors-relations-in-depth.html",
         "Hook Errors": "authors-hook-errors.html",
@@ -83,7 +81,7 @@
         "Submitting a Charm": "authors-charm-store.html#submitting",
         "Charm Store Policy": "authors-charm-policy.html",
         "Best Practices": "authors-charm-best-practices.html",
-        "Charm Feature Rating": "authors-charm-quality.html"
+        "Charm Feature Rating": "authors-charm-quality.html",
         "Charm Icons": "authors-charm-icon.html"
       }
     }


### PR DESCRIPTION
This new doc is a rewrite of the release notes (though maybe I need to update the release note with what I learned). I added examples and vetted them with Tim,

FIxes LP:1301964 and LP:1292167

Note that "Configure Proxy Access" is consistent with the names of the how to docs like "Mange" and "Deploy", but I see other sections use "Managing" and "Deploying". Don't hate me.
