### PR TITLE
Added tools/serve.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 build:
 	tools/mdbuild.py
 
@@ -8,7 +7,7 @@ clean:
 	rm -rf htmldocs/en
 
 serve:
-	cd htmldocs; python -m SimpleHTTPServer
+	tools/serve.py htmldocs 8000
 
 sysdeps:
 	sudo apt-get install python-html2text python-markdown python-pip git spell ispell ibritish

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python2
+
+import os
+import sys
+import SimpleHTTPServer
+from SocketServer import ThreadingMixIn
+from BaseHTTPServer import HTTPServer
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    pass
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("Please supply a directory to serve")
+    os.chdir(sys.argv[1])
+
+    # Remove the directory from argv so the HTTP port can still be
+    # specified after the directory (read by SimpleHTTPServer.test)
+    del sys.argv[1]
+
+    SimpleHTTPServer.test(ServerClass=ThreadingHTTPServer)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
The default HTTP server used by SimpleHTTPServer is single threaded which can make refreshes of documentation pages a bit slow. This PR adds a little script which starts a multi-threaded HTTP server for
viewing docs. It also takes the directory to serve on the command line, and avoids the traceback when Ctrl-C is used.

The "serve" make target has been updated to use the new script.