### PR TITLE
Update docs to match logging changes in 2.0

### DIFF
--- a/src/en/troubleshooting-logs.md
+++ b/src/en/troubleshooting-logs.md
@@ -1,5 +1,4 @@
-Title: Viewing Juju logs  
-
+Title: Viewing Juju logs
 
 # Viewing logs
 
@@ -9,70 +8,29 @@ reading individual logs on multiple (Juju) machines directly on the file system.
 The latter can nonetheless be done in exceptional circumstances and some explanation
 is provided here.
 
-See [Juju high availability](./juju-ha.html#ha-and-logging) when viewing logs
-in an HA context.
-
-
-## Juju agents
-
-One of the roles of the *Juju agent*, 'jujud', is to perform logging. There is
-one agent for every Juju machine and unit. For instance, for a machine with an
-id of '2', we see evidence of such agents:
-
-```bash
-juju ssh 2 ls -lh /var/lib/juju/agents
-```
-
-This example has the following output:
-
-```no-highlight
-drwxr-xr-x 2 root root 4.0K Apr 28 00:42 machine-2
-drwxr-xr-x 4 root root 4.0K Apr 28 00:42 unit-nfs2-0
-```
-
-So there are 2 agents running on this Juju machine. One for the machine itself
-and one for a service unit.
-
-The contents of one of these directories
-
-```bash
-juju ssh 2 ls -lh /var/lib/juju/agents/machine-2
-```
-
-reveals the agent's configuration file:
-
-```no-highlight
--rw------- 1 root root 2.1K Apr 28 00:42 agent.conf
-```
-
-Consider keeping backups of these files, especially prior to upgrading the
-agents. See
-[Upgrading Juju software](./models-upgrade.html#upgrading-the-model-software).
-
-
 ## The debug-log command
 
 The `juju debug-log` command shows the consolidated logs of all Juju agents
 (machines and units) running in a model. The `juju switch` command is used
 to change models. Alternatively, a model can be chosen with the '-m' option.
-The default model is the current model.
+The currently select model is used by default.
 
 The 'admin' model captures logs related to internal management (controller
 activity) such as adding machines and services to the database. Whereas a
 hosted model will provide logs concerning activities that take place post-
-provisioning.
-
-Due to the above, when deploying a service, it is normal for there to be an
+provisioning. When deploying a service, it is normal for there to be an
 absence of logging in the hosted model since logging first takes place in the
 'admin' model.
 
-The output is a fixed number of existing log lines (number specified by
-possible options; the default is 10) and a stream of newly appended messages.
-Both existing lines and appended lines can be filtered by specifying options.
+By default, the debug-log command will output the 10 most recent log lines and
+then stream new lines as they appear. 'Ctrl-C' can be used to terminate the
+command in order to regain the shell prompt.
 
-The exception to the streaming is when limiting the output (option '--limit';
-see below) and that limit is attained. In all other cases the command will need
-to be interrupted with 'Ctrl-C' in order to regain the shell prompt.
+The number of initial lines to output can be controlled by the --lines / -n
+option. Using the --replay option will cause all available logs to be emitted.
+
+The --no-tail / -T option can be used to have the debug-log command exit
+immediately after the initial log lines have been output.
 
 For complete syntax, see the [command reference page](./commands.html). The
 `juju help debug-log` command also provides reminders and more examples.
@@ -91,10 +49,10 @@ To begin with the last thirty log messages:
 juju debug-log -n 30
 ```
 
-To begin with all the log messages:
+To dump all available log messages and exit:
 
 ```bash
-juju debug-log --replay
+juju debug-log --replay --no-tail
 ```
 
 To begin with the last twenty log messages for the 'lxd-pilot' model:
@@ -110,7 +68,7 @@ juju debug-log -n 500 | grep amd64
 ```
 
 
-## Advanced filtering
+### Advanced filtering
 
 A Juju log line is written in this format:
 
@@ -121,26 +79,31 @@ entity that logged the message. An entity is a Juju machine or unit agent. The
 entity names are similar to the names shown by `juju status`.
 
 Similarly, the '--include-module' and '--exclude-module' options can be used to
-influence the type of message displayed based on a (dotted) module name. The
-module name can be truncated.
+influence the type of message displayed based on a (dotted) module name prefix.
 
-A combination of machine and unit filtering uses a logical OR whereas a
-combination of module and machine/unit filtering uses a logical AND.
+The filtering options combine as follows:
+
+  * --include options are logically ORed together
+  * --exclude options are logically ORed together
+  * --include-module options are logically ORed together
+  * --exclude-module options are logically ORed together
+  * the combined --include, --exclude, --include-module and --exclude-module
+    selections are then logically ANDed
 
 Log levels are cumulative; each lower level (more verbose) contains the
 preceding higher level (less verbose). The '--level' option restricts messages
 to the specified log-level or greater. The levels from lowest to highest are
 TRACE, DEBUG, INFO, WARNING, and ERROR.
 
-### Examples:
+### Examples
 
-To begin with the last 1000 lines and exclude messages from machine 3:
+To begin with the last 1000 lines that aren't related to machine 3:
 
 ```bash
 juju debug-log -n 1000 --exclude machine-3
 ```
 
-To select all the messages emitted from a particular unit and a particular
+To select all the messages emitted by a particular unit or a particular
 machine in the entire log:
 
 ```bash
@@ -163,37 +126,50 @@ juju debug-log --replay --exclude-module juju.state
 juju debug-log --replay --exclude-module juju
 ```
 
-To begin with the last 2000 lines and include messages pertaining to both the
-juju.cmd and juju.worker modules:
+To begin with the last 2000 lines which pertaining to either the juju.cmd and
+juju.worker modules but not for machine 2 and not for the "foo" worker:
 
 ```bash
 juju debug-log --lines 2000 \
-	--include-module juju.cmd \
-	--include-module juju.worker
+    --include-module juju.cmd \
+    --include-module juju.worker \
+    --exclude-module juju.worker.foo \
+    --exclude machine-2
 ```
-
 
 ## Log files
 
-Log files are located on every machine Juju creates, including the controller.
-They reside under `/var/log/juju` and correspond to the machine and any units. 
+Juju's log files are located at `/var/log/juju` on each Juju managed
+machine. This directory contains the Juju's logs for the machine and
+any [service units](./glossary.html) running on the machine.
 
-Using the example from a [previous section](#juju-agents):
+The Juju machine log files are named `machine-N.log` where `N` is the
+integer machine identifier. Unit logs files are named `unit-<unit
+name>.log`.
 
-```bash
-juju ssh 2 ls -lh /var/log/juju
-```
-
-Output:
+Log files can be accessed using the `juju ssh` command. For example,
+to see the log files on machine 2, which is running a unit of the
+mysql charm:
 
 ```no-highlight
--rw------- 1 syslog syslog  22K Apr 28 00:42 machine-2.log
--rw------- 1 syslog syslog 345K Apr 28 16:58 unit-nfs2-0.log
+$ juju ssh 2
+...
+$ ls -lh /var/log/juju
+drw------- 2 root root 4.0K Sep  2 02:17 machine-2.log
+drw------- 4 root root 4.0K Sep  2 02:19 unit-mysql-0.log
+$ sudo less /var/log/juju/machine-2.log
+$ sudo grep foo /var/log/juju/unit-mysql-0.log
 ```
 
-There is a special log file on each controller (`logsink.log`) that is used for
-the consolidated model messages used by `juju debug-log` (its contents get sent
-to the database):
+### logsink.log
+
+There is a special log file on each controller machine called `logsink.log` that
+records the log messages received by that controller machine. This file will
+contain log files for all models hosted by the controller. It is intended only
+as a last resort in the case of the logs stored in Juju's database not being
+available.
+
+Example:
 
 ```bash
 juju ssh -m admin 0 ls -lh /var/log/juju
@@ -206,10 +182,8 @@ Output:
 -rw------- 1 syslog syslog  85K Apr 28 17:03 machine-0.log
 ```
 
-Notice that the admin model was chosen with `juju ssh`. Also, a combination of
-commands `juju list-controllers` and `juju list-machines` yielded that the
-controller here has a machine id of '0' (typical).
-
-!!! Note: in a [High availability](./juju-ha.html) scenario, file `logsink.log`
-is not guaranteed to contain all messages since agents have a choice of several
-controllers to send their logs to.
+!!! Note: in a [High availability](./juju-ha.html) scenario, the `logsink.log`
+on each controller machine will only contain a subset of all the logs for the
+controller's models because each agent has a choice of several controllers to
+send their logs to. Merging the logsink.log from each controller host will
+provide the full set of logs.


### PR DESCRIPTION
- removed mention of all-machines.log as this is gone
- removed mention local provider differences as the local provider is gone
- prioritise debug-log over looking at log files directly
- removed irrelevant detail that made the logging docs harder to understand
- more detail about advanced log filtering
- document the new debug-log --no-tail option

