### PR TITLE
Release 1.22.4 is the current proposed release.

### DIFF
--- a/src/en/reference-releases.md
+++ b/src/en/reference-releases.md
@@ -36,7 +36,8 @@ Windows
 
 ## Proposed
 
-Current proposed version is 1.23.3, which became the stable release.
+Current proposed version is 1.22.4, which may become the 1.22 supported
+release on June 4.
 
 Proposed releases may be promoted to stable releases after a period of
 evaluation. They contain bug fixes and recently stablised features. They
@@ -51,11 +52,11 @@ sudo apt-get install juju-core</pre>
 {: .instruction }
 
 OS X
-: [juju-1.23.3-osx.tar.gz](https://launchpad.net/juju-core/1.23/1.23.3/+download/juju-1.23.3-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.23/1.23.3/+download/juju-1.23.3-osx.tar.gz/+md5))
+: [juju-1.22.4-osx.tar.gz](https://launchpad.net/juju-core/1.22/1.22.4/+download/juju-1.22.4-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.22/1.22.4/+download/juju-1.22.4-osx.tar.gz/+md5))
 {: .instruction }
 
 Windows
-: [juju-setup-1.23.3-signed.exe](https://launchpad.net/juju-core/1.23/1.23.3/+download/juju-setup-1.23.3.exe) ([md5](https://launchpad.net/juju-core/1.23/1.23.3/+download/juju-setup-1.23.3.exe/+md5))
+: [juju-setup-1.22.4-signed.exe](https://launchpad.net/juju-core/1.22/1.22.4/+download/juju-setup-1.22.4.exe) ([md5](https://launchpad.net/juju-core/1.22/1.22.4/+download/juju-setup-1.22.4.exe/+md5))
 {: .instruction }
 
 Proposed releases use the 'proposed' simple-streams. You must configure


### PR DESCRIPTION
We are proposing 1.22.4 to release the older supported 1.22.3. The current Juju is still 1.23.3