### PR TITLE
Benchmarks documentation

### DIFF
--- a/src/en/authors-charm-benchmarks.md
+++ b/src/en/authors-charm-benchmarks.md
@@ -1,11 +1,15 @@
+Title: Adding benchmarks to your charm
+
 # Why benchmarking
 
 Before proceeding make sure to read and understand the [Juju Actions](./authors-charm-actions)
 section of the docs as it will be referenced heavily in the upcoming sections
 
+With the introduction of Actions, you are now able to write repeatable, reliable, composable benchmarks. This allows you to perform the same benchmark against a variety of hardware configuration, architecture, and cloud provider to identify bottlenecks and test configuration changes so that you can get the most out of your computing dollar.
+
 # Types of benchmarks in charms
 
-Two types of benchmark: specific and generic.
+Two types of benchmark: specific and generic. The former tests application-specific functionality, such as measuring message queue latency or database query performance are specific to an application, whereas the later test things like memory, cpu, and disk i/o.
 
 There are three ways to deliver benchmarks in Juju, covered in the sections below. How your service is benchmarked will determine which methods you'll wish to use.
 
@@ -20,12 +24,13 @@ If you bundle a benchmarking service as part of your service, or if the benchmar
 suite for your application runs on the same machine, this will likely be the path
 for you.
 
-To start, create an action for your charm. The name of this action can be whatever
-best represents the action the user is taking. As an example, to run the
-cassandra-stress tool in the cassandra charm, you run the action named "stress".
-If there is no simple name, "benchmark" is a great placeholder. Going forward, in
-this example, the benchmark action will be named "load-gen". Here's an example
-`action.yaml`
+In the example below, we will walk through the steps of adding a *benchmark-enabled* action to a charm.
+
+The name of the action can be whatever best represents the action the user is taking. For example, to run the cassandra-stress tool in the cassandra charm, you run the action named "stress". If there is no simple name, "benchmark" is a great placeholder.
+
+Going forward, in this example, the benchmark action will be named "load-gen".
+
+Here's the `action.yaml` for our charm, which informs juju about the action we're exposing and what parameter(s) it takes.
 
 ```yaml
 load-gen:

--- a/src/en/draft-benchmarking.md
+++ b/src/en/draft-benchmarking.md
@@ -107,10 +107,18 @@ benchmark-finish
 # of your benchmark.
 
 # Raw results
-action-set results.raw="`cat /opt/load-gen/cpu/results/$run/load-gen.log`"
+benchmark-raw /opt/load-gen/cpu/results/$run/load-gen.log
 
 # Parse the output from load-gen
 score=`awk '{print $1}' /opt/load-gen/cpu/results/$run/load-gen.log`
+availability=`awk '{print $2}' /opt/load-gen/cpu/results/$run/load-gen.log`
+responsetime=`awk '{print $3}' /opt/load-gen/cpu/results/$run/load-gen.log`
+throughput=`awk '{print $4}' /opt/load-gen/cpu/results/$run/load-gen.log`
+
+benchmark-data 'score' '${score}' 'requests/sec' 'desc'
+benchmark-data 'availability' '${availability}'
+benchmark-data 'throughput' '${throughput}' 'bytes/sec' 'desc'
+benchmark-data 'response-time' '${responsetime}' 'secs' 'asc'
 
 # Set the composite score
 benchmark-composite ${score} "requests/sec" "desc"

--- a/src/en/draft-benchmarking.md
+++ b/src/en/draft-benchmarking.md
@@ -20,6 +20,21 @@ If you bundle a benchmarking service as part of your service, or if the benchmar
 suite for your application runs on the same machine, this will likely be the path
 for you.
 
+To start, create an action for your charm. The name of this action can be whatever
+best represents the action the user is taking. As an example, to run the
+cassandra-stress tool in the cassandra charm, you run the action named "stress".
+If there is no simple name, "benchmark" is a great placeholder. Going forward, in
+this example, the benchmark action will be named "load-gen". Here's an example
+`action.yaml`
+
+```yaml
+load-gen:
+  description: Generate load against the service
+  params:
+    size:
+      type: number
+
+
 ## Load generation charm
 
 ### Subordinate load generation charm

--- a/src/en/draft-benchmarking.md
+++ b/src/en/draft-benchmarking.md
@@ -1,0 +1,28 @@
+# Why benchmarking
+
+Before proceeding make sure to read and understand the [Juju Actions](./authors-charm-actions)
+section of the docs as it will be referenced heavily in the upcoming sections
+
+# Types of benchmarks in charms
+
+There are two main ways to deliver benchmarks in Juju. These three types are
+covered in each section below. How your service is benchmarked will determine
+which of these three methods you'll wish to use. For the cases where benchmarking
+is done as part of the software you're delivering, then the
+[As part of the charm](#as-part-of-the-charm) section will work best for you.
+If you charm requires software to be run externally across a network to
+benchmark the service, creating a [Load generation charm](#load-generation-charm)
+will be the section of most interest for you.
+
+## As part of the charm
+
+If you bundle a benchmarking service as part of your service, or if the benchmark
+suite for your application runs on the same machine, this will likely be the path
+for you.
+
+## Load generation charm
+
+### Subordinate load generation charm
+
+
+# How to write a benchmark

--- a/src/en/draft-benchmarking.md
+++ b/src/en/draft-benchmarking.md
@@ -33,6 +33,11 @@ load-gen:
   params:
     size:
       type: number
+      description: size of load to generate
+      default: 1
+```
+
+
 
 
 ## Load generation charm


### PR DESCRIPTION
We would like to merge this into the docs, for 1.23 and 1.24 and devel. This is the documentation on writing benchmarks for Juju charms. We're not sure the page it should reside, guidance on that would be great.