### PR TITLE
Remove link that breaks document generator.

### DIFF
--- a/src/en/authors-charm-with-docker.md
+++ b/src/en/authors-charm-with-docker.md
@@ -156,7 +156,6 @@ boolean logic to run when the state or combination of states is correct. States
 may be useful to other layers so it is very important to document in the
 `README.md` what states are set or removed in this layer.
 
-<a name="layer-docker-nginx"></a>
 ## layer-docker-nginx
 The layer-docker-nginx charm adds the [Nginx](http://nginx.org/) HTTP server
 docker image to the layer-docker charm by using `charm compose` and also uses


### PR DESCRIPTION
The removed link is an <a> with no href.  It is unclear why it was added.

Unfortunately it found a bug in the docs generator for jujucharms.com and has caused the generation to fail since its inclusion.

I am fixing the offending line so that docs can be generated again and creating a task to make the generator more robust.

