### PR TITLE
Initial draft / write-up of Charm Review Process document

### DIFF
--- a/src/en/charm-review-process.md
+++ b/src/en/charm-review-process.md
@@ -3,10 +3,20 @@
 Reviewing a Juju Charm is a process that can easily be broken down into
 the following parts:
 
-1. Setting up a branch of the charm
-2. Charm Information Review
-3. Charm Deployment, Configuration and Testing
-4. Gathering / Submitting Your Results
+1. Identifying what to review
+2. Setting up a branch of the charm
+3. Charm Information Review
+4. Charm Deployment, Configuration and Testing
+5. Gathering / Submitting Your Results
+
+## Identifying what to review
+
+When determining what charm (or merge request for a charm) you should
+review, prioritize whichever you think best achieves the goal of helping people
+enjoy getting things done in Juju. That might be the newest ones, neglected
+patches, easy patches, or those from new contributors. Take a look at the
+[Review Queue](http://review.juju.solutions) to best determine what needs to
+be done!
 
 ## Setting up a branch of the charm
 Lets get started with setting up a branch of the charm. The process below


### PR DESCRIPTION
This is the initial draft of a Charm Review Process document. This document is meant to outline the process for both ~charmers as well as community charm reviewers. Up until now, there has not been a simple yet detailed process on **how** to review Juju Charms, so it has not provided the community a good path on how to get involved in the overall review process.

Do note, this document is not, as it stands, meant to completely replace the reference-reviewers document, rather to supplement it. The current reference-reviewers document contains a bunch of unnecessary cruft, Ubuntuisms, etc. and will be reviewed, modified, and submitted in a separate pull request.

I look forward to everyone's comments, suggestions, etc. I think we should have a happy middleground that ensures the document is not overly complex, provides community reviewers and charmers alike a clear path on how to review charms, and doesn't lose out on "valuable" information.
