### PR TITLE
Fixed NOTE bugs, unnecessary [*] mark, lots of remnant code[...]

### DIFF
--- a/src/en/authors-testing.md
+++ b/src/en/authors-testing.md
@@ -103,7 +103,7 @@ test, and then the file ended with `INFO: END filename`.
 
 #### Deploy requirements and Poll
 
-The test below [*] deploys mediawiki with mysql and memcached related to it, and then tests to make sure it returns a page via http with `<title>` somewhere in the content.:
+The test below deploys mediawiki with mysql and memcached related to it, and then tests to make sure it returns a page via http with `<title>` somewhere in the content.:
 
 ```bash
 #!/bin/sh

--- a/src/en/charms-working-with-units.md
+++ b/src/en/charms-working-with-units.md
@@ -66,7 +66,7 @@ Or to run uptime on some instances:
     juju run "uptime" --machine=2
     juju run "uptime" --service=mysql
 
-!!! Note: When using `juju run` with the `--service` option, keep in mind that
+**Note: ** When using `juju run` with the `--service` option, keep in mind that
 whichever command you pass will run on *every unit* of that service.
 
 When used in combination with certain services you can script out certain

--- a/src/en/howto-offline-charms.md
+++ b/src/en/howto-offline-charms.md
@@ -115,7 +115,7 @@ the `set-env` command:
 juju set-env "default-series=trusty"
 ```
 
-!!! Note: Specifying a local repository makes Juju look there *first*, but if
+**Note: ** Specifying a local repository makes Juju look there *first*, but if
 the relevant charm is not found in that repository, it will fall back to
 fetching it from the charm store. If you wish to check where a charm was
 installed from, it is listed in the `juju status` output.

--- a/src/en/howto-privatecloud.md
+++ b/src/en/howto-privatecloud.md
@@ -1,20 +1,3 @@
-[ ![Juju logo](//assets.ubuntu.com/sites/ubuntu/latest/u/img/logo.png) Juju
-](https://juju.ubuntu.com/)
-
-  - Jump to content
-  - [Charms](https://juju.ubuntu.com/charms/)
-  - [Features](https://juju.ubuntu.com/features/)
-  - [Deploy](https://juju.ubuntu.com/deployment/)
-  - [Resources](https://juju.ubuntu.com/resources/)
-  - [Community](https://juju.ubuntu.com/community/)
-  - [Install Juju](https://juju.ubuntu.com/download/)
-
-Search: Search
-
-## Juju documentation
-
-LINKS
-
 #  Set up a Private Cloud using Simplestreams
 
 When Juju bootstraps a cloud, it needs two critical pieces of information:
@@ -304,36 +287,3 @@ available for Juju to use:
 The same comments apply. Run the validation tool without parameters to use
 details from the Juju environment, or override values as required on the command
 line. See `juju help metadata validate-tools` for more details.
-
-  - ## [Juju](/)
-
-    - [Charms](/charms/)
-    - [Features](/features/)
-    - [Deployment](/deployment/)
-  - ## [Resources](/resources/)
-
-    - [Overview](/resources/overview/)
-    - [Documentation](/docs/)
-    - [The Juju web UI](/resources/juju-gui/)
-    - [The charm store](/docs/authors-charm-store.html)
-    - [Tutorial](/docs/getting-started.html#test)
-    - [Videos](/resources/videos/)
-    - [Easy tasks for new developers](/resources/easy-tasks-for-new-developers/)
-  - ## [Community](/community)
-
-    - [Juju Blog](/community/blog/)
-    - [Events](/events/)
-    - [Weekly charm meeting](/community/weekly-charm-meeting/)
-    - [Charmers](/community/charmers/)
-    - [Write a charm](/docs/authors-charm-writing.html)
-    - [Help with documentation](/docs/contributing.html)
-    - [File a bug](https://bugs.launchpad.net/juju-core/+filebug)
-    - [Juju Labs](/communiy/labs/)
-  - ## [Try Juju](https://jujucharms.com/sidebar/)
-
-    - [Charm store](https://jujucharms.com/)
-    - [Download Juju](/download/)
-
-(C) 2013-2014 Canonical Ltd. Ubuntu and Canonical are registered trademarks of
-[Canonical Ltd](http://www.canonical.com).
-

--- a/src/en/tools-charm-tools.md
+++ b/src/en/tools-charm-tools.md
@@ -113,7 +113,7 @@ user input. To suppress prompts and accept all defaults instead, use the
   - `-t`, `--template`: The template to use when creating the charm.
   - `-a`, `--accept-defaults`: If the chosen template prompts for user
     input, suppress all prompts and accept the defaults instead.
-  - `-v`, `--verboes`: Show debug output.
+  - `-v`, `--verbose`: Show debug output.
 
 ### Bash Example
 


### PR DESCRIPTION
I found some issues where !!! Note was used instead of

```
**Note: **
```

There was also an unnecessary `[*]` mark in authors-testing. I assume a list item used to be here, but since this is a single step item and the `[*]` was not being rendered, I opted to remove it entirely.

The How To - Private Cloud had a lot of old code that looked like it was a remnant from an old doc header or table of contents, which simply isn't being used and took up a lot of page space.
