### PR TITLE
Add auth-file to the GCE config notes.

### DIFF
--- a/src/en/reference-release-notes.md
+++ b/src/en/reference-release-notes.md
@@ -54,6 +54,7 @@ This release replaces version 1.22.1.
       my-gce:
        type: gce
        project-id: <your-project-id>
+       auth-file: <path-to-json-file-from-google>
        private-key: <your-private-key>
        client-email: <your-client-email>
        client-id: <your-client-id>
@@ -72,25 +73,25 @@ This release replaces version 1.22.1.
   environment's resources as well as to track the environment's cost and
   resource usage.
 
-  'private-key', 'client-email', and 'client-id' are your GCE OAuth
-  credentials.  These details are associated with the 'service account' of
-  the GCE project you will use for your Juju environment.  For each GCE
-  project, a service account is set up automatically when you create
-  your project. Juju uses that service account to connect to the GCE API
-  and does so with the proper authentication scope.  After you have
-  created the project you must get the credentials to use in
-  environments.yaml.  The client ID and client email address are found at
-  the following URL:
+  'auth-file' is the path to a JSON file you get from your GCE console
+  that contains all the authentication credentials it needs.  After you
+  have created your project, download the file by pressing the
+  'Generate new JSON key' button in the 'Service Account' section of
 
       ```
       https://console.developers.google.com/project/<project-id>/apiui/credential
       ```
 
-  To get the private key you must create a new one by pressing the
-  'Generate new JSON key' button in the 'Service Account' section of the
-  credentials page.  Download the JSON file and copy the "private-key"
-  value into your environments.yaml.  You may need to change "\u003d"
-  to "=".  Note that the file also contains the client ID and email.
+  If necessary, instead of 'auth-file' you may set the 'private-key',
+  'client-email', and 'client-id' fields in your environments.yaml.  They
+  are your GCE OAuth credentials (matching those in the JSON file).  You
+  may need to change "\u003d" in the private key to "=".
+
+  Either way, these details are associated with the 'service account' of
+  the GCE project you will use for your Juju environment.  For each GCE
+  project, a service account is set up automatically when you create the
+  project.  Juju uses that service account to connect to the GCE API and
+  does so with the proper authentication scope.
 
   For more information please refer to
 

--- a/src/en/reference-release-notes.md
+++ b/src/en/reference-release-notes.md
@@ -78,15 +78,19 @@ This release replaces version 1.22.1.
   project, a service account is set up automatically when you create
   your project. Juju uses that service account to connect to the GCE API
   and does so with the proper authentication scope.  After you have
-  created the project go to the following URL to get the
-  credentials to use in environments.yaml:
-
-  If you extracted the 'private-key' by hand from the GCE project json,
-  change "\u003d" to "=".
+  created the project you must get the credentials to use in
+  environments.yaml.  The client ID and client email address are found at
+  the following URL:
 
       ```
       https://console.developers.google.com/project/<project-id>/apiui/credential
       ```
+
+  To get the private key you must create a new one by pressing the
+  'Generate new JSON key' button in the 'Service Account' section of the
+  credentials page.  Download the JSON file and copy the "private-key"
+  value into your environments.yaml.  You may need to change "\u003d"
+  to "=".  Note that the file also contains the client ID and email.
 
   For more information please refer to
 


### PR DESCRIPTION
"auth-file" was added in 1.23-beta2 (9d28cdfd0230ae9ef7c120a95adf8d53d2c4bfd8).

This patch also cleans up the GCE config notes a little.