### PR TITLE
issue #217; consolidating debug-log

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -423,6 +423,7 @@ Which tells you that you forgot to add a `copyright` file, you have left some
 default text in the README, and one of your relations has no hooks. All useful
 stuff.
 
+
 ## Testing
 
 Before we congratulate ourselves too much, we should check that the charm
@@ -435,7 +436,8 @@ juju debug-log
 
 This starts a process to tail the Juju log file and show us just exactly what is
 happening. It won't do much to begin with, but you should see messages appearing
-when we start to deploy our charm.
+when we start to deploy our charm. See 
+[Troubleshooting with debug-log](./troubleshooting-debug-log.html) for more details.
 
 Following our own recipe, in another terminal we should now do the following
 (assuming you already have a bootstrapped environment):

--- a/src/en/authors-hook-debug.md
+++ b/src/en/authors-hook-debug.md
@@ -9,6 +9,7 @@ command.
 
 The [dhx debugging plugin](./authors-hook-debug-dhx.html) is also available.
 
+
 ##  The 'debug-hooks' command
 
 The `juju debug-hooks` command accepts a unit and an optional list of hooks to
@@ -28,6 +29,7 @@ juju debug-hooks mysql/0 db-relation-joined db-relation-broken
 
 **Note:** It is possible and often desirable to run debug-hooks on more than
 one unit at a time. You should open a new terminal window for each.
+
 
 ## Running a debug session
 
@@ -93,6 +95,7 @@ of it), and start your session only when the unit reports an [error status
 ](./authors-hook-errors.html). You should then run `juju resolved --retry` for
 the affected unit, and go back to the debug-hooks session to interact.
 
+
 ## Special considerations
 
 While you're debugging hooks for one unit on a machine, you're blocking
@@ -103,67 +106,13 @@ the same machine will block one another, and that you can't control relative
 execution order directly (other than by erroring out of hooks you don't want to
 run yet, and retrying them later).
 
-##  The 'debug-log' command
 
-Sometimes for working out where problems occur, it is simply enough to be able
-to view the log files. As well as the logs on individual units, Juju keeps a
-consolidated log file which can be viewed with the `juju debug-log` command.
+## The 'debug-log' command
 
-As this is a consolidated log you don't need to specify a unit.
+Logs are indispensable when it comes time to troubleshoot. View the logs with
+the `debug-log` command. See
+[Troubleshooting with debug-log](./troubleshooting-debug-log.html).
 
-#### Usage:
-
-```bash
-juju debug-log [-n <number>] [--replay] [-e <environment>]
-```
-
-N.B. For full usage, see the [command reference page](commands.html)
-
-Where the `-n` switch is given and followed by a number, the log will be tailed
-from that many lines in the past (i.e., those number of existing lines in the
-log will be included in the output, along with any subsequent output).
-
-
-
-#### Examples:
-
-To read the ten most recent log entries and follow any subsequent entries to the
-log:
-
-```bash
-juju debug-log
-```
-
-To read the thirty most recent log entries and follow any subsequent entries to
-the log:
-
-```bash
-juju debug-log -n 30
-```
-
-To read all the log entries and follow any subsequent entries to the log:
-
-```bash
-juju debug-log --replay
-```
-
-To read the twenty most recent log entries on the 'local' environment:
-
-```bash
-juju debug-log -n 20 -e local
-```
-
-And of course it is possible to combine the command with other shell tools to
-make the output more useful, e.g. to filter the whole log for lines matching
-'INFO':
-
-```bash
-juju debug-log --replay  | grep 'INFO'
-```
-
-**Note:** As the command uses the follow behaviour of `tail` by default, you do
-not need to specify the `-f` switch. You will also need to end the session
-with `Control-C`
 
 # What on earth is tmux?
 

