### PR TITLE
Replace Online Labs references to Scaleway

### DIFF
--- a/src/en/config-scaleway.md
+++ b/src/en/config-scaleway.md
@@ -1,29 +1,28 @@
-# Configuring for Online Labs
+# Configuring for Scaleway
 
 !!! **Note:** This provider is in "beta"
 and makes use of [manual provisioning](config-manual.html). Manual provisioning
 allows Juju users to implement any cloud provider's API calls and act similar to
 a provider implemented in the Juju Core code base.
-You can access the provider source-code on [github](https://github.com/online-labs/juju-onlinelabs)
+You can access the provider source-code on [github](https://github.com/scaleway/juju-scaleway)
 
 This package provides a CLI plugin for Juju that allows automated
-provisioning of physical servers on Online Labs.
+provisioning of C1 BareMetal SSD servers on Scaleway.
 
-Online Labs is the first worldwide hosting provider to offer dedicated arm servers in the cloud.
+Scaleway is the first IaaS provider worldwide to offer an ARM based cloud.
 It’s the ideal platform for horizontal scaling.
-The solution provides on demand resources: it comes with on-demand SSD storage, movable IPs and an S3 compatible object storage service.
-http://labs.online.net
+The solution provides on demand resources: it comes with on-demand SSD storage, movable IPs
+, images, security group and an Object Storage solution.
+https://scaleway.com
 
 This plugin is highly inspired from [kAPIlt](https://github.com/kAPIlt) Juju plugins.
 
 ## Requirements
 
-!!! **Note:** This process requires you to have an Online Labs account.
-The service is in preview for a few weeks and an invitation is required.
-To get one, ask [@online_en](http://twitter.com/online_en) on twitter.
+!!! **Note:** This process requires you to have an Scaleway account.
 
-- You have an account and are logged into [cloud.online.net](https://cloud.online.net)
-- You have configured your [SSH Key](https://doc.cloud.online.net/howto/ssh_keys.html)
+- You have an account and are logged into [cloud.scaleway.com](https://cloud.scaleway.com)
+- You have configured your [SSH Key](https://www.scaleway.com/docs/configure_new_ssh_key)
 
 
 ## Installation
@@ -32,15 +31,15 @@ Plugin installation is done via pipi, the Python package manager, available by d
 a [virtualenv](http://virtualenv.readthedocs.org/en/latest/index.html) is also recommanded to sandbox this install from your system packages:
 
 ```
-pip install -U juju-onlinelabs
+pip install -U juju-scaleway
 ```
 
 ## Configuration
 
-### Online Labs API keys
+### Scaleway API keys
 
-Before you can start using Juju with Online Labs, you will need to get an API token.
-API tokens are unique identifiers associated with your Online Labs account.
+Before you can start using Juju with Scaleway, you will need to get an API token.
+API tokens are unique identifiers associated with your Scaleway account.
 
 To get one, open the pull-down menu on your account name and click on "My Credentials" link.
 
@@ -53,8 +52,8 @@ Then, to generate a new token, click the "Create New Token" button on the right 
 In a terminal, export your credentials required by the plugin using environment variables:
 
 ```
-export ONLINELABS_ACCESS_KEY=<organization_key>
-export ONLINELABS_SECRET_KEY=<secret_token>
+export SCALEWAY_ACCESS_KEY=<organization_key>
+export SCALEWAY_SECRET_KEY=<secret_token>
 ```
 
 !!! **Note:** As environment variables are not shared between shells, you will need to repeat this operation for every shell.
@@ -62,11 +61,11 @@ You can avoid this repetition by adding this environment variables in your shell
 
 ### Juju configuration
 
-The next step is to add an environment for Online Labs in your '~/.juju/environments.yaml'. This environment will look like the following:
+The next step is to add an environment for Scaleway in your '~/.juju/environments.yaml'. This environment will look like the following:
 
 ```
-    # https://jujucharms.com/docs/config-onlinelabs.html
-    onlinelabs:
+    # https://jujucharms.com/docs/config-scaleway.html
+    scaleway:
         type: manual
         bootstrap-host: null
         bootstrap-user: root
@@ -76,33 +75,33 @@ Then, you have to tell Juju which environment to use.
 To do this, in a terminal use the following command:
 
 ```
-export JUJU_ENV=onlinelabs
+export JUJU_ENV=scaleway
 ```
 
-To set Online Labs as your default provider, run the following command in your terminal:
+To set Scaleway as your default provider, run the following command in your terminal:
 
 ```
-juju switch onlinelabs
+juju switch scaleway
 ```
 
 ## Bootstrapping
 
-Now you can bootstrap your Online Labs environment.
-You need to route the command through the onlinelabs plugin that we installed via pip.
+Now you can bootstrap your Scaleway environment.
+You need to route the command through the scaleway plugin that we installed via pip.
 
 ```
-juju onlinelabs bootstrap
+juju scaleway bootstrap
 ```
 
 All machines created by this plugin will have the Juju environment
-name as a prefix for their servers name, for instance `onlinelabs-XXXYYYZZZ`
+name as a prefix for their servers name, for instance `scaleway-XXXYYYZZZ`
 
 After your environment is bootstrapped you can add additional machines
 to it via the `add-machine` command, for instance the following will
 add 2 additional machines:
 
 ```
-juju onlinelabs add-machine -n 2
+juju scaleway add-machine -n 2
 juju status
 ```
 
@@ -129,33 +128,33 @@ Assemble these workloads together via relations like lego blocks:
 juju add-relation wordpress mysql
 ```
 
-You can list all machines in Online Labs that are part of the Juju
-environment with the list-machines command. This directly queries the Online
-Labs API and does not interact with the Juju API.
+You can list all machines in Scaleway that are part of the Juju
+environment with the list-machines command. This directly queries the Scaleway
+API and does not interact with the Juju API.
 
 ```
-juju onlinelabs list-machines
+juju scaleway list-machines
 
 Id       Name               Status   Created      Address
-6222349  onlinelabs-0            active   2014-11-25   212.47.239.232
-6342360  onlinelabs-ef19ad5cc... active   2014-11-25   212.47.228.28
-2224321  onlinelabs-145bf7a80... active   2014-11-25   212.47.228.79
+6222349  scaleway-0            active   2014-11-25   212.47.239.232
+6342360  scaleway-ef19ad5cc... active   2014-11-25   212.47.228.28
+2224321  scaleway-145bf7a80... active   2014-11-25   212.47.228.79
 ```
 
 You can terminate allocated machines via their machine id. By default, the
-Online Labs plugin forces the terminatiom of machines, which also terminates any service unit running on on those machines:
+Scaleway plugin forces the terminatiom of machines, which also terminates any service unit running on on those machines:
 
 ```
-juju onlinelabs terminate-machine 1 2
+juju scaleway terminate-machine 1 2
 ```
 
 And you can destroy the entire environment via:
 
 ```
-juju onlinelabs destroy-environment
+juju scaleway destroy-environment
 ```
 
 destroy-environment also takes a --force option which only uses the
-Online Labs API. It's helpful if the state server or other machines are
+Scaleway API. It's helpful if the state server or other machines are
 killed independently of Juju.
 

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -6,7 +6,7 @@
               <li class=" sub"><a href="config-azure.html">Windows Azure</a></li>
               <li class=" sub"><a href="config-hpcloud.html">HP Public Cloud</a></li>
               <li class=" sub"><a href="config-joyent.html">Joyent</a></li>
-              <li class=" sub"><a href="config-onlinelabs.html">Online Labs</a></li>
+              <li class=" sub"><a href="config-scaleway.html">Scaleway</a></li>
               <li class=" sub"><a href="config-digitalocean.html">DigitalOcean</a></li>
               <li class=" sub"><a href="config-openstack.html">OpenStack</a></li>
               <li class=" sub"><a href="config-maas.html">MAAS (bare metal)</a></li>


### PR DESCRIPTION
As Online Labs became Scaleway, I replaced Online Labs references by Scaleway.