### PR TITLE
Navigation box clean up. Broken links, incorrect anchors, some header consistency.

### DIFF
--- a/src/en/config-azure.md
+++ b/src/en/config-azure.md
@@ -2,7 +2,7 @@ Title: Juju Azure provider
 TODO: Decide on what to do with provider-specific features (e.g. placement).
 
 
-# Overview
+# Configuring for Azure 
 
 The new Azure provider is backwards compatible with the previous provider but
 supports several additional features, in particular, support for unit placement

--- a/src/en/config-gce.md
+++ b/src/en/config-gce.md
@@ -1,7 +1,7 @@
 Title: Juju GCE provider
 
 
-# Overview
+# Configuring for the Google Compute Engine 
 
 Google Compute Engine (GCE) is the Infrastructure as a Service (IaaS) component
 of Google Cloud Platform which is built on the global infrastructure that runs

--- a/src/en/developer-debug-dhx.md
+++ b/src/en/developer-debug-dhx.md
@@ -4,9 +4,9 @@
 scripts that extend the functionality of Juju -- which allows you to fully and
 automatically customize the machines created by Juju, making developing and
 debugging hooks as painless as possible. It is drop in replacement for
-[`juju debug-hooks`](./developer-debugging.html#the-'debug-hooks'-command),
+[`juju debug-hooks`](developer-debugging.html#the-'debug-hooks'-command),
 recommended for more advanced users who need to
-[debug hooks](./developer-debugging.html) repetitively.
+[debug hooks](developer-debugging.html) repetitively.
 
 Bugs, feature requests, and pull requests can be submitted against the [Juju
 Plugins project](https://github.com/juju/plugins).

--- a/src/en/developer-layers-interfaces.md
+++ b/src/en/developer-layers-interfaces.md
@@ -40,7 +40,7 @@ this interface?
 - What states (if any) should this interface raise on the requirer?
 
 
-## Communication scopes and how to use them
+## Communication scopes 
 
 When writing an interface, there is also the concept of a communication scope.
 There are three distinct flavors of scoping for a conversation. At times there

--- a/src/en/developer-leadership.md
+++ b/src/en/developer-leadership.md
@@ -94,7 +94,7 @@ This is necessary, as it is for relation data, because a hook context needs
 to present *consistent* data; but it means that there's a small extra burden
 on users of `leader-set`.
 
-# Leadership How-Tos
+# Leadership howtos 
 
 ### How do I...
 

--- a/src/en/developer-leadership.md
+++ b/src/en/developer-leadership.md
@@ -94,7 +94,7 @@ This is necessary, as it is for relation data, because a hook context needs
 to present *consistent* data; but it means that there's a small extra burden
 on users of `leader-set`.
 
-# Leadership HowTo's
+# Leadership How-Tos
 
 ### How do I...
 

--- a/src/en/reference-release-notes.md
+++ b/src/en/reference-release-notes.md
@@ -1,6 +1,6 @@
 Title: Juju Release Notes
 
-# History
+# Release Notes History
 
 This section details all the available release notes for the stable series of
 `juju-core`.

--- a/src/en/wip-centos.md
+++ b/src/en/wip-centos.md
@@ -1,5 +1,6 @@
 Title: Juju support for CentOS7
 
+# Juju and CentOS
 Juju 1.24.0 has initial support for CentOS as a deployment OS (the Juju client
 software is already supported on CentOS - see the 
 [Releases](./reference-releases.html) page). This is experimental and has a 

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -98,7 +98,7 @@
                     <ul class="sub">
                       <li><a href="developer-leadership.html#leadership-hooks">Leadership Hooks</a></li>
                       <li><a href="developer-leadership.html#leadership-tools">Leadership Tools</a></li>
-                      <li><a href="developer-leadership.html#leadership-howtos">Leadership How-Tos</a></li>
+                      <li><a href="developer-leadership.html#leadership-howtos">Leadership Howtos</a></li>
                     </ul>
                   </li>
                   <li class="section"><a class="header" href="developer-actions.html">Implementing Actions</a>

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -68,7 +68,7 @@
                 <ul>
                   <li class="section"><a class="header" href="developer-getting-started.html">Getting Started</a>
                     <ul class="sub">
-                      <li><a href="developer-getting-started.html#prerequisites-and-tools">Prerequisites and Tools</a></li>
+                      <li><a href="developer-getting-started.html#install-libraries-and-tools">Prerequisites and Tools</a></li>
                       <li><a href="developer-getting-started.html#designing-your-charm">Designing your Charm</a></li>
                       <li><a href="developer-getting-started.html#writing-your-charm">Writing your Charm</a></li>
                       <li><a href="developer-getting-started.html#testing-your-charm">Testing your Charm</a></li>
@@ -103,7 +103,7 @@
                   </li>
                   <li class="section"><a class="header" href="developer-actions.html">Implementing Actions</a>
                     <ul class="sub">
-                      <li><a href="developer-actions.html#defining-actions">Defining Actions</a></li>
+                      <li><a href="developer-actions.html#implementing-actions">Defining Actions</a></li>
                       <li><a href="developer-actions.html#action-tools">Action Tools</a></li>
                     </ul>
                   </li>
@@ -122,7 +122,7 @@
                   </li>
                   <li class="section"><a class="header" href="developer-debugging.html">Debugging</a>
                     <ul class="sub">
-                      <li><a href="developer-debugging-layers.html">Debugging Layers</li>
+                      <li><a href="developer-debug-layers.html">Debugging Layers</li>
                       <li><a href="developer-debugging.html#the-'debug-hooks'-command">debug-hooks</a></li>
                       <li><a href="developer-debugging.html#the-'debug-log'-command">debug-log</a></li>
                       <li><a href="developer-debug-dhx.html">DHX</a></li>
@@ -151,7 +151,7 @@
                   </li>
                   <li class="section"><a class="header" href="authors-charm-store.html">The Juju Charm Store</a>
                     <ul class="sub">
-                      <li><a href="authors-charm-store.html#submitting">Submit a charm</a></li>
+                      <li><a href="authors-charm-store.html#submitting-a-new-charm">Submit a charm</a></li>
                       <li><a href="authors-charm-policy.html">Charm store policy</a></li>
                       <li><a href="charm-review-process.html">Charm review process</a></li>
                       <li><a href="authors-charm-best-practice.html">Best practices</a></li>
@@ -181,7 +181,7 @@
                   <li><a href="reference-constraints.html">Juju constraints</a></li>
                   <li><a href="reference-charm-hooks.html">Juju Charm Hooks</a></li>
                   <li><a href="reference-environment-variables.html">Juju environment variables</a></li>
-                  <li><a href="reference-hook-tools.html">Juju 'Hook Tools'</a></li>
+                  <li><a href="reference-hook-tools.html">Juju Hook Tools</a></li>
                   <li><a href="http://godoc.org/github.com/juju/juju/api">Juju API docs</a></li>
                   <li><a href="reference-releases.html">Releases</a></li>
                   <li><a href="reference-release-notes.html">Release notes</a></li>


### PR DESCRIPTION
There were some 404 links in the navigation box and some anchors that weren't referenced correctly. I fixed and tested all the links in the navigation box. This does not address all/any style or writing issues or consistency issues, but I did add a few missing headers  and changed a few for consistency reasons so that navigation becomes easier. 

There appears to be some issue with having a hyphen in the anchor name (howto vs how-to). I didn't try to resolve the weirdness I was seeing. The code that converts a header implicitly into an anchor drops any hyphens so it should have worked, so not sure what was going on. The current header had 'Leadership How-To's' which in any case is incorrect (the plural was intended, rather than the possessive case, I imagine, so if 'howto' is an acceptable noun, 'howtos' would be the correct plural). Python and Drupal and most other documentation use 'howto' rather than 'how-to'  or 'how to'.  Not sure if Juju docs has a position on this. 

Issue #776 (and possibly others, I haven't checked) is fixed by this. 

This also shouldn't have had the developer-debug-dhx.md fix in here (which is already in tree). 