### PR TITLE
Vagrant workflow

### DIFF
--- a/src/en/config-vagrant.md
+++ b/src/en/config-vagrant.md
@@ -174,3 +174,7 @@ to that group, run:
 
 
 Use the password "vagrant"
+
+## Reporting issues with the Vagrant Image
+
+If you encounter any bugs with the vagrant images, please [file a bug](https://bugs.launchpad.net/juju-vagrant-images) report.

--- a/src/en/howto-vagrant-workflow.md
+++ b/src/en/howto-vagrant-workflow.md
@@ -217,4 +217,4 @@ Installing juju, for deploying to non-local environments
 
 ## Reporting issues with the Vagrant Image
 
-If you encounter any bugs with the vagrant images, please [file a bug](https://bugs.launchpad.net/juju-vagrant-images)
+If you encounter any bugs with the vagrant images, please [file a bug](https://bugs.launchpad.net/juju-vagrant-images) report.


### PR DESCRIPTION
Updates the workflow to use trusty by default
Clean up some whitespace
Add documentation on local routing; sshuttle is broken on OS X 10.10, but traffic can be routed natively instead.
