### PR TITLE
Subordinate services: Broken links

### DIFF
--- a/src/en/authors-subordinate-services.md
+++ b/src/en/authors-subordinate-services.md
@@ -35,7 +35,7 @@ the second service. Subordinate services have a very tight relationship with
 their principal service, so it makes sense to be able to restrict that
 communication in some cases so that they only receive events about each other.
 That's precisely what happens when a relation is tagged as being a scoped to the
-container. See [scoped relations](charm.html).
+container. See [scoped relations](authors-relations-in-depth).
 
 Container relations exist because they simplify responsibilities for the
 subordinate service charm author who would otherwise always have to filter units
@@ -48,7 +48,7 @@ it.
 In order to deploy a subordinate service a scope: container relationship is
 required. Even when the principal services' charm author doesn't provide an
 explicit relationship for the subordinate to join, using an [_implicit relation_
-](implicit-relations.html) with scope: container will satisfy this constraint.
+](authors-implicit-relations) with scope: container will satisfy this constraint.
 
 ## Addressability
 


### PR DESCRIPTION
Fixed broken links to the pages having detailed information on scoped and implicit relations. While there is a page titled [Implicit relations](https://jujucharms.com/docs/devel/authors-implicit-relations) the _**Scoped relations**_ page does not exist. However, scope of relations (global, container) is discussed in details on page [Relations in depth](https://jujucharms.com/docs/devel/authors-relations-in-depth). I considered that linking _**Relations in depth**_ page is better than 404.