### PR TITLE
issue #86; environment-specific placement

### DIFF
--- a/src/en/charms-ha.md
+++ b/src/en/charms-ha.md
@@ -1,6 +1,8 @@
-Title:Ensuring High Availability (HA) for deployed services
+Title: Ensuring High Availability (HA) for deployed services
 
-# Service High Availability
+
+# Service High Availability (HA)
+
 
 ## Distribution groups
 Juju works with OpenStack, Amazon EC2 and Azure providers to ensure that in
@@ -23,29 +25,33 @@ juju deploy -n 10 <service>
 The way this works depends on whether Juju uses Availability Zones or
 Availability Sets for that provider.
 
+
 ## Availability Zones
 
 Juju supports Availability Zones on Amazon's EC2 and OpenStack-based clouds.
 Openstack Havana and newer is supported, which includes HP Cloud. Older
-versions of OpenStack are not supported.
+versions of OpenStack are not supported. See the per-provider [Install &
+Configure](./getting-started.html) section for more on these and any other
+provider-specific settings.
 
 If you do not specify a zone explicitly, Juju will automatically and uniformly
-distribute units across the available zones within the region.  The spread is
-based on density of instance "distribution groups".  This can be overridden
-with a placement directive.  e.g.
+distribute units across the available zones within the region. The spread is
+based on density of instance "distribution groups". This can be overridden
+with a placement directive:
 
 ```bash
 juju bootstrap --to zone=us-east-1b
 juju add-machine zone=us-east-1c
 ```
 
+
 ## Azure Availability Sets
 
-Juju supports Availability Sets on Microsoft's Azure.
-As long as at least two units are deployed, Azure guarantees 99.95%
-availability of the service overall.  Exposed ports are automatically
-load-balanced across all units within the service.  Using availability sets
-disables manual placement and the "add-machine" command.
+Juju supports Availability Sets on Microsoft's Azure.  As long as at least two
+units are deployed, Azure guarantees 99.95% availability of the service
+overall.  Exposed ports are automatically load-balanced across all units within
+the service.  Using availability sets disables manual placement and the
+"add-machine" command.
 
 In Juju 1.20 and later, new Azure environments use availability sets by
 default. To disable availability sets, the 'availability-sets-enabled' option

--- a/src/en/commands.md
+++ b/src/en/commands.md
@@ -1,6 +1,7 @@
-Title:Juju commands and usage
+Title: Juju command reference
 
-# Juju Command reference
+
+# Juju command reference
 
 You can get a list of the currently used commands by entering
 ```juju help commands``` from the commandline. The currently understood commands
@@ -99,7 +100,14 @@ Click on the expander to see details for each command.
   "placement directives" with "--to"; these give the provider additional
   information about how to allocate the machine. For example, one can direct the
   MAAS provider to acquire a particular node by specifying its hostname with
-  "--to". For more information on placement directives, see "juju help placement".
+  "--to".
+
+  See Also:
+  juju help constraints
+  juju help placement
+
+  The per-provider [Install & Configure](./getting-started.html) section mentions
+  these and any other provider-specific settings.
   
   #### Examples: 
 
@@ -110,11 +118,8 @@ Click on the expander to see details for each command.
       juju machine add lxc:4                (starts a new lxc container on machine 4)
       juju machine add --constraints mem=8G (starts a machine with at least 8GB RAM)
       juju machine add ssh:user@10.10.0.3   (manually provisions a machine with ssh)
-      juju machine add zone=us-east-1a
-
-  See Also:
-  juju help constraints
-  juju help placement
+      juju machine add zone=us-east-1a	    (zones not available to all providers)
+      juju machine add --to hostname	    (add a machine to a specific MAAS host)
 
 ^# add-relation
 

--- a/src/en/config-aws.md
+++ b/src/en/config-aws.md
@@ -1,4 +1,5 @@
 Title: Configuring Juju for Amazon Web Services
+
 # Configuring for Amazon Web Services
 
 This process requires you to have an Amazon Web Services (AWS) account. If you
@@ -69,9 +70,23 @@ Open this file to get the **access-key** and **secret-key** for the
 The **region:** value corresponds to the AWS regions.
 
 
-##Additional notes
+## AWS specific features
 
-Juju-owned instances running in AWS support consistent naming, tagging and the 
-ability to add user-controlled tags to created instances. 
-See the [naming and tagging documentation](config-tagging.html) for more
-information.
+Features supported by Juju-owned instances running within AWS:
+
+- Consistent naming, tagging, and the ability to add user-controlled tags to
+  created instances. See [Instance naming and tagging](config-tagging.html) for
+  more information.
+
+- The selection (placement) of availability zones, if existing, when adding a
+  machine:
+
+```bash
+juju machine add zone=us-east-1a
+```
+
+
+## Additional notes
+
+See [General config options](config-general.html) for additional and advanced
+customization of your environment.

--- a/src/en/config-maas.md
+++ b/src/en/config-maas.md
@@ -1,5 +1,6 @@
 Title: Configuring for MAAS (bare metal)
 
+
 # Configuring for MAAS (bare metal)
 
 Metal As A Service is software which allows you to deal with physical hardware
@@ -85,9 +86,9 @@ this setting by adding the optional configuration:
 ## MAAS specific features
 
 Juju automatically detects MAAS networks, and recognises physical and
-virtual networks on each machine. ```juju status``` will show the discovered
-networks. See [Juju Constraints](reference-constraints.html) and [Deploying
-Services](charms-deploying.html) to learn how to select machines with networks
+virtual networks on each machine. `juju status` will show the discovered
+networks. See [Juju Constraints](./reference-constraints.html) and [Deploying
+Services](./charms-deploying.html) to learn how to select machines with networks
 and enable the networks for use.
 
 There is one case where an additional configuration option should be made: 
