### PR TITLE
separate the juju run in two lines

### DIFF
--- a/src/en/charms-working-with-units.md
+++ b/src/en/charms-working-with-units.md
@@ -62,7 +62,8 @@ For example, to run uname on every instance:
 
 Or to run uptime on some instances:
 
-    juju run "uptime" --machine=2 juju run "uptime" --service=mysql
+    juju run "uptime" --machine=2
+    juju run "uptime" --service=mysql
 
 !!! Note: When using `juju run` with the `--service` option, keep in mind that
 whichever command you pass will run on *every unit* of that service.


### PR DESCRIPTION
The juju run command should be in 2 lines as it's 2 different examples.
