### PR TITLE
Added link to bundle file documentation

### DIFF
--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -81,6 +81,8 @@ following data:
         - - "wordpress:db"
           - "mysql:db"
 
+You can find more information about the bundle files in the [juju-deployer documentation](http://pythonhosted.org/juju-deployer/config.html)
+
 ## Naming your Bundle
 
 By default the Juju GUI will name the bundle `envExport`. This is the first line in a bundle. The bundle must have a unique name. We recommend descriptive names for your bundle but nothing too long. `wordpress-simple`, `hadoop-cluster`, and `mongodb-sharded` are some examples of bundle names. Avoid CamelCase and periods for bundle names.


### PR DESCRIPTION
An askubuntu question made me realise this documentation does not point to the complete bundle spec.

http://askubuntu.com/questions/592690/are-there-docs-for-the-juju-bundle-file-format/597039