### PR TITLE
Changes to authors-hook-debug

### DIFF
--- a/src/en/authors-hook-debug.md
+++ b/src/en/authors-hook-debug.md
@@ -191,51 +191,31 @@ hand. Here are some of the ones you may find useful:
 
 #### Window-related:
 
-Control-a 0
-
-    Switch to window 0 (similarly, any other numbered window).
-Control-a c
-
-    Create a new window.
-Control-a n
-
-    Switch to the next window.
-Control-a p
-
-    Switch to the previous window.
-Control-a w
-
-    Choose a window from a list.
+| Shortcut | Description |
+| -------- | -------- |
+| Control-a 0 | Switch to window 0 (similarly, any other numbered window). |
+| Control-a c | Create a new window. |
+| Control-a n | Switch to the next window. |
+| Control-a p | Switch to the previous window. |
+| Control-a w | Choose a window from a list. |
 
 #### Pane-related:
 
-Control-a %
-
-    Split pane vertically.
-Control-a |
-
-    Split pane horizontally.
-Control-a o
-
-    Switch focus to next pane.
-Control-a ;
-
-    Switch focus to the previous pane.
-Control-a !
-
-    Move current pane to a new window.
-Control-a x
-
-    Kill the current pane.
+| Shortcut | Description |
+| -------- | -------- |
+| Control-a % | Split pane vertically. |
+| Control-a &#124; | Split pane horizontally. |
+| Control-a o | Switch focus to next pane. |
+| Control-a ; | Switch focus to the previous pane. |
+| Control-a ! | Move current pane to a new window. |
+| Control-a x | Kill the current pane. |
 
 #### Miscellaneous:
 
-Control-a ?
-
-    Show currently configured keys.
-Control-a :
-
-    Enter the command prompt (for tmux commands)
+| Shortcut | Description |
+| -------- | -------- |
+| Control-a ? | Show currently configured keys. |
+| Control-a : | Enter the command prompt (for tmux commands) |
 
 You can get more info on tmux and its commands at the [relevant Ubuntu manpage
 entry.](http://manpages.ubuntu.com/manpages/trusty/man1/tmux.1.html)


### PR DESCRIPTION
Prior to change, authors-hook-debug had a list of commands for tmux that was longer than necessary (in terms of vertical space on the page). I changed it to use GFM tables.
