### PR TITLE
Add empty default parameter to charm docs

### DIFF
--- a/src/en/authors-charm-config.md
+++ b/src/en/authors-charm-config.md
@@ -13,7 +13,8 @@ definition must contain all of the following fields:
 
 Any option without these three fields will generate a Warning from the the
 [charm proof tool](tools-charm-tools.html#proof)
-indicating the option is not compliant with charm store policy.  
+indicating the option is not compliant with charm store policy. This policy
+allows older versions of juju to safely unset values.
 
 ## What to expose to users
 


### PR DESCRIPTION
- Add empty default param to examples
- Add simple explanation why this change is desired (other than it's to pass an arbitrary quality bar)
