### PR TITLE
Fixed an issue where multi-line navigation pane links would overflow into next link.

### DIFF
--- a/htmldocs/css/main.css
+++ b/htmldocs/css/main.css
@@ -141,7 +141,8 @@ code {
   margin-bottom: 1px;
   font-size: 13px;
   font-weight:bold;
-  height: 21px;
+  height: auto;
+  min-height: 22px !important;
   line-height: 22px;
 }
 


### PR DESCRIPTION
This happens under the REFERENCE section, specifically the context "Juju environment variables", which is two lines instead of one. The change in CSS still allows for the minimum list item height but allows it to automatically expand if necessary.