@@ -114,5 +115,8 @@ juju add-machine <hostname>
 For further information on using Juju with MAAS, see the
 [MAAS and Juju Quick Start guide](http://maas.ubuntu.com/docs/juju-quick-start.html).
 
-See also the section on [general configuration options](config-general.html)
-for additional and advanced customization of your environment.
+
+## Additional notes
+
+See [General config options](config-general.html) for additional and advanced
+customization of your environment.

--- a/src/en/config-openstack.md
+++ b/src/en/config-openstack.md
@@ -1,4 +1,6 @@
 Title: Configuring Juju for OpenStack
+
+
 # Configuring for OpenStack
 
 Start by generating a generic configuration file for Juju, using the
@@ -12,9 +14,9 @@ This will generate a file, `environments.yaml`, which will live in your
 `~/.juju/` directory (and will create the directory if it doesn't already
 exist).
 
-**Note:** If you have an existing configuration, you can use
-`juju generate-config --show` to output the new config file, then copy and
-paste relevant areas in a text editor etc.
+**Note:** If you have an existing configuration, you can use `juju
+generate-config --show` to output the new config file, then copy and paste
+relevant areas in a text editor etc.
 
 The essential configuration sections for OpenStack look like this:
 
@@ -89,22 +91,31 @@ most revent version of the environments.yaml template file, instead of having
 it write to file.
 
 Remember to substitute in the parts of the snippet that are important to you.
-If you are deploying on OpenStack the following documentation might also be
-useful:
-
-[Ubuntu Cloud Infrastructure](https://help.ubuntu.com/community/UbuntuCloudInfrastructure)
 
 
 ## Bootstrapping
 
-Before being able to bootstrap into a Private Openstack Cloud you'll need to generate
-simplestreams metadata:
+Before being able to bootstrap into a Private Openstack Cloud you'll need to
+generate simplestreams metadata. See
+[How to setup a Private Cloud](howto-privatecloud.html).
 
-[How to setup a Private Cloud](howto-privatecloud.html)
 
-##Additional notes
+## OpenStack specific features
 
-Juju-owned instances running in OpenStack support consistent naming, tagging and
-the ability to add user-controlled tags to created instances. 
-See the [naming and tagging documentation](config-tagging.html) for more
-information.
+Features supported by Juju-owned instances running within OpenStack:
+
+- Consistent naming, tagging, and the ability to add user-controlled tags to
+  created instances. See [Instance naming and tagging](config-tagging.html) for
+  more information.
+
+- The selection (placement) of availability zones, if existing, when adding a
+  machine:
+
+```bash
+juju machine add zone=us-east-1a
+```
+
+## Additional notes
+
+See [General config options](config-general.html) for additional and advanced
+customization of your environment.

--- a/src/en/getting-started.md
+++ b/src/en/getting-started.md
@@ -1,3 +1,6 @@
+Title: Getting started with Juju
+
+
 # Introduction
 
 This tutorial will explain how to get started with Juju, including installing,
@@ -5,12 +8,14 @@ configuring, and bootstrapping a new Juju environment. Prerequisites include:
 
   - An Ubuntu, OSX, or Windows machine to install the client upon.
   - An environment which can provide a new server with an Ubuntu cloud operating
-  system image on-demand. This includes services such as Amazon EC2, HP Cloud,
-  an OpenStack installation, or your local machine
+  system image on-demand. See under `Install & Configure` on the left for how
+  to use different providers, including any provider-specific settings.
   - An SSH key-pair. On Linux and Mac OSX: `ssh-keygen -t rsa -b 2048` On Windows:
-  See the [Windows instructions for SSH and PuTTY](getting-started-keygen-win.html)
+  See the [Windows instructions for SSH and PuTTY](getting-started-keygen-win.html).
+
 
 # Installation
+
 
 ## Ubuntu
 
@@ -25,6 +30,7 @@ sudo apt-get update && sudo apt-get install juju-core
 For more information on installing and the current versions available, see
 [the releases page](reference-releases.html).
 
+
 ## Mac OSX
 
 Juju is in [Homebrew](http://brew.sh/), to install do:
@@ -38,6 +44,7 @@ We also recommend trying Juju in [our Vagrant box](config-vagrant.html).
 For more installation information and what versions are available, see
 [the releases page](reference-releases.html).
 
+
 ## Windows
 
 See [the releases page](reference-releases.html) to download and run the
@@ -45,16 +52,19 @@ latest version of the Juju Windows installer.
 
 We also recommend trying Juju in [our Vagrant box](config-vagrant.html).
 
+
 # Configuring
 
 Juju needs to be configured to use your cloud provider. This is done via the
 following file:
+
 
 ## Linux & Mac OSX
 
 ```no-highlight
 ~/.juju/environments.yaml
 ```
+
 
 ## Windows
 
@@ -80,6 +90,7 @@ sections in the left pane (under *Install & Configure*).
 help` will show you the topics. You can also look at the
 [Juju command cheatsheet](https://github.com/juju/cheatsheet) if you are
 looking for a convenient command guide.
+
 
 # Testing your setup
 


### PR DESCRIPTION
- in commands.md:
i followed existing text and added:

`juju machine add --to myhostname`

- in config-maas.md:
existing text shows:

`juju add-machine hostname`

do we want to standardize: 'machine add' or 'add-machine'?

- in config-openstack.md:
i removed the link to the community wiki:

[https://help.ubuntu.com/community/UbuntuCloudInfrastructure](https://help.ubuntu.com/community/UbuntuCloudInfrastructure)

as i do not believe the community wiki to be an appropriate resource for our official documentation. this page in particular has not been updated in the last 16 months