### PR TITLE
Releases

### DIFF
--- a/htmldocs/css/main.css
+++ b/htmldocs/css/main.css
@@ -551,10 +551,17 @@ hr {
   font-weight: 600;
 }
 
-dl { border: 1px dotted #aaa; padding: 0.5em; background: #eeeeee; } 
-dt { float: left; clear: left; width: 100px; text-align: left; font-weight: bold; color: #000; } 
-dd { margin: 0 0 0 110px; padding: 0 0 0.5em 0; }
+dl {
+  border: 1px dotted #aaa;
+  padding: 0.5em;
+  background: #eeeeee;
+  margin-bottom: .75em;
+} 
+dt { float: left; clear: left; width: 130px; text-align: left; font-weight: bold; color: #000; } 
+dd { margin: 0 0 0 140px; padding: 0 0 0.5em 0; }
 dd:before { content: "- "; }
+dd.instruction:before  { content: none; }
+
 
 li img {
   margin-top: 10px;
@@ -585,4 +592,6 @@ h5:hover .anchor {
   background-color: #ddd;
   border-radius: 2px;
 }
-
+td pre {
+  text-align: left;
+}

--- a/src/en/reference-releases.md
+++ b/src/en/reference-releases.md
@@ -1,0 +1,97 @@
+Title: Juju Releases
+
+
+# Get the Latest Juju
+
+Juju is available for Ubuntu (and Debian-based OSes), Windows, and OS X.
+There can be 3 concurrent releases representing the stability of Juju's
+feature set. Unless you are testing new features and fixes, choose the
+current stable release to manage cloud deployments.
+
+
+## Stable
+
+The current stable version of Juju is 1.21.3.
+
+Stable juju is suitable for everyday production use.
+
+Ubuntu
+: <pre>sudo add-apt-repository ppa:juju/stable
+sudo apt-get update
+sudo apt-get install juju-core</pre>
+{: .instruction }
+
+OS X Homebrew
+: <pre>brew install juju</pre>
+{: .instruction }
+
+OS X
+: [juju-1.21.3-osx.tar.gz](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-1.21.3-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-1.21.3-osx.tar.gz/+md5))
+{: .instruction }
+
+Windows
+: [juju-setup-1.21.3-signed.exe](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-setup-1.21.3-signed.exe) ([md5](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-1.21.3-osx.tar.gz/+md5))
+{: .instruction }
+
+
+## Proposed
+
+No version is currently proposed to become stable.
+The current version in proposed is identical to stable.
+
+Proposed releases may be promoted to stable releases after a period of
+evaluation. They contain bug fixes and recently stablised features. They
+require evaluation from the community to verify no regressions are
+present. A propose version will not be promoted to stable if a
+regression is reported.
+
+Ubuntu
+: <pre>sudo add-apt-repository ppa:juju/proposed
+sudo apt-get update
+sudo apt-get install juju-core</pre>
+{: .instruction }
+
+OS X
+: [juju-1.21.3-osx.tar.gz](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-1.21.3-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-1.21.3-osx.tar.gz/+md5))
+{: .instruction }
+
+Windows
+: [juju-setup-1.21.3-signed.exe](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-setup-1.21.3-signed.exe) ([md5](https://launchpad.net/juju-core/1.21/1.21.3/+download/juju-1.21.3-osx.tar.gz/+md5))
+{: .instruction }
+
+Proposed releases use the 'proposed' simple-streams. You must configure
+the 'agent-stream' option in your environments.yaml to use the matching
+juju agents.
+
+    agent-stream: proposed
+
+
+## Development
+
+The current development release is 1.22-beta3.
+
+Development releases provide new features that are being stablised.
+These releases are *not* suitable for production environments. Upgrading
+from stable releases to development releases is not supported. You can
+upgrade test environments to development releases to test new features
+and fixes.
+
+Ubuntu
+: <pre>sudo add-apt-repository ppa:juju/devel
+sudo apt-get update
+sudo apt-get install juju-core</pre>
+{: .instruction }
+
+OS X
+: [juju-1.22-beta4-osx.tar.gz](https://launchpad.net/juju-core/1.22/1.22-beta4/+download/juju-1.22-beta4-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.22/1.22-beta4/+download/juju-1.22-beta4-osx.tar.gz/+md5))
+{: .instruction }
+
+Windows
+: [juju-setup-1.22-beta4.exe](https://launchpad.net/juju-core/1.22/1.22-beta4/+download/juju-setup-1.22-beta4.exe) ([md5](https://launchpad.net/juju-core/1.22/1.22-beta4/+download/juju-setup-1.22-beta4.exe/+md5))
+{: .instruction }
+
+Development releases use the 'devel' simple-streams. You must configure
+the 'agent-stream' option in your environments.yaml to use the matching
+juju agents.
+
+    agent-stream: devel

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -82,6 +82,7 @@
               <li class="sub"><a href="commands.html">Juju commands</a></li>
               <li class="sub"><a href="reference-constraints.html">Juju constraints</a></li>
               <li class="sub"><a href="reference-environment-variables.html">Juju environment variables</a></li>
+              <li class="sub"><a href="reference-releases.html">Releases</a></li>
               <li class="sub"><a href="reference-release-notes.html">Release notes</a></li>
               <li class="sub"><a href="glossary.html">Glossary</a></li>
               <li class="sub"><a href="reference-reviewers.html">Charm Review Criteria</a></li>

--- a/tools/build-from-source
+++ b/tools/build-from-source
@@ -3,7 +3,7 @@
 
 function build() {
    echo "Converting $(basename $1)"
-   txt=`markdown_py -x callouts -x partial_gfm -x anchors_away -x foldouts -x meta $1`
+   txt=`markdown_py -x callouts -x partial_gfm -x anchors_away -x foldouts -x meta -x def_list -x attr_list $1`
    DOCNAV="$(cat src/navigation.tpl)" CONTENT=$txt cheetah fill --stdout --env src/base.tpl > htmldocs/`basename ${1%.*}`.html
 }
 


### PR DESCRIPTION
Hi Nick.

I am co-opting this PR to discuss text and formatting of a page to list current releases and how get them. The goal is a single page that explain the 3 kinds of releases we do, and help the user get the version suited to them. There was a recent change to the ubuntu/juju site that is pointing windows users to
    https://launchpad.net/juju-core/+download
Which is promoting devel releases. I can see 10 or more Windows users got a devel release instead of a working stable release.

1. I think the text has the right information, but needs love.

2. I experimented with several layouts. for the instructions for ubuntu/osx/win. The subheader and list layouts were too loose and repetitive. They were hard to scan. I tried tables which almost works, but I had to fight the Ubunutu CSS. I don't like the table. So I offer additional support for definition lists. I like this. Even if you don't like the layout, you may want to keep definition lists for the glossary. The dashes for the dd elements did not play well with the code blocks, so I added attribute support to remove them.