### PR TITLE
Executable files in /tests need not end in .test

### DIFF
--- a/src/en/authors-testing.md
+++ b/src/en/authors-testing.md
@@ -42,9 +42,8 @@ properly.
 
 A simple structure will be utilized to attach tests to charms. Under the charm
 root directory, a sub-directory named 'tests' will be scanned by a test runner
-for executable files matching the glob `*.test`. These will be run in lexical
-order by the test runner, with a predictible environment. The tests can make 
-the following assumptions:
+for executable files. These will be run in lexical order by the test runner,
+with a predictible environment. The tests can make the following assumptions:
 
 - A minimal install of the release of Ubuntu which the charm is targetted at 
   will be available.
@@ -76,8 +75,8 @@ packages: [ package1, package2, package3 ]
 
 If a tool is needed to perform a test and is not available in the Ubuntu
 archive, it can also be included in the `tests/` directory, as long as the file
-which contains it does not end in `.test`. Note that build tools cannot be
-assumed to be available on the testing system.
+which contains it is not executable. Note that build tools cannot be assumed to
+be available on the testing system.
 
 ### Purpose of tests
 


### PR DESCRIPTION
This closes: https://bugs.launchpad.net/amulet/+bug/1485757

Please check to make sure this is accurate.