### PR TITLE
note change to default instance type

### DIFF
--- a/src/en/config-aws.md
+++ b/src/en/config-aws.md
@@ -69,6 +69,7 @@ Open this file to get the **access-key** and **secret-key** for the
 
 The **region:** value corresponds to the AWS regions.
 
+By default, Juju will deploy units to m3.medium instances, unless otherwise constrained.
 
 ## AWS specific features
 


### PR DESCRIPTION
in 1.25, we changed how the default instance type was determined, so that we default to m3.medium (the previous default, m1.small, is problematic since they're being phased out by Amazon).