--- a/src/en/troubleshooting-debug-log.md
+++ b/src/en/troubleshooting-debug-log.md
@@ -1,0 +1,118 @@
+Title: Troubleshooting with debug-log
+
+# Troubleshooting with debug-log
+
+When problems arise the first step in determining the cause is to look at the
+logs. The `debug-log` command shows the consolidate logs of all Juju agents
+running on all machines in the environment.
+
+The output is a fixed number of existing log lines (number specified by
+possible options; the default is 10) and a stream of newly appended messages.
+Both existing lines and appended lines are filtered by any specified options.
+The exception to the streaming is when limiting the output (option `--limit`;
+see below) and that limit is attained. In all other cases the command will need
+to be interrupted with `Ctrl-C` in order to regain the shell prompt.
+
+For complete syntax, see the [command reference page](./commands.html).
+
+You can also learn more by running `juju debug-log --help` and `juju help 
+logging`.
+
+
+## Examples:
+
+**#1** - To begin with the last ten log messages:
+
+```bash
+juju debug-log
+```
+
+**#2** - To begin with the last thirty log messages:
+
+```bash
+juju debug-log -n 30
+```
+
+**#3** - To begin with all the log messages:
+
+```bash
+juju debug-log --replay
+```
+
+**#4** - To begin with the last twenty log messages for the 'local' environment:
+
+```bash
+juju debug-log -n 20 -e local
+```
+
+**#5** - To begin with the last 500 lines filtered by the string 'amd64':
+
+```bash
+juju debug-log --lines 500 | grep amd64
+```
+
+**#6** - To begin with the first 20 lines from last 3000 lines of the entire log:
+
+```bash
+juju debug-log --lines 3000 --limit 20
+```
+
+
+## Advanced filtering
+
+A Juju log line is written in this format:
+
+`<entity> <timestamp> <log-level> <module>:<line-no> <message>`
+
+The `include` and `exclude` options select and deselect, respectively, the
+entity that logged the message. An entity is a juju machine or unit agent. The
+entity names are similar to the names shown by `juju status`.
+
+### Examples:
+
+**#7** - To exclude all the log messages from the bootstrap machine (the
+state-server; always machine "0") in the last 1000 lines:
+
+```bash
+juju debug-log --lines 1000 --exclude machine-0
+```
+
+**#8** - To select all the messages emitted from a particular unit and a particular
+machine in the entire log:
+
+```bash
+juju debug-log --replay --include unit-mysql-0 --include machine-1
+```
+
+**Note:** The unit can also be written `mysql/0` (as shown with status).
+
+**#9** - To see all WARNING and ERROR messages in the entire log:
+
+```bash
+juju debug-log --replay --level WARNING
+```
+
+**Note**: The `level` option restricts messages to the specified log-level or
+greater. The levels from lowest to highest are TRACE, DEBUG, INFO, WARNING, and
+ERROR.
+
+**#10** - To progressively exclude more content from the entire log:
+
+```bash
+juju debug-log --replay --exclude-module juju.state.apiserver
+juju debug-log --replay --exclude-module juju.state
+juju debug-log --replay --exclude-module juju
+```
+
+**Note:** The `include-module` and `exclude-module` are used to select/deselect the
+type of message displayed based on a (dotted) module name. The module name can
+be truncated.
+
+**#11** - To see messages pertaining to both the juju.cmd and juju.worker modules
+from the last 2000 lines of the log:
+
+```bash
+juju debug-log --lines 2000 \
+	--include-module juju.cmd \
+	--include-module juju.worker
+```

--- a/src/en/troubleshooting-debug-log.md
+++ b/src/en/troubleshooting-debug-log.md
@@ -21,37 +21,37 @@ logging`.
 
 ## Examples:
 
-**#1** - To begin with the last ten log messages:
+To begin with the last ten log messages:
 
 ```bash
 juju debug-log
 ```
 
-**#2** - To begin with the last thirty log messages:
+To begin with the last thirty log messages:
 
 ```bash
 juju debug-log -n 30
 ```
 
-**#3** - To begin with all the log messages:
+To begin with all the log messages:
 
 ```bash
 juju debug-log --replay
 ```
 
-**#4** - To begin with the last twenty log messages for the 'local' environment:
+To begin with the last twenty log messages for the 'local' environment:
 
 ```bash
 juju debug-log -n 20 -e local
 ```
 
-**#5** - To begin with the last 500 lines filtered by the string 'amd64':
+To begin with the last 500 lines filtered by the string 'amd64':
 
 ```bash
 juju debug-log --lines 500 | grep amd64
 ```
 
-**#6** - To begin with the first 20 lines from last 3000 lines of the entire log:
+To begin with the first 20 lines from last 3000 lines of the entire log:
 
 ```bash
 juju debug-log --lines 3000 --limit 20
@@ -68,35 +68,39 @@ The `include` and `exclude` options select and deselect, respectively, the
 entity that logged the message. An entity is a juju machine or unit agent. The
 entity names are similar to the names shown by `juju status`.
 
+Similarly, the `include-module` and `exclude-module` options can be used to
+influence the type of message displayed based on a (dotted) module name. The
+module name can be truncated.
+
 ### Examples:
 
-**#7** - To exclude all the log messages from the bootstrap machine (the
+To exclude all the log messages from the bootstrap machine (the
 state-server; always machine "0") in the last 1000 lines:
 
 ```bash
 juju debug-log --lines 1000 --exclude machine-0
 ```
 
-**#8** - To select all the messages emitted from a particular unit and a particular
+To select all the messages emitted from a particular unit and a particular
 machine in the entire log:
 
 ```bash
 juju debug-log --replay --include unit-mysql-0 --include machine-1
 ```
 
-**Note:** The unit can also be written `mysql/0` (as shown with status).
+!!! Note: The unit can also be written `mysql/0` (as shown by 'juju status').
 
