### PR TITLE
vagrant howto code snippets updated for 14.04

### DIFF
--- a/src/en/howto-vagrant-workflow.md
+++ b/src/en/howto-vagrant-workflow.md
@@ -89,9 +89,8 @@ hooks.
 
     #!/bin/bash
     set -ex
-    apt-get install -y ruby1.9.3 rubygems
-    update-alternatives --set ruby /usr/bin/ruby1.9.1
-    update-alternatives --set gem /usr/bin/gem1.9.1
+    # Prior to ubuntu 14.04, rubygems-integration should be replaced by rubygems on the following line
+    apt-get install -y ruby1.9.3 rubygems-integration build-essential
     HOME=/root gem install genghisapp bson_ext --no-ri --no-rdoc
 
 ####  Config-Changed Hook
@@ -106,7 +105,7 @@ hooks.
 
     #!/bin/bash
     set -ex
-    PORT=`config-get port`
+    PORT=80
     if [ ! -f /root/.vegas/genghisapp/genghisapp.pid ] ; then
         HOME=/root genghisapp -L -p $PORT
     fi


### PR DESCRIPTION
install hook example snippet changed to use rubygems-integration in 14.04, and not to set alternatives (this errors when using the current jujubox as per the howto, so removed completely)

port set to 80 in start hook example snippet - perhaps should be rewritten to be defaulted in the config