### PR TITLE
Update config-openstack documentation

### DIFF
--- a/src/en/config-openstack.md
+++ b/src/en/config-openstack.md
@@ -91,3 +91,10 @@ useful:
 
 [Ubuntu Cloud
 Infrastructure](https://help.ubuntu.com/community/UbuntuCloudInfrastructure)
+
+# Bootstrapping
+
+Before being able to bootstrap into a Private Openstack Cloud you'll need to generate
+simplestreams metadata:
+
+[How to setup a Private Cloud](howto-privatecloud.html)


### PR DESCRIPTION
Direct users to the Private Cloud howto for syncing simplestreams metadata in
order to successfully juju bootstrap.

It was not obvious that the "How to Private Cloud" was the next step to getting
juju working with Openstack.

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