-**#9** - To see all WARNING and ERROR messages in the entire log:
+To see all WARNING and ERROR messages in the entire log:
 
 ```bash
 juju debug-log --replay --level WARNING
 ```
 
-**Note**: The `level` option restricts messages to the specified log-level or
+!!! Note: The `level` option restricts messages to the specified log-level or
 greater. The levels from lowest to highest are TRACE, DEBUG, INFO, WARNING, and
 ERROR.
 
-**#10** - To progressively exclude more content from the entire log:
+To progressively exclude more content from the entire log:
 
 ```bash
 juju debug-log --replay --exclude-module juju.state.apiserver
@@ -104,11 +108,7 @@ juju debug-log --replay --exclude-module juju.state
 juju debug-log --replay --exclude-module juju
 ```
 
-**Note:** The `include-module` and `exclude-module` are used to select/deselect the
-type of message displayed based on a (dotted) module name. The module name can
-be truncated.
-
-**#11** - To see messages pertaining to both the juju.cmd and juju.worker modules
+To see messages pertaining to both the juju.cmd and juju.worker modules
 from the last 2000 lines of the log:
 
 ```bash

--- a/src/en/troubleshooting.md
+++ b/src/en/troubleshooting.md
@@ -56,6 +56,7 @@ If you have a version less than 1:2.2.4-0ubuntu1 make sure you have either the
 ppa:juju/stable added to your system. `sudo apt-get update` then install juju-
 local package. Before retrying, make sure you run `juju destroy-environment`
 
+
 ## No machines start
 
 If you get a successful bootstrap, but services you deploy never come up,
@@ -71,83 +72,13 @@ If the contents of this directory are older than a few weeks, delete files
 present, destroy the environment with `juju destroy-environment`, rebootstrap
 and attempt deployment again.
 
+
 # Troubleshooting with debug-log
 
-The `debug-log` command shows the consolidate logs of all juju agents 
-running on all machines in the environment. The command operates like 
-`tail -f` to stream the logs to the your terminal.
+Logs are indispensable when it comes time to troubleshoot. View the logs with
+the `debug-log` command. See
+[Troubleshooting with debug-log](./troubleshooting-debug-log.html).
 
-The `lines` and `limit` options allow you to select the starting log 
-line and how many additional lines to display. The default behaviour is 
-to show the last 10 lines of the log. The `lines` option selects the 
-starting line from the end of the log. The `limit` option restricts the 
-number of lines to show. For example, you can see just 20 lines from 
-last 100 lines of the log like this:
-
-```bash
-juju debug-log --lines 100 --limit 20
-```
-
-There are many ways to filter the juju log to see just the pertinent 
-information. A juju log line is written in this format:
-
-    <entity> <timestamp> <log-level> <module>:<line-no> <message>
-
-The `include` and `exclude` options select the entity that logged the 
-message. An entity is a juju machine or unit agent. The entity names are 
-similar to the names shown by `juju status'. You can exclude all the log 
-messages from the bootstrap machine that hosts the state-server like 
-this:
-
-```bash
-juju debug-log --exclude machine-0
-```
-
-The options can be used multiple times to select the log messages. This 
-example selects all the message from a unit and its machine as reported 
-by status:
-
-```bash
-juju debug-log --include unit-mysql-0 --include machine-1
-```
-
-The `level` option restricts messages to the specified log-level or 
-greater. The levels from lowest to highest are TRACE, DEBUG, INFO, 
-WARNING, and ERROR. The WARNING and ERROR messages from the log can seen 
-thusly:
-
-```bash
-juju debug-log --level WARNING
-```
-
-The `include-module` and `exclude-module` are used to select the kind of
-message displayed. The module name is dotted. You can specify all or
-some of a module name to include or exclude messages from the log. This
-example progressively excludes more content from the logs:
-
-```bash
-juju debug-log --exclude-module juju.state.apiserver
-juju debug-log --exclude-module juju.state
-juju debug-log --exclude-module juju
-```
-
-The `include-module` and `exclude-module` options can be used multiple 
-times to select the modules you are interested in. For example, you can 
-see the juju.cmd and juju.worker messages like this:
-
-```bash
-juju debug-log --include-module juju.cmd --include-module juju.worker
-```
-
-The `debug-log` command output can be piped to grep to filter the 
-message like this:
-
-```bash
-juju debug-log --lines 500 | grep amd64
-```
-
-You can learn more by running `juju debug-log --help` and `juju help 
-logging`.
 
 ##  Unit KVM / LXC container problems:
 


### PR DESCRIPTION
I could not get the examples done using markdown ordered lists without losing the code formatting. I could indent the actual text/commands but then the multi-line blocks would end up on one line.

Also, in troubleshooting-debug-log.md, the second 'Note' does not get formatted like the other two do (locally anyway).

Feel free to make up for my lackings.