### PR TITLE
reworked link refs to be relative

### DIFF
--- a/src/en/authors-charm-store.md
+++ b/src/en/authors-charm-store.md
@@ -9,8 +9,8 @@ call The Charm Store.
 
   - The main project page is here: [https://launchpad.net/charms](https://launchpad.net/charms)
   - There are useful tools for downloading, modifying, and contributing here: [https://launchpad.net/charm-tools](https://launchpad.net/charm-tools)
-  - Here is the official tutorial for charm authors: [https://jujucharms.com/docs/authors-charm-writing](https://jujucharms.com/docs/authors-charm-writing)
-  - Here is the official tutorial for bundle authors: [https://jujucharms.com/docs/charms-bundles.html](https://jujucharms.com/docs/charms-bundles.html)
+  - Here is the official tutorial for charm authors: [https://jujucharms.com/docs/authors-charm-writing](authors-charm-writing)
+  - Here is the official tutorial for bundle authors: [https://jujucharms.com/docs/charms-bundles.html](charms-bundles.html)
 
 ## Charm Store Submission
 

--- a/src/en/authors-intro.md
+++ b/src/en/authors-intro.md
@@ -8,4 +8,4 @@ There are however times when the particular service you want to use doesn't have
 
 You might want to start by looking at [what makes a charm](authors-charm-components.html), which breaks down and explains the different components that go into making a charm. Or you may want to dive right in with the [walkthrough for writing an example charm](authors-charm-writing.html).
 
-Because charms are language agnostic, there are many paths to writing a charm. [Charm Helpers](https://jujucharms.com/docs/tools-charm-helpers.html) is a good place to start if you are already familiar with Python.
+Because charms are language agnostic, there are many paths to writing a charm. [Charm Helpers](tools-charm-helpers.html) is a good place to start if you are already familiar with Python.

--- a/src/en/charms-environments.md
+++ b/src/en/charms-environments.md
@@ -34,7 +34,9 @@ It is also possible to determine the current environment by checking the
 
 ## Specifying an environment
 
-You can use the `-e` switch with a Juju command, followed by a valid environment label, to specify that the command should be run against that environment. Using the `-e` switch takes precedence over any other setting.
+You can use the `-e` switch with a Juju command, followed by a valid environment
+label, to specify that the command should be run against that environment. Using
+the `-e` switch takes precedence over any other setting.
 
 For example:
 
@@ -42,7 +44,8 @@ For example:
     juju switch amazon             # switches the environment to the cloud defined by 'amazon'
     juju deploy mysql -e mycloud   # deploys mysql charm on the cloud defined by 'mycloud'
 
-**Note: ** Unlike many switches used with juju, `-e` must come at the end of the command in order to be parsed correctly.
+**Note: ** Unlike many switches used with juju, `-e` must come at the end of the
+command in order to be parsed correctly.
 
 ## Switching environments
 
@@ -58,12 +61,17 @@ reason, you can switch the current environment using the `switch` command:
 This command will return with an error message if `JUJU_ENV`is set (as this
 takes precedence).
 
-**Note:** The environment selected with `switch` is persistent. Even if you log out, switch your computer off, travel into space or sail around the world, when you start using Juju again, it will still point at the last environment you specified with `switch`.
+**Note:** The environment selected with `switch` is persistent. Even if you log
+out, switch your computer off, travel into space or sail around the world, when
+you start using Juju again, it will still point at the last environment you
+specified with `switch`.
 
 ## Default environment
 
 The default environment is the environment which will be used if you have not
-issued a `switch` command and do not specify an environment to use with the `-e` switch or alter the `JUJU_ENV` environment variable. The default environment is specified at the top of the `environments.yaml` file, before the environment
+issued a `switch` command and do not specify an environment to use with the `-e`
+switch or alter the `JUJU_ENV` environment variable. The default environment is
+specified at the top of the `environments.yaml` file, before the environment
 specifications themselves, like this:
 
     ...
@@ -87,7 +95,8 @@ example, to see the default series that charms are deployed with, type:
     juju get-environment default-series
 
 The `set-environment` command will set a configuration option to the specified
-value. For example, you can set the default series that charms are deployed with to trusty like this:
+value. For example, you can set the default series that charms are deployed with
+to trusty like this:
 
     juju set-environment default-series=trusty
 
@@ -120,7 +129,8 @@ boilerplate `environments.yaml` so you can easily manually edit your own
 configurations or cut and paste new environments into your existing
 configuration.
 
-To generate a new boilerplate `environments.yaml` file direct to the console you can use:
+To generate a new boilerplate `environments.yaml` file direct to the console you
+can use:
 
     juju generate-config --show
 

--- a/src/en/charms-relationships.md
+++ b/src/en/charms-relationships.md
@@ -39,7 +39,7 @@ implementing it. If not feel free to create a new one.
 # How do I get/send data?
 
 Once you've defined your metadata, you'll need to create a few [new
-hooks](https://jujucharms.com/docs/authors-charm-hooks.html#relation-hooks)
+hooks](authors-charm-hooks.html#relation-hooks)
 the hook names are defined in the linked documentation, but since you're
 _just_ sending the address information we'll keep with a simple bash example
 of the implementation of each hook.
@@ -66,11 +66,16 @@ example:
 
     relation-set hostname=`unit-get private-address` public-address=`unit-get public-address`
 
-This will send two keys, `hostname` and `public-address` to whatever service it's connected to.
+This will send two keys, `hostname` and `public-address` to whatever service
+it's connected to.
 
 ## foo-client/hooks/backend-relation-changed
 
-Notice the difference in file name, this is invoking the `relation-changed` hook instead of `relation-joined`. Presumably the server is just giving the details of where it lives, so the client charm needs to know where that address is. By putting this in the relation-changed hook every time data on the relation is updated the hook is called again.
+Notice the difference in file name, this is invoking the `relation-changed` hook
+instead of `relation-joined`. Presumably the server is just giving the details
+of where it lives, so the client charm needs to know where that address is. By
+putting this in the relation-changed hook every time data on the relation is
+updated the hook is called again.
 
     #!/bin/bash
     set -eux
@@ -97,5 +102,5 @@ we don't have data. Yes, but, it's more along the lines of "We don't have
 data, yet". By exiting zero, once the corresponding service actually sets
 the value, it'll trigger the `relation-changed` hook again and we'll be able
 to read the value. This is considered an example of an [idempotency
-guard](https://jujucharms.com/docs/authors-charm-hooks.html#writing-hooks)
+guard](authors-charm-hooks.html#writing-hooks)
 which are crucial as you write hooks.

--- a/src/en/howto-node.md
+++ b/src/en/howto-node.md
@@ -68,11 +68,11 @@ laptop and then push out to the public cloud.
 
 We need to configure 2 environments, a local one and a public cloud one.
 
-1. Configure the [local provider](https://jujucharms.com/docs/config-local.html) on your machine.
+1. Configure the [local provider](config-local.html) on your machine.
 1. Configure a public or private cloud on your machine.
-  - [AWS](https://jujucharms.com/docs/config-aws.html)
-  - [HP Cloud](https://jujucharms.com/docs/config-hpcloud.html)
-  - [OpenStack](https://jujucharms.com/docs/config-openstack.html)
+  - [AWS](config-aws.html)
+  - [HP Cloud](config-hpcloud.html)
+  - [OpenStack](config-openstack.html)
 
 In this example the local environment is named `local` and we'll deploy to an
 AWS environment called `amazon`. First let's `switch` to the local environment

--- a/src/en/howto-offline-charms.md
+++ b/src/en/howto-offline-charms.md
@@ -16,7 +16,7 @@ these charms to pull code from an internal server when appropriate.
 
 ### Installation
 
-In addition to [Juju](https://jujucharms.com/docs/#installation) we need
+In addition to [Juju](getting-started#installation) we need
 to install charm-tools:
 
 ```
@@ -49,15 +49,16 @@ The command
 juju charm get mysql
 ```
 
-will download the MySQL charm to a `mysql` directory within your current path. By
-running
+will download the MySQL charm to a `mysql` directory within your current path.
+By running
 
 ```
 juju charm get wordpress ~/charms/precise/
 ```
 
-you will download the WordPress charm to `~/charms/precise/wordpress`. It is also
-possible to fetch all official charm store charms. The command for this task is
+you will download the WordPress charm to `~/charms/precise/wordpress`. It is
+also possible to fetch all official charm store charms. The command for this
+task is:
 
 ```
 juju charm getall [-h|--help] [CHARMS_DIRECTORY]

--- a/src/en/howto-rails.md
+++ b/src/en/howto-rails.md
@@ -15,7 +15,7 @@ deploy to a cloud, this is a powerful method for developing your application in
 an environment that more closely resembles production.
 
 Before moving on you should have gone through the [Getting
-Started](https://jujucharms.com/docs/getting-started.html) section and
+Started](getting-started.html) section and
 installed and configured Juju.
 
 ##  Basic Usage of the Ruby on Rails Charm


### PR DESCRIPTION
changed all the applicable references to be relative rather than absolute. This allows for greater portability, removes possible conflicts with languages/versions and compatibility for a printed version.

A few minor reformats included as a bonus.