### PR TITLE
Fix github link in docs

### DIFF
--- a/htmldocs/contributing.html
+++ b/htmldocs/contributing.html
@@ -128,7 +128,7 @@
               <h2>Submitting your work</h2>
               <p>We love it when the community contributes to documentation, here's how to contribute:</p>
               <ul>
-              <li>The code is available on <a href="http://github.com/docs/juju">github.com/juju/docs</a></li>
+              <li>The code is available on <a href="http://github.com/juju/docs">github.com/juju/docs</a></li>
               <li><a href="https://help.github.com/articles/fork-a-repo">Fork the repository</a></li>
               <li>Add or edit the documentation in your favorite text editor</li>
               <li><a href="https://help.github.com/articles/creating-a-pull-request">Submit a pull requestion</a></li>


### PR DESCRIPTION
I noticed the link to the github repo was wrong.  Here's a fix.
