### PR TITLE
fix typo in URL for developer-layers-interfaces

### DIFF
--- a/src/en/developer-layers.md
+++ b/src/en/developer-layers.md
@@ -75,7 +75,7 @@ Interface layers currently must be written in Python and extend the ReactiveBase
 class, though they can then be used by any language using the built-in CLI API.
 
 There's more on programming interface layers in the [Developing Interface
-Layers](developers-layers-interfaces.html) guide.
+Layers](developer-layers-interfaces.html) guide.
 
 ## Charm Layers
 


### PR DESCRIPTION
The document developer-layers.md has a broken link to developer-layers-interfaces.html because of a typo. 