### PR TITLE
Misc

### DIFF
--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -204,7 +204,7 @@ and named according to the following rules.
 
     **Tip:** You should review the configuration options for the charms you are
     planning to use in a bundle, some of them generate passwords for services or
-    might need configuration as a separate step. This may or may not be desireable
+    might need configuration as a separate step. This may or may not be desirable
     for users, so if there are any extra steps required document them in your
     README.md file.
 

--- a/src/en/charms-constraints.md
+++ b/src/en/charms-constraints.md
@@ -18,7 +18,7 @@ constraint, with one exception:
 
   - An empty value always means "not constrained". This allows you to ignore
     environment settings at the service level without having to explicitly
-    remember and re-set the juju default values. Note that there is no way to
+    remember and reset the juju default values. Note that there is no way to
     change the juju default values, though environment settings will override
     them.
 

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -296,7 +296,7 @@ requirements. The `networks` option takes a comma-delimited list of
 juju-specific network names. Juju will enable the networks on the
 machines that host service units. This is different from the network
 constraint which selects a machine that matches the networks, but does
-not configure the machine to use them For example, this commands deploys
+not configure the machine to use them. For example, this commands deploys
 a service to a machine on the "db" and "monitor" networks and enabled
 them:
 

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -93,7 +93,7 @@ juju set-env "default-series=trusty"
 # Deploying with a configuration file
 
 Deployed services usually start with a sane default configuration. However, for
-some services it is desireable (and quicker) to configure them at deployment
+some services it is desirable (and quicker) to configure them at deployment
 time. This can be done by creating a YAML format file of configuration values
 and using the `--config=` switch:
 

--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -156,8 +156,8 @@ juju expose vanilla
 Because Juju is a large complex system, not unlike a Linux software
 distribution, there is a need to test the charms themselves and how they
 interact with one another. All new charms require tests that verify the service
-installs, configures, scales and relates as intended. The tests should be self
-contained, installing all the required packages so the tests can be run
+installs, configures, scales and relates as intended. The tests should be
+self-contained, installing all the required packages so the tests can be run
 automatically with a tool called
 [`bundletester`](https://github.com/juju-solutions/bundletester). Similar to
 hooks the tests should be executable files in a `tests/` directory of the charm.

--- a/src/en/getting-started.md
+++ b/src/en/getting-started.md
@@ -148,8 +148,8 @@ juju add-relation wordpress mysql
 
 This command uses information provided by the relevant charms to associate these
 services with each other in whatever way makes sense. There is much more to be
-said about linking services together which is covered in the Juju command
-documentation, but for the moment, we just need to know that it will link these
+said about linking services together which is covered in the Juju [command
+documentation](commands.html), but for the moment, we just need to know that it will link these
 services together.
 
 In order to make our WordPress public, we now need to expose this service:

--- a/src/en/howto-charm-with-docker.md
+++ b/src/en/howto-charm-with-docker.md
@@ -204,7 +204,7 @@ installed and configured. The install_nginx function sets the state
 def install_nginx():
     '''
     Default to only pulling the image once. A forced upgrade of the image is
-    planned later. Updating on every run may not be desireable as it can leave
+    planned later. Updating on every run may not be desirable as it can leave
     the service in an inconsistent state.
     '''
     if reactive.is_state('nginx.available'):


### PR DESCRIPTION
A few trivial typo cleanups. Also made the text "command documentation" into a link to the command reference doc (assuming that's the one intended?) in getting-started.md. As the link "Juju commands" is way down below in the Reference section, it's not easily seen, and it's not obvious where the Getting Started developer guide is referring you to.