### PR TITLE
Release 1.26-alpha2 is the current devel release.

### DIFF
--- a/src/en/reference-releases.md
+++ b/src/en/reference-releases.md
@@ -76,8 +76,8 @@ agent-stream: proposed
 
 ## Development
 
-1.26-alpha1 is currently in development for testing.
-The previous development release was 1.25-beta1.
+1.26-alpha2 is currently in development for testing.
+The previous development release was 1.26-alpha1.
 
 Development releases provide new features that are being stablised.
 These releases are *not* suitable for production environments. Upgrading
@@ -92,15 +92,15 @@ sudo apt-get install juju-core</pre>
 {: .instruction }
 
 Centos
-: [juju-1.26-alpha1-centos7.tar.gz](https://launchpad.net/juju-core/1.26/1.26-alpha1/+download/juju-1.26-alpha1-centos7.tar.gz) ([md5](https://launchpad.net/juju-core/1.26/1.26-alpha1/+download/juju-1.26-alpha1-centos7.tar.gz/+md5))
+: [juju-1.26-alpha2-centos7.tar.gz](https://launchpad.net/juju-core/1.26/1.26-alpha2/+download/juju-1.26-alpha2-centos7.tar.gz) ([md5](https://launchpad.net/juju-core/1.26/1.26-alpha2/+download/juju-1.26-alpha2-centos7.tar.gz/+md5))
 {: .instruction }
 
 OS X
-: [juju-1.26-alpha1-osx.tar.gz](https://launchpad.net/juju-core/1.26/1.26-alpha1/+download/juju-1.26-alpha1-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.26/1.26-alpha1/+download/juju-1.26-alpha1-osx.tar.gz/+md5))
+: [juju-1.26-alpha2-osx.tar.gz](https://launchpad.net/juju-core/1.26/1.26-alpha2/+download/juju-1.26-alpha2-osx.tar.gz) ([md5](https://launchpad.net/juju-core/1.26/1.26-alpha2/+download/juju-1.26-alpha2-osx.tar.gz/+md5))
 {: .instruction }
 
 Windows
-: [juju-setup-1.26-alpha1.exe](https://launchpad.net/juju-core/1.26/1.26-alpha1/+download/juju-setup-1.26-alpha1.exe) ([md5](https://launchpad.net/juju-core/1.26/1.26-alpha1/+download/juju-setup-1.26-alpha1.exe/+md5))
+: [juju-setup-1.26-alpha2.exe](https://launchpad.net/juju-core/1.26/1.26-alpha2/+download/juju-setup-1.26-alpha2.exe) ([md5](https://launchpad.net/juju-core/1.26/1.26-alpha2/+download/juju-setup-1.26-alpha2.exe/+md5))
 {: .instruction }
 
 Development releases use the 'devel' simple-streams. You must configure


### PR DESCRIPTION
This branch updates docs to reflect 1.26-alpha2