### PR TITLE
Fix header capitalization to be consistent; a few other capitalization/other cleanups.

### DIFF
--- a/src/en/actions.md
+++ b/src/en/actions.md
@@ -1,6 +1,6 @@
 Title: Juju actions  
 
-# Juju Actions
+# Juju actions
 
 Juju Charms can describe Actions that users can take on deployed services.
 

--- a/src/en/authors-charm-actions.md
+++ b/src/en/authors-charm-actions.md
@@ -1,6 +1,6 @@
 Title: Implementing actions in Juju charms  
 
-# Actions for the Charm author
+# Actions for the charm author
 
 Actions are scripts, binaries, or other executables defined on a charm which may
 be invoked or queued remotely by the user on demand.  For example, the Charm
@@ -17,7 +17,7 @@ the UI for an Action invocation will be automatically built based on
 interact with Juju.  Actions can retrieve params passed by the user, set
 responses in a map, or set a failure status with a message.
 
-## Defining Actions
+## Defining actions
 
 To define the Actions available on a Charm, executables (scripts, binaries,
 etc.) for each Action must be included in the `/actions` directory in the Charm,
@@ -64,7 +64,7 @@ snapshot:
 [See below](#example-schema) for a more detailed example.
 
 
-### Schema Requirements
+### Schema requirements
 
 `actions.yaml` must be included in the charm root, and must conform to the
 following requirements:
@@ -88,7 +88,7 @@ following requirements:
  - `additionalProperties: false` should be included at the same level as the
    `description` key if additional params passed by the user should be rejected.
 
-### Example Schema
+### Example schema
 
 Charm dir:
 ```nohighlight
@@ -133,7 +133,7 @@ This schema would support a call such as:
 juju action do mysql/0 snapshot filename=out.tar.gz compression.kind=gzip
 ```
 
-### Action Tools
+### Action tools
 
 Three tools are provided to the Action author for the Action to interact with Juju:
 
@@ -180,7 +180,7 @@ action-set result-map.time-completed="$(date)" result-map.message="Hello world!"
 action-set outcome="success"
 ```
 
-#### Results for this Action
+#### Results for this action
 ```nohighlight
 juju action fetch <some action ID>
 
@@ -242,7 +242,7 @@ status: failed
 
 ---
 
-## Params Transformation
+## Params transformation
 
 This section specifies the transformation from `params` to JSON-Schema.  This is
 meant as a clarifying aid to creating more complex schemas and should not be

--- a/src/en/authors-charm-benchmarks.md
+++ b/src/en/authors-charm-benchmarks.md
@@ -12,7 +12,7 @@ to identify bottlenecks and test configuration changes so that you can get the
 most out of your computing dollar.
 
 
-# Benchmark Execution Methods
+# Benchmark execution methods
 
 There are three ways to execute benchmarks in Juju and the nature of the
 benchmark will determine which method to use:
@@ -28,7 +28,7 @@ benchmark will determine which method to use:
       services.
 
 
-## Integrated into a Service Charm
+## Integrated into a service charm
 
 With this method, we add a *benchmark-enabled* action to a charm.
 
@@ -103,7 +103,7 @@ for instance, is a subordinate charm that can run against any related
 MySQL-compatible database, such as MySQL, Percona, and MariaDB.
 
 
-# Anatomy of a Benchmark
+# Anatomy of a benchmark
 
 ## charm-benchmark
 
@@ -113,7 +113,7 @@ commands from any language. For usage see the
 [charm-benchmark documentation](http://charm-benchmark.readthedocs.org/en/latest/).
 
 
-## How to Write a Benchmark
+## How to write a benchmark
 
 Benchmarks are simply *Juju Actions* that follow a specific pattern. For
 example, here's what `actions/load-gen` might look like:

--- a/src/en/authors-charm-best-practice.md
+++ b/src/en/authors-charm-best-practice.md
@@ -1,6 +1,6 @@
 Title: Best practice for charm authors  
 
-# Best Practice for Charm Authors
+# Best practice for charm authors
 
 This document is to capture charm best practices from the community. We expect
 devops to be strongly opinionated, therefore some strong opinions don't make
@@ -13,7 +13,7 @@ list](https://lists.ubuntu.com/mailman/listinfo/juju) with some ideas on what
 you'd like to see added. Ideally we'd like to document all sorts of great ideas
 on how people are using Juju.
 
-## Best Practice Tips for using Juju in general
+## Best practice tips for using Juju in general
 
 - Check out the [Juju cheat sheet](https://github.com/juju/cheatsheet)
 - Check out the [Juju plugins](https://github.com/juju/plugins)
@@ -22,7 +22,7 @@ on how people are using Juju.
   [disabling IPv6](http://askubuntu.com/questions/440649/how-to-disable-ipv6-in-ubuntu-14-04)
   on the main host.
 
-## Best Practice Tips for Charm Authors
+## Best practice tips for charm authors
 
 - Avoid symlinks if you can, people can use Windows for charms. If you prefer
   having your hook code in one file you can achieve the same affect by stubbing
@@ -36,7 +36,7 @@ on how people are using Juju.
 - Implement a pattern that can be easily unit testable, and submit unit tests
   with your charm.
 
-## Examples of Best Practice Charms
+## Examples of best practice charms
 
 Here is a list of charms that leverage a particular technology that you might
 want to look at as examples:
@@ -50,7 +50,7 @@ want to look at as examples:
 - Example cinder charm - The [cinder-vnx charm](https://jujucharms.com/cinder-vnx), use this if you're interested in adding support for your specific storage hardware to Ubuntu OpenStack.
 - Example neutron charm - The [neutron-openvswitch charm](https://jujucharms.com/neutron-openvswitch), use this if you're interested in adding support for your specific networking hardware to Ubuntu OpenStack.
 
-## Juju Best Practices and Tips from Canonical's Infrastructure Team
+## Juju best practices and tips from Canonical's Infrastructure Team
 
 Since Canonical IS uses Juju in production they have certain requirements from
 charms in order for them to run on a production OpenStack deployment. Though
@@ -91,7 +91,7 @@ Tips for production usage:
     data loss. If a user deploys a charm and later sets the configuration values
     the user would expect the charm to react to those changes accordingly.
 
-## Charm Coding Guidelines
+## Charm coding guidelines
 
 If written in Bash:
 

--- a/src/en/authors-charm-components.md
+++ b/src/en/authors-charm-components.md
@@ -1,6 +1,6 @@
 Title: Components of a charm  
 
-# What makes a Charm?
+# What makes a charm?
 
 Each charm is a structured bundle of files. Conceptually, charms are composed of
 metadata, configuration data, and hooks with some extra support files.

--- a/src/en/authors-charm-components.md
+++ b/src/en/authors-charm-components.md
@@ -7,7 +7,7 @@ metadata, configuration data, and hooks with some extra support files.
 
 ## Required files
 
-A charm requires only a single file in order to be considered valid by juju:
+A charm requires only a single file in order to be considered valid by Juju:
 
  - `metadata.yaml` [describes the charm](./authors-charm-metadata.html) and the
     relations it can participate in.
@@ -20,7 +20,7 @@ actually do anything. For that, some additional files will be required.
 The following files will be treated specially, if present:
 
  - `/hooks` must be a directory holding executables with specific names, that
-   will be invoked by juju at the relevant times. A charm needs to implement at
+   will be invoked by Juju at the relevant times. A charm needs to implement at
    least one hook in order to do anything at all. How to implement hooks is
    covered more thoroughly in the [Hooks section](./authors-charm-hooks.html)
  - `/actions` must be a directory holding executables with specific names, which
@@ -55,7 +55,7 @@ at runtime, copy them on the system alongside the software and reference those
 instead.
 
 This is because the software does _not_ have control over the charm directory;
-_juju_ has control over the charm directory, which it temporarily cedes to the
+_Juju_ has control over the charm directory, which it temporarily cedes to the
 charm only when running a hook. Juju will occasionally do things to the contents
 of that directory that assume it is neither read nor written outside a hook, and
 the results of such interactions can only be undefined.
@@ -69,7 +69,7 @@ change.
 
 Finally, any file written at runtime constrains all future implementations of
 the charm. When [upgrading a charm](./developer-upgrade-charm.html), any change
-that would cause runtime state to be overwritten will cause juju to abort the
+that would cause runtime state to be overwritten will cause Juju to abort the
 operation and hand over to the user for resolution. This is inconvenient for the
 users and undermines confidence in the charm.
 

--- a/src/en/authors-charm-config.md
+++ b/src/en/authors-charm-config.md
@@ -20,7 +20,7 @@ definition must contain all of the following fields:
 Any option without these three fields will generate a Warning from the the
 [charm proof tool](tools-charm-tools.html#proof)
 indicating the option is not compliant with charm store policy. This policy
-allows older versions of juju to safely unset values.
+allows older versions of Juju to safely unset values.
 
 ## What to expose to users
 

--- a/src/en/authors-charm-hooks.md
+++ b/src/en/authors-charm-hooks.md
@@ -4,7 +4,7 @@ Title: Charm hooks
 
 A service unit's direct action is entirely defined by its charm's hooks. Hooks
 are executable files in a charm's `hooks` directory; hooks with particular names
-(see below) will be invoked by the juju unit agent at particular times, and
+(see below) will be invoked by the Juju unit agent at particular times, and
 thereby cause changes to the world.
 
 Whenever a hook-worthy event takes place, the unit agent first checks whether
@@ -69,7 +69,7 @@ configuration changes into account.
 `start` runs immediately after the first `config-changed` hook. It should be
 used to ensure the charm's software is running. Note that the charm's software
 should be configured so as to persist through reboots without further
-intervention on juju's part.
+intervention on Juju's part.
 
 ### upgrade-charm
 
@@ -111,7 +111,7 @@ services. Units of a single client service will surely want to connect to, and
 use, the same database; but if units of another client service were to use that
 same database, the consequences could be catastrophic for all concerned.
 
-If juju respected the `limit` field in relation [metadata](./authors-charm-
+If Juju respected the `limit` field in relation [metadata](./authors-charm-
 metadata.html), it would be possible to work around this, but it's not a high-
 priority [bug](https://bugs.launchpad.net/bugs/1089297): most provider services
 _should_ be able to handle multiple requirers anyway; and most requirers will

--- a/src/en/authors-charm-leadership.md
+++ b/src/en/authors-charm-leadership.md
@@ -1,6 +1,6 @@
 Title: Implementing leadership in Juju charms  
 
-# Leadership for the Charm author
+# Leadership for the charm author
 
 Leadership provides a mechanism whereby multiple units of a service can make
 use of a single, shared, authoritative source for charm-driven configuration

--- a/src/en/authors-charm-leadership.md
+++ b/src/en/authors-charm-leadership.md
@@ -6,7 +6,7 @@ Leadership provides a mechanism whereby multiple units of a service can make
 use of a single, shared, authoritative source for charm-driven configuration
 settings.
 
-Every service deployed by juju is guaranteed to have at most one leader at any
+Every service deployed by Juju is guaranteed to have at most one leader at any
 time. This is true independent of what the charm author does; whether or not
 you implement the hooks or use the tools, the unit agents will each seek to
 acquire leadership, and maintain it while they have it or wait for the current
@@ -24,7 +24,7 @@ should implement the following hooks:
     some other unit writes leader settings).
 
 No particular guarantees can be made regarding the timeliness of the
-`leader-settings-changed` hook; it's always possible for the juju agent itself
+`leader-settings-changed` hook; it's always possible for the Juju agent itself
 to be taken out of commission at the wrong moment and not restarted for a long
 time.
 
@@ -48,7 +48,7 @@ unprepossessing race scenarios.
     to verify continued leadership past lease expiry time, it would start to
     return false.
 
-Every service deployed by juju also has access to a pseudo-relation over which
+Every service deployed by Juju also has access to a pseudo-relation over which
 leader settings can be communicated with the following tools:
 
   * `leader-set` acts much like `relation-set`, in that it lets you write string
@@ -149,7 +149,7 @@ operations, so you can't guarantee a run every 30s anyway).
 
 And we don't plan to allow coarser-grained leadership requests. This is because
 if one unit could declare itself leader for a day (or even an hour) a failed
-leader will leave other parts of juju blocked for that length of time, and we're
+leader will leave other parts of Juju blocked for that length of time, and we're
 not willing to take on that cost; the 30-60s handover delay is bad enough
 already.
 
@@ -168,7 +168,7 @@ If you start your long-lived process in `leader-elected`, and stop it in
 `leader-settings-changed`, this will *usually* do what you want, but is
 vulnerable to a number of failure modes -- both because hook execution may be
 blocked until after the leadership lease has actually expired, *and* because
-total juju failure could also cause the hook not to run (but leave the workload
+total Juju failure could also cause the hook not to run (but leave the workload
 untouched).
 
 In the future, we may implement a `leader-deposed` hook, that can run with

--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -13,7 +13,7 @@ the following fields:
       and you needn't pay further attention to the restrictions.
   - `summary` is a one-line description of the charm.
   - `description` is a long-form description of the charm and its features.
-  It will also appear in the juju GUI.
+  It will also appear in the Juju GUI.
   - `tags` is a descriptive tag that is used to sort the charm in the store.
 
 

--- a/src/en/authors-charm-policy.md
+++ b/src/en/authors-charm-policy.md
@@ -1,6 +1,6 @@
 Title: Charm store policy  
 
-# Charm Store Policy
+# Charm store policy
 
 This document serves to record the policies around charms and bundles included
 in the charm store, and the management of said collection. Charms and bundles in
@@ -58,7 +58,7 @@ policy the charm will undergo the
 confirms the charm is no longer being maintained, fails to adhere to Charm Store
 policy, and thus is removed from the recommended status in the Juju Charm Store. 
 
-# Charm Metadata
+# Charm metadata
 
 ## metadata.yaml
 

--- a/src/en/authors-charm-store.md
+++ b/src/en/authors-charm-store.md
@@ -1,6 +1,6 @@
 Title: The Juju charm store  
 
-# The Juju Charm Store
+# The Juju charm store
 
 Juju includes a collection of what we call `Charms` that let you deploy whatever
 services you want in Juju. A collection of charms that are designed to work
@@ -14,7 +14,7 @@ call The Charm Store.
   - Here is the official tutorial for charm authors: [authors-charm-writing](authors-charm-writing.html)
   - Here is the official tutorial for bundle authors: [charms-bundles](charms-bundles.html)
 
-## Charm Store Submission
+## Charm store submission
 
 There are currently 2 methods to submit a charm and have it listed in the charm
 store. Both methods have their perks - but it is suggested to start with your
@@ -25,13 +25,13 @@ ensure that your Charm gets into the Recommended Charms section of the Charm
 Store, so please follow the instructions in the
 [Recommended Charms](#recommended-charms) section below.
 
-## Charm Store Process
+## Charm store process
 
 This process is designed to allow prospective developers to have their charms
 reviewed and updated in the [Charm Store](https://jujucharms.com) in a timely
 manner that ensures peer reviews and quality.
 
-## Submitting a new Charm
+## Submitting a new charm
 
 Everyone with a launchpad account has access to have their charms listed in the
 charm store, without review, approximately 20 minutes after the initial push to
@@ -75,7 +75,7 @@ bzr push lp:~<your-lp-username>/charms/trusty/<your-charm>/trunk
 
 Your charm should then be looked at in a timely manner.
 
-### Name Space Charms
+### Name-Space charms
 
 There are some key differences with regard to deployment charms in your personal
 namespace.
@@ -86,7 +86,7 @@ namespace.
   - Workflow to accept contributions
 
 
-#### Submission Process
+#### Submission process
 
 When you feel your charm is ready for submission to your personal name space,
 you must initialise the repository and push your development branch to Launchpad.
@@ -122,7 +122,7 @@ space URL.
 juju deploy cs:~your-launchpad-username/series/nagios
 ```
 
-#### Charm Store Display
+#### Charm store display
 
 Name Spaced charms will be displayed under the **other** category in the GUI.
 They will be displayed with non-descript icons for the service. Only
@@ -143,14 +143,14 @@ the Launchpad
 [Developer Merge Proposal Documentation](https://dev.launchpad.net/UsingMergeProposals)
 
 
-### Recommended Charms
+### Recommended charms
 
 To have your charm listed as a charmer team recommended charm, you have to
 undergo a rigorous review process where the team evaluate the charm, evaluate 
 tests for your charm, and deploy & run tests against the provided service with
 different configuration patterns.
 
-After following the Submission Process outlined above:
+After following the submission process outlined above:
 
   1. File a bug against charms at 
      [https://launchpad.net/charms/+filebug](https://launchpad.net/charms/+filebug)
@@ -165,7 +165,7 @@ After following the Submission Process outlined above:
      in the review queue!
 
 
-## Submitting a fix to an existing Charm
+## Submitting a fix to an existing charm
 
   1. Grab the charm you want to fix, we'll use Nagios as an example: `bzr branch lp:charms/precise/nagios`
   1. Modify it to meet your needs.
@@ -180,12 +180,12 @@ After following the Submission Process outlined above:
   1. For the reviewer field put the `charmers` team, this will get your code
      into the review queue!
 
-## Submitting bundles to the Charm Store
+## Submitting bundles to the charm store
 
 Refer to the [Bundles page](charms-bundles.html) for instructions on how to
 create bundles of charms and submit them to the store.
 
-## Getting Help
+## Getting help
 
 Inspired by [Bazaar's Patch Pilot
 programme](http://wiki.bazaar.canonical.com/PatchPilot) there will be patch

--- a/src/en/authors-charm-store.md
+++ b/src/en/authors-charm-store.md
@@ -43,7 +43,7 @@ You can submit your charm to the 12.04 and 14.04 releases of Ubuntu. You are not
 required to submit to both releases, but we recommend supporting both whenever
 possible so that users get the most flexibility:
 
-  1. Install juju and charm-tools.
+  1. Install Juju and charm-tools.
   1. Create a repository, something like `mkdir -p ~/charms/precise`; 'precise'
      is the release code name for the [release of Ubuntu](http://releases.ubuntu.com)
      you wish to target your charm at. You can also use `trusty` if you're

--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -456,7 +456,7 @@ will look something like this:
 
 ![Step five - debug](./media/author-charm-writing-debug.png)
 
-If you wait for all the Juju operations to finish and run a juju status command,
+If you wait for all the Juju operations to finish and run a `juju status` command,
 you will be able to retrieve the public address for the Vanilla forum we just
 deployed. Copy it into your browser and you should see the setup page
 (pre-populated with the database config) waiting for any changes.

--- a/src/en/authors-hook-debug-dhx.md
+++ b/src/en/authors-hook-debug-dhx.md
@@ -1,6 +1,6 @@
 Title: DHX plugin  
 
-# DHX: A Customized Hook Debugging Environment Plugin
+# DHX: A customized hook debugging environment plugin
 
 [DHX](https://github.com/juju/plugins/blob/master/juju-dhx) is a Juju plugin
 that allows you to fully and automatically customise the machines created by
@@ -39,7 +39,7 @@ Here is an overview of the features:
 - Automatic sync of changes made to charm during debug session
 - Support for easy paired debug sessions
 
-# Installation and Setup
+# Installation and setup
 
 First, follow [the instructions in the README](https://github.com/juju/plugins#install)
 to install the plugin bundle.
@@ -79,7 +79,7 @@ dhx` (or `juju debug-hooks-ext`, if you want to be verbose). This will
 automatically detect if the environment you're connecting to has been
 customized and, if not, apply your customizations.
 
-## Improved Unit Selection
+## Improved unit selection
 
 Instead of typing out the full unit name, in the form `service/0`, you can let
 DHX figure out which unit you want to debug. It will use cues such as which
@@ -132,7 +132,7 @@ Units:
 Select a unit by number or name: [mysql/1]
 ```
 
-## Retrying Failed Hooks
+## Retrying failed hooks
 
 The most common reason why you need to start a debug-hooks session is because a
 hook failed and you want to debug it to figure out why. Once you are in the 

--- a/src/en/authors-hook-debug.md
+++ b/src/en/authors-hook-debug.md
@@ -78,7 +78,7 @@ events on that unit will be paused indefinitely.
 The queue can be halted by exiting with an `exit 1` command, which will flag the
 hook as failed. Juju will revert to its normal behaviour of suspending
 everything until this error status is resolved, which you can do by issuing the
-command (from your juju terminal window, not the debugging window) of
+command (from your Juju terminal window, not the debugging window) of
 `juju resolved <unit>`.
 
 You can finish your debugging session by closing all windows in the tmux

--- a/src/en/authors-hook-environment.md
+++ b/src/en/authors-hook-environment.md
@@ -4,11 +4,11 @@ Title: The hook environment, hook tools and how hooks are run
 
 When a charm is deployed onto a unit, the raw charm is extracted into a
 directory; this directory is known as the charm directory. It's owned and
-operated by juju, and juju sometimes temporarily cedes control of it to user
+operated by Juju, and Juju sometimes temporarily cedes control of it to user
 code, by running a hook inside it.
 
 When a hook's running, it should be considered to have sole access to the charm
-directory; at all other times, you should consider that juju may be making
+directory; at all other times, you should consider that Juju may be making
 arbitrarily scary changes to the directory, and that it is not safe to read or
 write to anything in there at all.
 
@@ -19,7 +19,7 @@ of your _software_ must remain unperturbed by direct changes to the charm.
 
 So, every hook runs with easy access to the charm files. Every hook also runs as
 root, with a number of useful variables set, and has access to hook-specific
-tools that let you interrogate and affect the juju environment.
+tools that let you interrogate and affect the Juju environment.
 
 No more than one hook will execute on a given system at a given time. A unit in
 a container is considered to be on a different system to any unit on the
@@ -55,11 +55,11 @@ In addition, every relation hook makes available relation-specific variables:
   being reported to have -joined, -changed, or -departed.
 
 Juju does _not_ pay any attention to the values of the above variables when
-running hook tools: they're a one-way communication channel from juju to the
+running hook tools: they're a one-way communication channel from Juju to the
 charm only. Finally, in all cases:
 
   - The `$JUJU_AGENT_SOCKET` and `$JUJU_CONTEXT_ID` variables allow the hook
-    tools to work: juju _does_ pay attention to them, but you should treat
+    tools to work: Juju _does_ pay attention to them, but you should treat
     them as opaque and avoid messing with them.
 
 Finally, if you're [debugging](./authors-hook-debug.html), you'll also have
@@ -110,7 +110,7 @@ There are several cases where a charm needs to reboot a machine, such as
 after a kernel upgrade, or to upgrade the entire system. The charm may not
 be able to complete the hook until the machine is rebooted.
 
-The juju-reboot command allows charm authors to schedule a reboot from inside
+The `juju-reboot` command allows charm authors to schedule a reboot from inside
 a charm hook. The reboot will only happen if the hook completes without error. 
 You can schedule a reboot like so:
 
@@ -123,7 +123,7 @@ The `--now` option can be passed to block hook execution. in this case the
 re-queues it for the next run. This will allow you to create multi-step 
 install hooks.
 
-Charm authors must wrap calls to juju-reboot to ensure it is actually 
+Charm authors must wrap calls to `juju-reboot` to ensure it is actually 
 necessary, otherwise the charm risks entering a reboot loop. The preferred
 work-flow is to check if the feature/charm is in the desired state, and
 reboot when needed. This bash example assumes that "$FEATURE_IS_INSTALLED"

--- a/src/en/authors-hook-errors.md
+++ b/src/en/authors-hook-errors.md
@@ -2,7 +2,7 @@ Title: Dealing with errors encountered by charm hooks
 
 # Hook errors
 
-If any of your hooks returns a non-zero exit code, juju will stop managing the
+If any of your hooks returns a non-zero exit code, Juju will stop managing the
 unit directly and will wait for user intervention. This is a Bad Thing, and you
 should make every effort to avoid it, because the average user may not be in a
 position to diagnose the fault with any great degree of sophistication.
@@ -21,7 +21,7 @@ potentially underinformed responses to those errors.
 
 When a unit agent sets an error status, it stops running hooks and relinquishes
 control over the charm directory. This means that it's generally safe to `juju
-ssh` into the unit and use it as though you were the sole administrator; juju
+ssh` into the unit and use it as though you were the sole administrator; Juju
 will only take back control of the directory when explicitly requested, in
 response to either `juju resolved` or `juju upgrade-charm --force`.
 

--- a/src/en/authors-implicit-relations.md
+++ b/src/en/authors-implicit-relations.md
@@ -6,7 +6,7 @@ Implicit relations allow for interested services to gather lifecycle-oriented
 events and data about other services without expecting or requiring any
 modifications on the part of the author of the other service's charm.
 
-Implicit relationships are named in the reserved juju-* namespace. Both the
+Implicit relationships are named in the reserved `juju-*` namespace. Both the
 relation name and interface names provided by Juju are prefixed with `juju-`.
 Charms attempting to provide new relationships in this namespace will trigger an
 error.

--- a/src/en/authors-relations.md
+++ b/src/en/authors-relations.md
@@ -20,9 +20,9 @@ the other charms with the counterpart role.
 Juju decides which services can be related based on the interface names only.
 They have to match.
 
-## Relation Composition
+## Relation composition
 
-### Provides and Requires
+### Provides and requires
 
 The `provides` and `requires` keys defined in
 [metadata.yaml](./authors-charm-metadata) are used to define pairings of charms
@@ -140,7 +140,7 @@ requires:
 it can't be expected to do anything useful without a MongoDB service available.
 
 
-## Relationship Execution in Charms
+## Relationship execution in charms
 
 When services are related, Juju decides which hooks to call within each charm
 based on this local relation name. When WordPress is related to MySQL, the
@@ -149,7 +149,7 @@ the WordPress end. Corresponding hooks will be called on the 'mysql' charm "db-
 relation-joined, db-relation-changed" (based on the 'mysql' relation names).
 
 
-# Authoring Charm Interfaces
+# Authoring charm interfaces
 
 Relations are basically a bidirectional channel of communication between services.
 They're not actually talking directly, the agents communicate via the state
@@ -157,7 +157,7 @@ server, but it helps to think of it as direct communication between the
 services. Relation hooks can call tools such as `relation-get` and `relation-
 set` to pass information back and forth between the service endpoints.
 
-### Pseudo Relationship Talk
+### Pseudo relationship talk
 
 For example, `wordpress` and `mysql` might have a conversation like the following:
 
@@ -298,7 +298,7 @@ requires:
 ```
 
 
-## Interface Documentation
+## Interface documentation
 
 Although we have described above that interfaces arrive by convention, there
 are several well-used interfaces which have enough implementations to define a

--- a/src/en/authors-service-config.md
+++ b/src/en/authors-service-config.md
@@ -6,7 +6,7 @@ Title: Service configuration
 
 A [Charm](./charm.html) often will require access to specific options or
 configuration. Charms allow for the manipulation of the various configuration
-options which the charm author has chosen to expose. juju provides tools to help manage these options and respond to changes in these options over the lifetime of the service deployment. These options apply to the entire service, as opposed to only a specific unit or relation. Configuration is modified by an
+options which the charm author has chosen to expose. Juju provides tools to help manage these options and respond to changes in these options over the lifetime of the service deployment. These options apply to the entire service, as opposed to only a specific unit or relation. Configuration is modified by an
 administrator at deployment time or over the lifetime of the services.
 
 As an example a wordpress service may expose a 'blog-title' option. This option
@@ -16,14 +16,14 @@ of a hook on each of them.
 
 ## Using configuration options
 
-Configuration options are manipulated using a command line interface. juju
-provide a set command to aid the administrator in changing values.
+Configuration options are manipulated using a command line interface. Juju
+provides a `set` command to aid the administrator in changing values.
 
     juju set <service name> option=value [option=value]
 
 This command allows changing options at runtime and takes one or more name/value pairs which will be set into the service options. Configuration options which are set together are delivered to the services for handling together. E.g. if you are changing a username and a password, changing them individually may yield bad results since the username will temporarily be set with an incorrect password.
 
-While its possible to set multiple configuration options on the command line its also convenient to pass multiple configuration options via the --file argument which takes the name of a YAML file. The contents of this file will be applied as though these elements had been passed to juju set.
+While its possible to set multiple configuration options on the command line its also convenient to pass multiple configuration options via the --file argument which takes the name of a YAML file. The contents of this file will be applied as though these elements had been passed to `juju set`.
 
 A configuration file may be provided at deployment time using the --config
 option, as follows:
@@ -33,7 +33,7 @@ option, as follows:
 
 The service name is looked up inside the YAML file to allow for related service
 configuration options to be collected into a single file for the purposes of
-deployment and passed repeated to each juju deploy invocation.
+deployment and passed repeated to each `juju deploy` invocation.
 
 Below is an example local.yaml containing options which would be used during
 deployment of a service named myblog.
@@ -50,7 +50,7 @@ deployment of a service named myblog.
 
 Charm authors create a config.yaml file which resides in the charm's top-level
 directory. The configuration options supported by a service are defined within
-its respective charm. juju will only allow the manipulation of options which
+its respective charm. Juju will only allow the manipulation of options which
 were explicitly defined as supported.
 
 The specification of possible configuration values is intentionally minimal, but still evolving. Currently the charm define a list of names which they react. Information includes a human readable description and an optional default value. Additionally type may be specified. All options have a default type of 'str' which means its value will only be treated as a text string. Other valid options are 'int' and 'float'.
@@ -77,11 +77,11 @@ config-get returns all the configuration options for a service as JSON data when
 Changes to options (see previous section) trigger the charm's config-changed
 hook. The config-changed hook is guaranteed to run after any changes are made to the configuration, but it is possible that multiple changes will be observed at once. Because its possible to set many configuration options on a single command line invocation it is easily possible to ensure related options are available to the service at the same time.
 
-The config-changed hook must be written in such a way as to deal with changes to one or more options and deal gracefully with options that are required by the charm but not yet set by an administrator. Errors in the config-changed hook force juju to assume the service is no longer properly configured. If the
+The config-changed hook must be written in such a way as to deal with changes to one or more options and deal gracefully with options that are required by the charm but not yet set by an administrator. Errors in the config-changed hook force Juju to assume the service is no longer properly configured. If the
 service is not already in a stopped state it will be stopped and taken out of
 service. The status command will be extended in the future to report on workflow and unit agent status which will help reveal error conditions of this nature.
 
-When options are passed using juju deploy their values will be read in from a
+When options are passed using Juju deploy their values will be read in from a
 file and made available to the service prior to the invocation of the its
 install hook. The install and start hooks will have access to config-get and
 thus complete access to the configuration options during their execution. If theinstall or start hooks don't directly need to deal with options they can simply invoke the config-changed hook.

--- a/src/en/authors-subordinate-services.md
+++ b/src/en/authors-subordinate-services.md
@@ -33,7 +33,7 @@ subordinate services will execute.
 running container of another service unit.
 
 **Container relation**: A scope:container relationship. While modeled
-identically to traditional, scope: global, relationships, juju only implements
+identically to traditional, scope: global, relationships, Juju only implements
 the relationship between the units belonging to the same container.
 
 ## Relations

--- a/src/en/authors-testing.md
+++ b/src/en/authors-testing.md
@@ -1,6 +1,6 @@
 Title: Testing Juju charms  
 
-# Charm Testing
+# Charm testing
 
 Juju has been designed from the start to foster a large collection of "charms".
 Charms are expected to number in the thousands, and be self contained, with 
@@ -35,7 +35,7 @@ be the focus of an implementation.
 
 Note that this requirement is already satisfied by [Mark Mims' jenkins tester](https://github.com/mmm/charmtester/).
 
-## Phase 2 - Charm Specific tests
+## Phase 2 - charm specific tests
 
 Charm authors will have the best insight into whether or not a charm is working
 properly.
@@ -92,7 +92,7 @@ things to test in each charm beyond install/start is:
 - Adding multiple units to a web app charm and relating to a load balancer 
   results in the same HTML on both units directly and the load balancer.
 
-### Exit Codes
+### Exit codes
 
 Upon exit, the test's exit code will be evaluated to mean the following:
 
@@ -116,9 +116,9 @@ contents of files are to be logged, the contents should be preceded by `INFO:
 BEGIN filename`, where filename is a logical name unique to this run of the
 test, and then the file ended with `INFO: END filename`.
 
-### Example Tests
+### Example tests
 
-#### Deploy requirements and Poll
+#### Deploy requirements and poll
 
 The test below deploys mediawiki with mysql and memcached related to it, and 
 then tests to make sure it returns a page via http with `<title>` somewhere 
@@ -252,7 +252,7 @@ Juju core to allow such things to be made into plugins. Until then, it can be
 included in each test dir that uses it, or we can build a package of tools 
 that are common to tests.
 
-## Test Runner
+## Test runner
 
 A test runner will periodically poll the collection of charms for changes since
 the last test run. If there have been changes, the entire set of changes will

--- a/src/en/authors-testing.md
+++ b/src/en/authors-testing.md
@@ -18,7 +18,7 @@ specification.
 ## Phase 1 - Generic tests
 
 All charms share some of the same characteristics. They all have a yaml file
-called `metadata.yaml`, and when deployed, juju will always attempt to progress
+called `metadata.yaml`, and when deployed, Juju will always attempt to progress
 the state of the service from install to config to started. Because of this, 
 all charms can be tested using the following algorithm:
 
@@ -47,12 +47,12 @@ with a predictible environment. The tests can make the following assumptions:
 
 - A minimal install of the release of Ubuntu which the charm is targeted at 
   will be available.
-- A version of juju is installed and available in the system path.
-- A juju environment with no services deployed inside it is already 
+- A version of Juju is installed and available in the system path.
+- A Juju environment with no services deployed inside it is already 
   bootstrapped, and will be the default for command line usage.
 - The CWD is the `tests` directory off the charm root.
 - Full network access to deployed nodes will be allowed.
-- the bare name of any charm in arguments to juju will be resolved to a charm 
+- the bare name of any charm in arguments to Juju will be resolved to a charm 
   url and/or repository arguments of the test runner's choice. This means that 
   if you need mysql, you do not do `juju deploy cs:mysql` or 
   `juju deploy --repository ~/charms local:mysql`, but just `juju deploy mysql`.
@@ -264,7 +264,7 @@ All of the charms will be scanned for tests in lexical order by series, charm
 name, branch name. Non official charms which have not been reviewed by charmers
 will not have their tests run until the test runner's restrictions have been
 vetted for security, since we will be running potentially malicious code. It is
-left to the implementor to determine what mix of juju, client platform, and
+left to the implementor to determine what mix of Juju, client platform, and
 environment settings are appropriate, as all of these are variables that will
 affect the running charms, and so may affect the outcome.
 

--- a/src/en/charm-review-process.md
+++ b/src/en/charm-review-process.md
@@ -1,8 +1,8 @@
 Title: Charm review process  
 
-# Charm Review Process
+# Charm review process
 
-Reviewing a Juju Charm is a process that can easily be broken down into
+Reviewing a Juju charm is a process that can easily be broken down into
 the following parts:
 
 1. Identifying what to review
@@ -66,9 +66,9 @@ cd charm-name
 ```
 
 
-## Charm Information Review
+## Charm information review
 
-### Charm Proofing
+### Charm proofing
 
 Now that we have set up / branched the charm and are in the charm's directory,
 we need to run the following command:
@@ -93,7 +93,7 @@ charm is likely to be deployable, continue on with the review. Just be sure to
 note that the charm, as it stands, breaks Charm Store Policy and will not be
 accepted in its current form.
 
-### Reading The README
+### Reading the README
 
 Understanding the purpose of the charm is crucial for both those that are
 reviewing as well as for those that may want to deploy the charm. We recommend
@@ -111,7 +111,7 @@ and relations.
 
 Make note of sections of the README that need improvement or are missing.
 
-### Charm Configuration
+### Charm configuration
 
 Take a look at the charm's config.yaml file, using the
 [Charm Configuration](authors-charm-config.html) document for reference. We
@@ -124,7 +124,7 @@ Inspect the charm's metadata.yaml file and use the
 [Charm metadata](authors-charm-metadata.html) document as reference.
 
 
-## Charm Code Review
+## Charm code review
 
 Reviewing a charm's code is an **optional** step for community reviewers.
 If you feel comfortable reviewing the charm's code, here are some things to
@@ -138,7 +138,7 @@ watch out for in the charms code:
    failed execution, thereby allowing Juju to more accurately detect a failed hook.
 
 
-## Charm Deployment, Configuration, and Testing
+## Charm deployment, configuration, and testing
 
 If a charm has tests (you can determine if it does by checking for a "tests"
 folder), run the command below and verify the charm that way:
@@ -220,7 +220,7 @@ files, check that file for the values you set earlier. Check the hooks to see
 which ones are written to configuration files (if applicable at all).
 
 
-## Gathering / Submitting Your Results
+## Gathering / Submitting your results
 
 Gather the information that you have obtained from the charm review, such as
 whether the charm proof passes or has issues, if the README is understandable

--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -1,8 +1,8 @@
 Title: Creating and using bundles  
 
-# Creating and using Bundles
+# Creating and using bundles
 
-A Bundle is a set of services with a specific configuration and their
+A bundle is a set of services with a specific configuration and their
 corresponding relations that can be deployed together in a single step.
 Instead of deploying a single service, they can be used to deploy an entire
 workload, with working relations and configuration. The use of bundles allows
@@ -176,7 +176,7 @@ other than "0", which is used to represent the bootstrap node.  Leaving the
 machine specification out of your bundle tells Juju to place units on new
 machines if no placement directives are given.
 
-## Sharing your Bundle with the Community
+## Sharing your bundle with the community
 
 Bundles are shared by putting a branch onto Launchpad with specific naming
 which will then be pulled into the Charm Store. The branch must be constructed
@@ -229,7 +229,7 @@ Freenode) who can assist. You can also use the
 [Juju mailing list](https://lists.ubuntu.com/mailman/listinfo/juju).
 
 
-## Deploying a Bundle from the Charm Store with the GUI
+## Deploying a bundle from the charm store with the GUI
 
 To deploy a bundle from the Charm Store using the GUI, first find the bundle
 you wish to deploy via search or browsing the bundles to the left. To view

--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -38,7 +38,7 @@ method.
 A bundle file can be deployed via the command-line interface by using the `juju
 quickstart` tool.
 
-The juju quickstart tool can be installed on Ubuntu versions newer than 14.04 by
+The Juju quickstart tool can be installed on Ubuntu versions newer than 14.04 by
 running the following command:
 
 ```bash
@@ -171,7 +171,7 @@ however you wish.  A machine specification is a YAML object with named machines
 possible fields: `series`, `constraints`, and `annotations`.
 
 Note that the machine spec is optional.  If it is not included, solutions such
-as the juju deployer will fail if a placement specification refers to a machine
+as the Juju deployer will fail if a placement specification refers to a machine
 other than "0", which is used to represent the bootstrap node.  Leaving the
 machine specification out of your bundle tells Juju to place units on new
 machines if no placement directives are given.

--- a/src/en/charms-config.md
+++ b/src/en/charms-config.md
@@ -1,6 +1,6 @@
 Title: Service configuration  
 
-# Service Configuration
+# Service configuration
 
 When deploying a service, the charm you use will often support or even require
 specific configuration options to be set.

--- a/src/en/charms-constraints.md
+++ b/src/en/charms-constraints.md
@@ -6,7 +6,7 @@ Machine constraints allow you to choose the hardware to which your services will
 be deployed.
 
 Constraints can be set for environments and services, with service constraints
-overriding environment constraints, the default values set by juju when
+overriding environment constraints, the default values set by Juju when
 otherwise unspecified. Changes to constraints do not affect any unit that has
 already been assigned to a machine.
 
@@ -20,8 +20,8 @@ constraint, with one exception:
 
   - An empty value always means "not constrained". This allows you to ignore
     environment settings at the service level without having to explicitly
-    remember and reset the juju default values. Note that there is no way to
-    change the juju default values, though environment settings will override
+    remember and reset the Juju default values. Note that there is no way to
+    change the Juju default values, though environment settings will override
     them.
 
 The commands `juju deploy`, `juju bootstrap`, and `juju add-machine` have a

--- a/src/en/charms-constraints.md
+++ b/src/en/charms-constraints.md
@@ -1,6 +1,6 @@
 Title: Machine constraints  
 
-# Machine Constraints
+# Machine constraints
 
 Machine constraints allow you to choose the hardware to which your services will
 be deployed.
@@ -67,7 +67,7 @@ Output constraints for mysql
 ```bash
 juju get-constraints mysql
 ```
-# Provider Constraints
+# Provider constraints
 
 See a [complete listing of constraints](reference-constraints.html) for details
 on what each constraint means. Two of the most commonly used are:

--- a/src/en/charms-constraints.md
+++ b/src/en/charms-constraints.md
@@ -10,7 +10,7 @@ overriding environment constraints, the default values set by juju when
 otherwise unspecified. Changes to constraints do not affect any unit that has
 already been assigned to a machine.
 
-Constraint can be set by the `juju set-constraints` command, taking an optional
+Constraints can be set by the `juju set-constraints` command, taking an optional
 `--service` arg, and any number of `key=value` pairs. When the service name is
 specified, the constraints are set on that service; otherwise they are set on
 the environment.

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -295,7 +295,7 @@ horizontally scale out on dedicated machines when you need to.
 
 Use the `networks` option to specify service-specific network
 requirements. The `networks` option takes a comma-delimited list of
-juju-specific network names. Juju will enable the networks on the
+Juju-specific network names. Juju will enable the networks on the
 machines that host service units. This is different from the network
 constraint which selects a machine that matches the networks, but does
 not configure the machine to use them. For example, this commands deploys

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -1,6 +1,6 @@
 Title: Deploying services  
 
-# Deploying Services
+# Deploying services
 
 The fundamental point of Juju is that you can use it to deploy services through
 the use of charms (the magic bits of code that make things just work). These
@@ -12,7 +12,7 @@ most part you can forget about this, as Juju will always try to apply the most
 relevant charm, so deploying can be straightforward and easy.
 
 
-# Deploying from the Charm Store
+# Deploying from the charm store
 
 In most cases, you will want to deploy charms by fetching them directly from the
 Charm Store. This ensures that you get the relevant, up to date version of the
@@ -285,7 +285,7 @@ This will allow you to save money when you need it by using --to, but also
 horizontally scale out on dedicated machines when you need to.
 
 
-## References and Examples
+## References and examples
 
   - [ Scaling Down in the Cloud with Juju](http://www.jorgecastro.org/2013/07/31/deploying-wordpress-to-the-cloud-with-juju/)
   - [ Targeted Machine Deployment with Juju](http://javacruft.wordpress.com/2013/07/25/juju-put-it-there-please/)

--- a/src/en/charms-environments.md
+++ b/src/en/charms-environments.md
@@ -50,7 +50,7 @@ juju switch amazon             # switches the environment to the cloud defined b
 juju deploy mysql -e mycloud   # deploys mysql charm on the cloud defined by 'mycloud'
 ```
 
-**Note: ** Unlike many switches used with juju, `-e` must come at the end of the
+**Note: ** Unlike many switches used with `juju`, `-e` must come at the end of the
 command in order to be parsed correctly.
 
 ## Switching environments
@@ -96,7 +96,7 @@ specifications themselves, like this:
 Juju has a set of commands that permit you to view and change the configuration
 of a running environment. The commands can be used to make temporary changes,
 such as to logging, or permanent changes, such as to take advantage of new
-features after juju is upgraded.
+features after Juju is upgraded.
 
 The `get-environment` command will display all the environment's configured
 options. You can pass the name of an option to see just the one value. For
@@ -117,7 +117,7 @@ juju set-environment default-series=trusty
 The `unset-environment` command will set a configuration option to the default
 value. It acts as a reset. Options without default value are removed. It is an
 error to unset a required option. For example, you can unset the default series
-that charms are deployed with (so that the juju store can choose the best series
+that charms are deployed with (so that the Juju store can choose the best series
 for a charm) like this:
 
 ```bash
@@ -127,8 +127,8 @@ juju unset-environment default-series
 ## Upgrading environments
 
 The `upgrade-juju` command upgrades a running environment. It selects the most
-recent supported version of juju compatible with the command-line version. The
-juju machine and unit agents will be updated to the new version. The `--version`
+recent supported version of Juju compatible with the command-line version. The
+Juju machine and unit agents will be updated to the new version. The `--version`
 option can be used to select a specific version to upgrade to.
 
 ```bash

--- a/src/en/charms-exposing.md
+++ b/src/en/charms-exposing.md
@@ -1,7 +1,7 @@
 Title: Exposing services    
 
 
-# Exposing Services
+# Exposing services
 
 By design, Juju operates a very secure environment for deploying your services.
 Even if you have deployed services, they won't be publicly available unless

--- a/src/en/charms-ha.md
+++ b/src/en/charms-ha.md
@@ -26,7 +26,7 @@ The way this works depends on whether Juju uses Availability Zones or
 Availability Sets for that provider.
 
 
-## Availability Zones
+## Availability zones
 
 Juju supports Availability Zones on Amazon's EC2 and OpenStack-based clouds.
 Openstack Havana and newer is supported, which includes HP Cloud. Older
@@ -45,7 +45,7 @@ juju add-machine zone=us-east-1c
 ```
 
 
-## Azure Availability Sets
+## Azure availability sets
 
 Juju supports Availability Sets on Microsoft's Azure.  As long as at least two
 units are deployed, Azure guarantees 99.95% availability of the service

--- a/src/en/charms-relations.md
+++ b/src/en/charms-relations.md
@@ -1,6 +1,6 @@
 Title: Managing relationships  
 
-# Managing Relationships
+# Managing relationships
 
 Few services you might want to run can do so completely independently - most of
 them rely on some other software components to be present and running too (e.g.
@@ -22,7 +22,7 @@ that and acknowledging the task. As you will see though, adding a relationship
 is much easier than even this brief explanation.
 
 
-## Creating Relations
+## Creating relations
 
 Creating relationships is usually very straightforward. Simply deploy the two
 services:
@@ -113,7 +113,7 @@ services:
 ```
 
 
-## Removing Relations
+## Removing relations
 
 There are times when a relationship just isn't working and it is time to move
 on. Fortunately, it is a simple single-line command to break off these

--- a/src/en/charms-scaling.md
+++ b/src/en/charms-scaling.md
@@ -1,7 +1,7 @@
 Title: Scaling charms  
 TODO: Check final note still relevant for 2.0 release  
 
-# Scaling Charms
+# Scaling charms
 
 One of the killer features of computing in the cloud is that it (should)
 seamlessly allow you to scale up or down your services to meet your needs and
@@ -31,7 +31,7 @@ The command options are:
 ```
 
 
-## Scaling behind a Load Balancer
+## Scaling behind a load balancer
 
 Usually you just can't add more units to a service and have it magically scale
 - you need to use a load balancer. In this case you can just deploy a proxy in
@@ -74,7 +74,7 @@ are installed and configured _before_ adding them to the load balancer,
 ensuring minimal user disruption of the service.
 
 
-## Scaling Charms with built in Horizontal scaling
+## Scaling charms with built in horizontal scaling
 
 Some charms have native scaling built in. For instance, the WordPress charm
 has built in load balancing. In this case, scaling up services is really as
@@ -157,7 +157,7 @@ juju add-unit mysql --to 3
 ```
 
 
-## Scaling Back
+## Scaling back
 
 Sometimes you may want to scale back some of your services, and this too is
 easy with Juju.

--- a/src/en/charms-service-groups.md
+++ b/src/en/charms-service-groups.md
@@ -1,6 +1,6 @@
 Title: Groups of services  
 
-# Groups of Services
+# Groups of services
 
 Juju deploys units of a service from a charm. The simplest way to do this is
 
@@ -82,7 +82,7 @@ juju add-relation mywiki:slave slavedb:db
 ```
 
 
-## Upgrade Groups and/or Config Groups
+## Upgrade groups and/or config groups
 
 There are also interesting use-cases for breaking large services down into
 separate groups of units. Instead of a single 5000-node hadoop service named

--- a/src/en/charms-storage.md
+++ b/src/en/charms-storage.md
@@ -3,7 +3,7 @@ TODO: LXC/local caveat needs editing or removing
       Commands need updating for 2.0  
       Storage commands need more examples/usage  
 
-# Using Juju Storage
+# Using Juju storage
 
 Many services require access to a storage resource of some form. Juju charms can
 declare what storage requirements they have, and these can be allocated when

--- a/src/en/charms-working-with-units.md
+++ b/src/en/charms-working-with-units.md
@@ -1,6 +1,6 @@
 Title: Working with units  
 
-# Using Units
+# Using units
 
 Each node that Juju manages is referred to as a "unit". Generally speaking,
 when using Juju you interact with the services at the service level. There are
@@ -9,7 +9,7 @@ debugging purposes. Juju provides a few different commands to make this
 easier.
 
 
-## The juju ssh command
+## The Juju ssh command
 
 The `juju ssh` command will connect you, via SSH, into a target unit. For
 example:
@@ -29,7 +29,7 @@ however for more complex commands we recommend using `juju run` instead.
 See also the `juju help ssh` command for more information.
 
 
-## The juju scp command
+## The Juju scp command
 
 Copying files to and from units can be a common task depending on your
 workload, so Juju provides a `juju scp` command for copying files securely to
@@ -66,7 +66,7 @@ juju scp -e testing foo.txt apache2/1:
 For more information, run the `juju help scp` command.
 
 
-## The juju run command
+## The Juju run command
 
 The `juju run` command can be used by devops or scripts to inspect or do work
 on services, units, or machines. Commands for services or units are executed in

--- a/src/en/commands.md
+++ b/src/en/commands.md
@@ -1,6 +1,6 @@
 Title:Juju commands and usage
 
-# Juju Command reference
+# Juju command reference
 
 You can get a list of the currently used commands by entering
 ```juju help commands``` from the commandline. The currently understood commands

--- a/src/en/commands.md
+++ b/src/en/commands.md
@@ -1,4 +1,4 @@
-Title:Juju commands and usage
+Title: Juju commands and usage
 
 # Juju command reference
 
@@ -441,7 +441,7 @@ Click on the expander to see details for each command.
   
   Adding units to an existing service is a way to scale out a model by
   deploying more instances of a service.  Add-unit must be called on services that
-  have already been deployed via juju deploy.
+  have already been deployed via `juju deploy`.
   
   By default, services are deployed to newly provisioned machines.  Alternatively,
   service units can be added to a specific existing machine using the --to
@@ -487,7 +487,7 @@ Click on the expander to see details for each command.
   
   Adding units to an existing service is a way to scale out a model by
   deploying more instances of a service.  Add-unit must be called on services that
-  have already been deployed via juju deploy.
+  have already been deployed via `juju deploy`.
   
   By default, services are deployed to newly provisioned machines.  Alternatively,
   service units can be added to a specific existing machine using the --to
@@ -679,7 +679,7 @@ Click on the expander to see details for each command.
   localhost:170170
   
   The first endpoint is guaranteed to be an IP address and port. If a single endpoint
-  is available and it's a hostname, juju tries to resolve it locally first.
+  is available and it's a hostname, Juju tries to resolve it locally first.
   
   Additionally, you can use the --format argument to specify the output format.
   Supported formats are: "yaml", "json", or "smart" (default - host:port, one per line).
@@ -766,7 +766,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   create, manage, and restore backups of juju's state
+   create, manage, and restore backups of Juju's state
 
 
   
@@ -797,9 +797,9 @@ Click on the expander to see details for each command.
 
   _-v, --verbose  (= false)_  show more verbose output
   
-  "juju backups" is used to manage backups of the state of a juju controller.
-  Backups are only supported on juju controllers, not hosted models.  For
-  more information on juju controllers, see:
+  "juju backups" is used to manage backups of the state of a Juju controller.
+  Backups are only supported on Juju controllers, not hosted models.  For
+  more information on Juju controllers, see:
   
       jujuhelp juju-controllers
   
@@ -826,7 +826,7 @@ Click on the expander to see details for each command.
   restore  - restore from a backup archive to a new controller
 
 
-  upload   - store a backup archive file remotely in juju
+  upload   - store a backup archive file remotely in Juju
 
 
 
@@ -875,7 +875,7 @@ Click on the expander to see details for each command.
   help          - show help on a command or other topic
 
 
-  list          - list juju blocks
+  list          - list Juju blocks
 
 
   remove-object - block an operation that would remove an object
@@ -933,16 +933,16 @@ Click on the expander to see details for each command.
   
   bootstrap starts a new model of the current type (it will return an error
   if the model has already been bootstrapped).  Bootstrapping a model
-  will provision a new machine in the model and run the juju controller on
+  will provision a new machine in the model and run the Juju controller on
   that machine.
   
   If boostrap-constraints are specified in the bootstrap command, 
-  they will apply to the machine provisioned for the juju controller, 
+  they will apply to the machine provisioned for the Juju controller, 
   and any future controllers provisioned for HA.
   
   If constraints are specified, they will be set as the default constraints 
   on the model for all future workload machines, 
-  exactly as if the constraints were set with juju set-constraints.
+  exactly as if the constraints were set with `juju set-constraints`.
   
   It is possible to override constraints and the automatic machine selection
   algorithm by using the "--to" flag. The value associated with "--to" is a
@@ -952,7 +952,7 @@ Click on the expander to see details for each command.
   Bootstrap initialises the cloud environment synchronously and displays information
   about the current installation steps.  The time for bootstrap to complete varies
   across cloud providers from a few seconds to several minutes.  Once bootstrap has
-  completed, you can run other juju commands against your model. You can change
+  completed, you can run other Juju commands against your model. You can change
   the default timeout and retry delays used during the bootstrap by changing the
   following settings in your environments.yaml (all values represent number of seconds):
   
@@ -1040,7 +1040,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--generate  (= false)_  generate a new strong password
@@ -1116,10 +1116,10 @@ Click on the expander to see details for each command.
 
   _--no-download  (= false)_  do not download the archive
   
-  "create" requests that juju create a backup of its state and print the
+  "create" requests that Juju create a backup of its state and print the
   backup's unique ID.  You may provide a note to associate with the backup.
   
-  The backup archive and associated metadata are stored remotely by juju.
+  The backup archive and associated metadata are stored remotely by Juju.
   
   The --download option may be used without the --filename option.  In
   that case, the backup archive will be stored in the current working
@@ -1178,7 +1178,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--config  (= )_  path to yaml-formatted file containing model config values
@@ -1498,7 +1498,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   terminate all machines and other associated resources for the juju controller
+   terminate all machines and other associated resources for the Juju controller
 
 
   
@@ -1649,7 +1649,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
   
   Disabling a user stops that user from being able to log in. The user still
   exists and can be reenabled using the "juju enable-user" command.  If the user is
@@ -1755,7 +1755,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
   
   Enabling a user that is disabled allows that user to log in again. The user
   still exists and can be reenabled using the "juju enable-user" command.  If the
@@ -1806,7 +1806,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   generate boilerplate configuration for juju models
+   generate boilerplate configuration for Juju models
 
 
   
@@ -1964,11 +1964,11 @@ Click on the expander to see details for each command.
   _-o, --output (= "")_  specify an output file
   
   Shows the list of constraints that have been set on the specified service
-  using juju service set-constraints.  You can also view constraints
-  set for a model by using juju model get-constraints.
+  using Juju service set-constraints.  You can also view constraints
+  set for a model by using Juju model get-constraints.
   
   Constraints set on a service are combined with model constraints for
-  commands (such as juju deploy) that provision machines for services.  Where
+  commands (such as `juju deploy`) that provision machines for services.  Where
   model and service constraints overlap, the service constraints take
   precedence.
   
@@ -2054,11 +2054,11 @@ Click on the expander to see details for each command.
   _-o, --output (= "")_  specify an output file
   
   Shows a list of constraints that have been set on the model
-  using juju set-model-constraints.  You can also view constraints
-  set for a specific service by using juju get-constraints <service>.
+  using `juju set-model-constraints`.  You can also view constraints
+  set for a specific service by using `juju get-constraints <service>`.
   
   Constraints set on a service are combined with model constraints for
-  commands (such as juju deploy) that provision machines for services.  Where
+  commands (such as `juju deploy`) that provision machines for services.  Where
   model and service constraints overlap, the service constraints take
   precedence.
   
@@ -2212,7 +2212,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   generate boilerplate configuration for juju models
+   generate boilerplate configuration for Juju models
 
 
   
@@ -2239,7 +2239,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   forcibly terminate all machines and other associated resources for a juju controller
+   forcibly terminate all machines and other associated resources for a Juju controller
 
 
   
@@ -2315,7 +2315,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--format  (= tabular)_  specify output format (json|tabular|yaml)
@@ -2415,7 +2415,7 @@ Click on the expander to see details for each command.
 
   _--utc  (= false)_  display time as UTC in RFC3339 format
   
-  List all the machines in a juju model.
+  List all the machines in a Juju model.
   Default display is in tabular format with the following sections:
   ID, STATE, DNS, INS-ID, SERIES, AZ
   
@@ -2454,7 +2454,7 @@ Click on the expander to see details for each command.
 
   _--utc  (= false)_  display time as UTC in RFC3339 format
   
-  List all the machines in a juju model.
+  List all the machines in a Juju model.
   Default display is in tabular format with the following sections:
   ID, STATE, DNS, INS-ID, SERIES, AZ
   
@@ -2485,7 +2485,7 @@ Click on the expander to see details for each command.
   _--all  (= false)_  show all models  (administrative users only)
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--exact-time  (= false)_  use full timestamp precision
@@ -2786,7 +2786,7 @@ Click on the expander to see details for each command.
   _--all  (= false)_  include disabled users in the listing
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--exact-time  (= false)_  use full timestamp precision
@@ -2827,7 +2827,7 @@ Click on the expander to see details for each command.
 
   _--server  (= )_  path to yaml-formatted server file
   
-  login connects to a juju controller and caches the information that juju
+  login connects to a Juju controller and caches the information that Juju
   needs to connect to the api server in the $(JUJU_DATA)/models directory.
   
   In order to login to a controller, you need to have a user already created for you
@@ -2843,7 +2843,7 @@ Click on the expander to see details for each command.
   
   A new strong random password is generated to replace the password defined in
   the server file. The 'test-controller' will also become the current controller that
-  the juju command will talk to by default.
+  the Juju command will talk to by default.
   
   If you have used the 'api-info' command to generate a copy of your current
   credentials for a controller, you should use the --keep-password option as it will
@@ -2888,7 +2888,7 @@ Click on the expander to see details for each command.
 
   _--utc  (= false)_  display time as UTC in RFC3339 format
   
-  List all the machines in a juju model.
+  List all the machines in a Juju model.
   Default display is in tabular format with the following sections:
   ID, STATE, DNS, INS-ID, SERIES, AZ
   
@@ -2927,7 +2927,7 @@ Click on the expander to see details for each command.
 
   _--utc  (= false)_  display time as UTC in RFC3339 format
   
-  List all the machines in a juju model.
+  List all the machines in a Juju model.
   Default display is in tabular format with the following sections:
   ID, STATE, DNS, INS-ID, SERIES, AZ
   
@@ -2994,7 +2994,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
   
   Remove all blocks in the Juju controller.
   
@@ -3702,7 +3702,7 @@ Click on the expander to see details for each command.
       jujumodel set-constraints.
   
   Constraints set on a service are combined with model constraints for
-  commands (such as juju deploy) that provision machines for services.  Where
+  commands (such as `juju deploy`) that provision machines for services.  Where
   model and service constraints overlap, the service constraints take
   precedence.
   
@@ -3805,7 +3805,7 @@ Click on the expander to see details for each command.
       juju set-constraints.
   
   Constraints set on a service are combined with model constraints for
-  commands (such as juju deploy) that provision machines for services.  Where
+  commands (such as `juju deploy`) that provision machines for services.  Where
   model and service constraints overlap, the service constraints take
   precedence.
   
@@ -4236,7 +4236,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--exact-time  (= false)_  use full timestamp precision
@@ -4700,7 +4700,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   show or change the default juju model or controller name
+   show or change the default Juju model or controller name
 
 
   
@@ -4710,7 +4710,7 @@ Click on the expander to see details for each command.
 
   _-l, --list  (= false)_  list the model names
   
-  Show or change the default juju model or controller name.
+  Show or change the default Juju model or controller name.
   
   If no command line parameters are passed, switch will output the current
   model as defined by the file $JUJU_DATA/current-model.
@@ -5056,7 +5056,7 @@ Click on the expander to see details for each command.
   with an entirely different one. The new charm's URL and revision are inferred as
   they would be when running a deploy command.
   
-  Please note that --switch is dangerous, because juju only has limited
+  Please note that --switch is dangerous, because Juju only has limited
   information with which to determine compatibility; the operation will succeed,
   regardless of potential havoc, so long as the following conditions hold:
   
@@ -5097,7 +5097,7 @@ Click on the expander to see details for each command.
 
   #### purpose:
 
-   upgrade the tools in a juju model
+   upgrade the tools in a Juju model
 
 
   
@@ -5123,7 +5123,7 @@ Click on the expander to see details for each command.
   _-y, --yes  (= false)_  answer 'yes' to confirmation prompts
   
   The upgrade-juju command upgrades a running model by setting a version
-  number for all juju agents to run. By default, it chooses the most recent
+  number for all Juju agents to run. By default, it chooses the most recent
   supported version compatible with the command-line tools version.
   
   A development version is defined to be any version with an odd minor
@@ -5138,11 +5138,11 @@ Click on the expander to see details for each command.
 
   _- when an explicit --version major.minor is given (e.g. --version 1.17,_  or 1.17.2, but not just 1)
   
-  For development use, the --upload-tools flag specifies that the juju tools will
+  For development use, the --upload-tools flag specifies that the Juju tools will
   packaged (or compiled locally, if no jujud binaries exists, for which you will
   need the golang packages installed) and uploaded before the version is set.
   Currently the tools will be uploaded as if they had the version of the current
-  juju tool, unless specified otherwise by the --version flag.
+  Juju tool, unless specified otherwise by the --version flag.
   
   When run without arguments. upgrade-juju will try to upgrade to the
   following versions, in order of preference, depending on the current
@@ -5184,7 +5184,7 @@ Click on the expander to see details for each command.
 
 
 
-  _-c, --controller (= "")_  juju controller to operate in
+  _-c, --controller (= "")_  Juju controller to operate in
 
 
   _--name (= "")_  the local name for this model

--- a/src/en/config-KVM.md
+++ b/src/en/config-KVM.md
@@ -94,7 +94,7 @@ And `juju status` should give something similar to:
 ```
 
 
-## LXC Containers within a KVM Guest
+## LXC containers within a KVM guest
 
 You can go further and use the KVM guest as a hosting system for LXC
 containers. This is achieved in the manner in which Juju commands are invoked;
@@ -109,7 +109,7 @@ recommended to use LXC cloning to speed up the creation of LXC containers.
 Unfortunately, `lxc-clone` cannot be specified during run-time with `juju
 set-env`.
 
-### KVM Guest Network Bridge
+### KVM guest network bridge
 
 Connect to the KVM guest, assuming a Juju machine # of '1' (based on the above
 output for `juju status`):

--- a/src/en/config-LXC.md
+++ b/src/en/config-LXC.md
@@ -109,7 +109,7 @@ another-local:
 `root-dir` to a location within it. Use locations **outside** of it.
 
 
-## Bootstrapping and Destroying
+## Bootstrapping and destroying
 
 The usage of LXC containers requires **root** privileges for some steps and
 Juju will prompt for your password if needed. Juju cannot be run under sudo
@@ -264,7 +264,7 @@ sudo lxc-destroy -n juju-trusty-lxc-template
 ```
 
 
-## LXC Containers within KVM guests
+## LXC containers within KVM guests
 
 You can also use Juju to create KVM guests within which are placed LXC
 containers. See [Configuring for KVM](./config-KVM.html#lxc-containers-within-a-kvm-guest).

--- a/src/en/config-digitalocean.md
+++ b/src/en/config-digitalocean.md
@@ -78,7 +78,7 @@ then source the file so it's loaded in your current environment:
 source ~/.bashrc
 ```
 
-## DigitalOcean Configuration
+## DigitalOcean configuration
 
 In order for Juju to access the nodes, you will need an SSH key populated
 within the Digital Ocean Control panel.

--- a/src/en/config-digitalocean.md
+++ b/src/en/config-digitalocean.md
@@ -1,6 +1,6 @@
-Title: Configuring for Digital Ocean  
+Title: Configuring for DigitalOcean  
 
-# Configuring for Digital Ocean
+# Configuring for DigitalOcean
 
 !!! **Note:** This particular provider is in "beta" as it is developed by
 community member [Kapil Thangavelu](http://github.com/kapilt/juju-digitalocean)
@@ -42,7 +42,7 @@ exist).
 generate-config --show` to output the new config file, then copy and paste
 relevant areas in a text editor etc.
 
-You will need to add a section for Digital Ocean which will look like the
+You will need to add a section for DigitalOcean which will look like the
 following:
 
 ```yaml
@@ -54,15 +54,15 @@ following:
 ```
 
 
-This is a simple configuration intended to run on Digital Ocean. When
+This is a simple configuration intended to run on DigitalOcean. When
 bootstrapped, the tools will be served from the bootstrap-host on storage port
 8040.
 
 You will also need to obtain your account's `ClientID` and `APIKey` from the
 Apps & API page.
 
-![Digital Ocean Apps and API page v2 Listing](./media/getting_started_do_api_v2.png)
-![Digital Ocean Apps and API page v1 Listing](./media/getting_started_do_api_v1.png)
+![DigitalOcean Apps and API page v2 Listing](./media/getting_started_do_api_v2.png)
+![DigitalOcean Apps and API page v1 Listing](./media/getting_started_do_api_v1.png)
 
 You will additionally need to set your API Key and ID in your shell's rc files,
 for example append the following to `~/.bashrc`
@@ -81,9 +81,9 @@ source ~/.bashrc
 ## DigitalOcean configuration
 
 In order for Juju to access the nodes, you will need an SSH key populated
-within the Digital Ocean Control panel.
+within the DigitalOcean Control panel.
 
-![Digital Ocean SSH Key Listing](./media/getting_started_do_ssh_key.png)
+![DigitalOcean SSH Key Listing](./media/getting_started_do_ssh_key.png)
 
 
 ## Bootstrapping
@@ -95,7 +95,7 @@ commands issued will be performed against
 juju switch digitalocean
 ```
 
-To bootstrap a Digital Ocean environment, you will need to route the command
+To bootstrap a DigitalOcean environment, you will need to route the command
 through the docean plugin that we installed via `pip`.
 
 ```bash
@@ -140,7 +140,7 @@ This plugin accepts these standard Juju constraints:
 !!! **Note:** Additionally it supports the following provider specific
 constraints. **region** and **transfer**
 
-- region - to denote the Digital Ocean data centre to utilize. All Digital Ocean
+- region - to denote the DigitalOcean data centre to utilize. All DigitalOcean
   data centres are supported and various short hand aliases are defined. ie.
   valid values include ams2, nyc1, nyc2, sfo1, sg1. The plugin defaults to 'nyc2'.
 

--- a/src/en/config-general.md
+++ b/src/en/config-general.md
@@ -64,7 +64,7 @@ juju unset-env apt-mirror
 to restore the default behaviour in a running environment.
 
 
-## Versions and Streams
+## Versions and streams
 
 The ```agent-stream``` option selects the versions of Juju which an environment
 can deploy and upgrade to. This defaults to "released", indicating that only
@@ -120,13 +120,13 @@ enable-os-upgrade: false
 You may also want to just update the package list to ensure a Charm has the
 latest software available to it by disabling upgrades but enabling updates.
 
-### Local Provider
+### Local provider
 
-The Local Provider, however, skips upgrades by default for faster provisioning.
+The local provider, however, skips upgrades by default for faster provisioning.
 If you wish to enable upgrades in your local development, you will need to
 explicitly set enable-os-upgrade to "true".
 
-If you are using the Local Provider to develop Charms or test, you will want to
+If you are using the local provider to develop charms or test, you will want to
 regularly purge the Juju LXC template and LXC host cache to be certain you are
 using fresh images. See
 [Installing and configuring Juju for LXC (Linux)](./config-LXC.html#ensuring-a-fresh-cache).

--- a/src/en/config-local.md
+++ b/src/en/config-local.md
@@ -1,6 +1,6 @@
 Title: Using the local provider  
 
-# Using the Local Provider
+# Using the local provider
 
 The purpose of the "local provider" is to provide a testing ground or sandbox
 for users to experiment with Juju and to speed up the process of writing

--- a/src/en/config-manual.md
+++ b/src/en/config-manual.md
@@ -1,6 +1,6 @@
 Title: Manual provisioning  
 
-# Manual Provisioning
+# Manual provisioning
 
 ## Introduction
 

--- a/src/en/config-vagrant.md
+++ b/src/en/config-vagrant.md
@@ -24,7 +24,7 @@ The following instructions will help you get the environment set up:
 
 ### Ubuntu
 
-To install vagrant and the other required tools on Ubuntu, run:
+To install Vagrant and the other required tools on Ubuntu, run:
 
 ```bash
 sudo apt-get update
@@ -69,7 +69,7 @@ images are also listed on [Vagrant Cloud](https://vagrantcloud.com/ubuntu).
 Vagrant makes getting started really easy.
 
 Create a directory to work in. This directory will be shared with the guest,
-and contain the vagrant configuration for the machine.
+and contain the Vagrant configuration for the machine.
 
 ```bash
 mkdir ~/vagrant
@@ -145,7 +145,7 @@ To SSH in, run `vagrant ssh`
 ## Routing local traffic to Vagrant
 
 **Note:** If your local network is using 10.0.3.x you will need to alter the
-Juju networking in the vagrant box, and substitute the network provided in the
+Juju networking in the Vagrant box, and substitute the network provided in the
 command above
 
 ### Native routing (optional, OS X 10.10 and above)
@@ -198,7 +198,7 @@ sshuttle -r vagrant@localhost:2222 10.0.3.0/24
 Use the password "vagrant"
 
 
-## Reporting issues with the Vagrant Image
+## Reporting issues with the Vagrant image
 
 If you encounter any bugs with the Vagrant images, please
 [file a bug](https://bugs.launchpad.net/juju-vagrant-images) report.

--- a/src/en/config-vmware.md
+++ b/src/en/config-vmware.md
@@ -1,6 +1,6 @@
 Title: Configuring Juju for use with vSphere  
 
-# Configuring the VMWare (vSphere) Provider
+# Configuring the VMWare (vSphere) provider
 
 Juju supports VMWare's vSphere ("Software-Defined Data Center") installations
 as a targetable cloud. In order to use the vSphere provider, you will need to

--- a/src/en/contributing.md
+++ b/src/en/contributing.md
@@ -16,13 +16,13 @@ writing in GFM.
 
 ## Documentation bugs
 
-Bugs for documentation issues are submitted here:
+You can submit a new documentation bug (issue) with this link:
 
-https://github.com/juju/docs/issues/new
+[Submit a new documentation issue](https://github.com/juju/docs/issues/new)
 
-and listed here:
+and view existing documentation issues here:
 
-https://github.com/juju/docs/issues
+[Documentation Issues](https://github.com/juju/docs/issues)
 
 
 ## How to contribute text
@@ -63,7 +63,7 @@ Well written text goes here blah blah
 
 As you can see, the TODO metadata can have more than one item, as long as
 additional items are indented by at least 4 spaces directly after the previous
-one. The Metadata section ends immediately there is a blank line, and the
+one. The Metadata section ends immediately when there is a blank line, and the
 normal document text can begin.
 
 

--- a/src/en/contributing.md
+++ b/src/en/contributing.md
@@ -108,7 +108,7 @@ To implement this callout, use the following syntax:
 
 ```no-highlight
 !!! Note: If you want to get more information on what is actually happening, or
-to help resolve problems, you can add the `--show-log` switch to the juju
+to help resolve problems, you can add the `--show-log` switch to the Juju
 command to get verbose output.
 ```
 

--- a/src/en/developer-debug-dhx.md
+++ b/src/en/developer-debug-dhx.md
@@ -1,6 +1,6 @@
 Title: DHX debug plugin  
 
-# DHX: A Customized Hook Debugging Environment Plugin
+# DHX: A customized hook debugging environment plugin
 
 [DHX](https://github.com/juju/plugins/blob/master/juju-dhx) is a plugin --
 scripts that extend the functionality of Juju -- which allows you to fully and
@@ -38,7 +38,7 @@ Here is an overview of the features:
 - Automatic sync of changes made to charm during debug session
 - Support for easy paired debug sessions
 
-# Installation and Setup
+# Installation and setup
 
 First, follow [the instructions in the README](https://github.com/juju/plugins#install)
 to install the plugin bundle.
@@ -78,7 +78,7 @@ dhx` (or `juju debug-hooks-ext`, if you want to be verbose). This will
 automatically detect if the environment you're connecting to has been
 customized and, if not, apply your customizations.
 
-## Improved Unit Selection
+## Improved unit selection
 
 Instead of typing out the full unit name, in the form `service/0`, you can let
 DHX figure out which unit you want to debug. It will use cues such as which
@@ -130,7 +130,7 @@ Units:
 Select a unit by number or name: [mysql/1]
 ```
 
-## Retrying Failed Hooks
+## Retrying failed hooks
 
 The most common reason why you need to start a debug-hooks session is because a
 hook failed and you want to figure out why. Once you are in the debug-hooks
@@ -174,7 +174,7 @@ created by the charm while running which should not be pulled back down. Any
 file you add to the list of `sync_excludes` in your config will be skipped when
 performing the sync. The list also supports the use of wildcards.
 
-## Remote Paired Debugging
+## Remote paired debugging
 
 Paired programming can be useful for applying another set of eyes to a problem.
 DHX supports this by allowing you to import another developer's Launchpad ID,

--- a/src/en/developer-debug-layers.md
+++ b/src/en/developer-debug-layers.md
@@ -1,12 +1,12 @@
 Title: Debugging building layers  
 
-# Debugging Building Layers
+# Debugging building layers
 
 While building from charm layers is a quick and easy process most of the time,
 occasionally things surface which are not immediately obvious to us as the end
 user. Thankfully layers are straightforward and simple to debug.
 
-### Environment Variables
+### Environment variables
 
 Often times, unexpected behavior comes from not having the proper environment
 variables set on your workspace. The three required environment variables to

--- a/src/en/developer-debugging.md
+++ b/src/en/developer-debugging.md
@@ -113,7 +113,7 @@ events on that unit will be paused indefinitely.
 The queue can be halted by exiting with an `exit 1` command, which will flag the
 hook as failed. Juju will revert to its normal behaviour of suspending
 everything until this error status is resolved, which you can do by issuing the
-command (from your juju terminal window, not the debugging window) of
+command (from your Juju terminal window, not the debugging window) of
 `juju resolved <unit>`.
 
 You can finish your debugging session by closing all windows in the tmux

--- a/src/en/developer-event-cycle.md
+++ b/src/en/developer-event-cycle.md
@@ -1,6 +1,6 @@
-Title: Event Cycle  
+Title: Event cycle  
 
-# Event Cycle
+# Event cycle
 
  Taking a broad look at multiple services, there are several common events that
 each service goes through: install, configure, start, upgrade, and stop. To
@@ -36,7 +36,7 @@ hooks:
 There is more information on [Charm Hooks](./reference-charm-hooks.html) in the
 Reference section of the Juju documentation.
 
-# Deployment Events by example
+# Deployment events by example
 
 When deploying a charm, there is a guaranteed set lifecycle events that every
 charm will run - this is the basic series of hooks executed in the initial
@@ -48,7 +48,7 @@ deployment cycle.
 1. start
 1. update-status
 
-# Configuration Events by example
+# Configuration events by example
 
 Other event chains can be initiated by Juju commands or actions in the GUI.
 These chains follow a few different paths depending on which event is triggered
@@ -57,7 +57,7 @@ vanilla charm, Juju would then call the config-changed hook, and nothing else.
 
 1. config-changed
 
-# Relation Events by example
+# Relation events by example
 
 When a relation is added from the vanilla charm to a database charm, the first
 event is `database-relation-joined` the two units know about each other and the
@@ -79,7 +79,7 @@ configuration and restart the service if necessary.
 1. database-relation-departed
 1. database-relation-broken
 
-# Leader Events by example
+# Leader events by example
 
 Software with many distributed services may require a notion of a “leader”, or a
 single service as the organizer of the other services. Such services often have
@@ -93,7 +93,7 @@ an event if the leader is ever destroyed or otherwise displaced.
 There is more detailed information about [Charm Leadership in the Juju
 documentation](./authors-charm-leadership.html).
 
-# Storage Events by example
+# Storage events by example
 
 Many services require access to storage resources. Juju has events related to
 storage for the charm to respond to. There are two events related to storage,

--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -1,6 +1,6 @@
 Title: Getting started developing charms  
 
-# Getting Started Developing Charms
+# Getting started developing charms
 
 The developer guide is for anyone wanting to write bits of code that we call
 charms. This guide introduces some new concepts that, once learned, can help
@@ -76,7 +76,7 @@ service requires a relationship to a database using the “mysql” interface. T
 MariaDB charm implements the mysql interface, which fulfills the db relation and
 is already in [the charm store](https://jujucharms.com/mariadb).
 
-## Writing your Charm
+## Writing your charm
 
 The fastest way to write a new charm is to build off of existing layers. This
 allows you to create code that is very focused for the service you are trying
@@ -153,7 +153,7 @@ juju add-relation mariadb vanilla
 juju expose vanilla
 ```
 
-## Testing your Charm
+## Testing your charm
 
 Because Juju is a large complex system, not unlike a Linux software
 distribution, there is a need to test the charms themselves and how they

--- a/src/en/developer-hook-tools.md
+++ b/src/en/developer-hook-tools.md
@@ -155,7 +155,7 @@ if (Is-Leader) {
 
 ## juju-log
 
-`juju-log` writes a message to the juju log at the appropriate log level. Valid
+`juju-log` writes a message to the Juju log at the appropriate log level. Valid
 levels are: INFO, WARN, ERROR, DEBUG
 
 python:  
@@ -341,7 +341,7 @@ payload-register monitoring docker 0fcgaba
 
 `payload-unregister` used while a hook is running to let Juju know
 that a payload has been manually stopped. The <class> and <id> provided
-must match a payload that has been previously registered with juju using
+must match a payload that has been previously registered with Juju using
 payload-register.
 
 python:  

--- a/src/en/developer-layers.md
+++ b/src/en/developer-layers.md
@@ -30,7 +30,7 @@ should be broken up into these types of layers. Generally, a charm will contain
 one base layer, one charm layer, and one or more interface layers, but it is
 possible that a charm might include more than one base layer, as well.
 
-## Base, or Runtime, Layers
+## Base, or Runtime, layers
 
 Base layers are layers that other charms can be built on. They contain things
 that are common to many different charms, and allow charms to reuse that
@@ -54,7 +54,7 @@ Base layers can be written in any language, but must at a minimum provide the
 reactive framework that glues layers together, which is written in Python. This
 can be done trivially by building the base layer off of layer-basic.
 
-## Interface Layers
+## Interface layers
 
 Interface layers are perhaps the most misunderstood type of layer, and are
 responsible for the communication that transpires over a relation between two
@@ -76,7 +76,7 @@ class, though they can then be used by any language using the built-in CLI API.
 There's more on programming interface layers in the [Developing Interface
 Layers](developer-layers-interfaces.html) guide.
 
-## Charm Layers
+## Charm layers
 
 Building on base and interface layers, charm layers are what actually get turned
 into charms. This is where the core logic of the charm should go, the logic

--- a/src/en/developer-leadership.md
+++ b/src/en/developer-leadership.md
@@ -1,6 +1,6 @@
 Title: Implementing leadership in Juju charms  
 
-# Leadership for the Charm author
+# Leadership for the charm author
 
 Leadership provides a mechanism whereby multiple units of a service can make
 use of a single, shared, authoritative source for charm-driven configuration

--- a/src/en/developer-leadership.md
+++ b/src/en/developer-leadership.md
@@ -151,7 +151,7 @@ Juju's leadership concept is, by choice, relatively fine-grained, to ensure
 timely handover of agent-level responsibilities. That's why `is-leader` success
 guarantees only 30 seconds of leadership; but it's no fun running a separate
 watchdog process to `juju-run is-leader` every 30 seconds and kill your process
-when that stops working (apart from anything else, your juju-run could be
+when that stops working (apart from anything else, your `juju-run` could be
 blocked by other operations, so you can't guarantee a run every 30 seconds
 anyway).
 

--- a/src/en/developer-testing.md
+++ b/src/en/developer-testing.md
@@ -1,6 +1,6 @@
 Title: Writing charm tests  
 
-# Writing Charm Tests
+# Writing charm tests
 
 Charm authors will have the best insight into whether or not a charm is working
 properly. It is up to the author to create tests that ensure quality and
@@ -100,7 +100,7 @@ file or more information on the options included in the
 [`tests.yaml`](https://github.com/juju-solutions/bundletester#testsyaml)
 file.
 
-### Example Tests
+### Example tests
 
 #### Initial test can install Amulet
 

--- a/src/en/developer-upgrade-charm.md
+++ b/src/en/developer-upgrade-charm.md
@@ -1,6 +1,6 @@
 Title: Upgrading a charm  
 
-# Upgrade Charm
+# Upgrade charm
 
 A service's charm can be changed at runtime with the `upgrade-charm` command. By
 default, it changes to the latest available version of the same charm; if

--- a/src/en/getting-started-keygen-win.md
+++ b/src/en/getting-started-keygen-win.md
@@ -1,6 +1,6 @@
 Title: Generating ssh keys on Windows  
 
-# Creating SSH Keypairs on Windows
+# Creating SSH keypairs on Windows
 
 This walkthrough will show how to create SSH keys for use with Juju on Windows.
 

--- a/src/en/howto-charm-with-docker.md
+++ b/src/en/howto-charm-with-docker.md
@@ -37,14 +37,14 @@ or data. When applied to Charms, layers allow you to extend or build off
 other charms to make more complex or useful charms. The `layer.yaml` file in
 the root directory of the charm controls what layer(s) will be imported.
 
-#### Reactive Charms
+#### Reactive charms
 
 The docker charm makes use of the
 [charms.reactive](http://pythonhosted.org/charms.reactive/) python framework.
 The code for the docker layer can be found in the `reactive/` folder in the
 root charm directory.
 
-#### Building Charms
+#### Building charms
 
 The docker layer makes use of the
 [Charm Layers](authors-charm-building.html)
@@ -87,7 +87,7 @@ For the most complete information on charms.reactive go to
 <http://pythonhosted.org/charms.reactive/>
 
 
-## The Big Picture Decomposed
+## The big picture decomposed
 
 We're going to be dissecting each section of the layers. To give you a top-down
 view of what we'll be examining, the following illustration will provide the
@@ -309,7 +309,7 @@ def configure_website_port(http):
     hookenv.status_set('active', '')
 ```
 
-## Fully Assembled Diagram
+## Fully assembled diagram
 
 ![Charm artifact composed diagram](./media/charm-layers-composed.png)
 

--- a/src/en/howto-drupal-iis.md
+++ b/src/en/howto-drupal-iis.md
@@ -1,6 +1,6 @@
 Title: Deploying Drupal Windows with Juju charms  
 
-#  Using Juju to Deploy Drupal Windows Charm
+#  Using Juju to deploy Drupal Windows charm
 
 Juju is able to deploy workloads on top of Windows. For the moment, only MAAS
 and OpenStack can be used as providers, but shortly in the future,
@@ -19,7 +19,7 @@ properly installed and configured. You can visit [Getting
 Started](https://jujucharms.com/docs/getting-started.html) section to get
 instructions on that.
 
-##  Basic Usage of the Drupal IIS Charm
+##  Basic usage of the Drupal IIS charm
 
 First, make sure you bootstrapped an environment. If you have not already,
 do so:

--- a/src/en/howto-harvesting.md
+++ b/src/en/howto-harvesting.md
@@ -1,6 +1,6 @@
 Title: Juju and machine utilization  
 
-# Juju and Utilized Machines
+# Juju and utilized machines
 
 Juju can manage the entire life cycle of a service. When deploying a
 Charm, Juju will start and provision machines. Likewise, when
@@ -16,7 +16,7 @@ keep you out of web consoles.
 
 So how does harvesting in Juju work?
 
-# Machine States
+# Machine states
 
 To discuss how Juju manages machines, it's important to first
 understand how Juju perceives machines in the environment.
@@ -41,7 +41,7 @@ being tracked for removal.
 
 The machine is alive, but Juju knows nothing about it.
 
-# Harvesting Modes
+# Harvesting modes
 
 ## None
 
@@ -67,7 +67,7 @@ terminate all instances &#x2013; destroyed or unknown &#x2013; that it
 finds. This is a good option if you are only utilizing Juju for your
 environment.
 
-# Modifying Harvesting Mode
+# Modifying harvesting mode
 
 Juju's harvesting behaviour is set through the environments.yaml file.
 To change the default behaviour, edit this file and set the

--- a/src/en/howto-highavailability.md
+++ b/src/en/howto-highavailability.md
@@ -18,7 +18,7 @@ to use for the extra state servers, e.g.:
 juju ensure-availability -n 3 --to name1,name2
 ```
 
-Once it has been run, every subsequent run (without `-n`) will make juju
+Once it has been run, every subsequent run (without `-n`) will make Juju
 ensure that there are at least the last requested number of State Servers;
 bare in mind that this number can be increased by calling it again with 
 `-n` but currently there is no way to decrease it (planned for a future 

--- a/src/en/howto-node.md
+++ b/src/en/howto-node.md
@@ -1,6 +1,6 @@
 Title: Deploying node.js apps with Juju  
 
-#  Using Juju to Deploy your Node.js Application
+#  Using Juju to deploy your node.js application
 
 One of Juju's main use cases is to deploy your application directly out of
 version control and into a cloud. Since Juju supports local and remote clouds,
@@ -20,7 +20,7 @@ Before moving on you should have gone through the [Getting
 Started](https://jujucharms.com/docs/getting-started.html) section and
 installed and configured Juju.
 
-##  Basic Usage of the Node.js Charm
+##  Basic usage of the node.js charm
 
 First, create a configuration file `myapp.yaml` to add info about your app
 pointing to your github repo:
@@ -79,7 +79,7 @@ juju remove-unit myapp/9 myapp/8 myapp/7 myapp/6 myapp/5 myapp/4 myapp/3 myapp/2
 ```
 
 
-##  Local to Cloud Workflow
+##  Local to cloud workflow
 
 The previous example deploys your application quickly to the cloud, in this
 example we will show how to hack and test on an application locally on your
@@ -127,7 +127,7 @@ Now open up your browser and go to `http://localhost` to get your application
 loaded in your browser.
 
 
-###  Continuous Deployment
+###  Continuous deployment
 
 Continue to write your code, push to git as you land features and fixes. When
 you're ready to test it you can tell Juju to check the git repository again:
@@ -142,7 +142,7 @@ The charm will then fetch the latest code and you can refresh your browser at
 Repeat pushing to git and using the juju set command to keep a live instance of
 your application running in your local environment.
 
-###  Push to your Public/Private Cloud
+###  Push to your public/private cloud
 
 After you've repeatedly upgraded your application locally it's time to push it
 out to a place where your coworkers can see your app in all it's glory, let's
@@ -196,7 +196,7 @@ juju destroy-environment -e amazon
 juju destroy-environment -e local
 ```
 
-##  Charm Details
+##  Charm details
 
 This section is to explain how the charm works and is provided here as a
 reference.

--- a/src/en/howto-node.md
+++ b/src/en/howto-node.md
@@ -139,7 +139,7 @@ juju set myapp app_branch=https://github.com/yourapplication
 The charm will then fetch the latest code and you can refresh your browser at
 `http://localhost`.
 
-Repeat pushing to git and using the juju set command to keep a live instance of
+Repeat pushing to git and using the `juju set` command to keep a live instance of
 your application running in your local environment.
 
 ###  Push to your public/private cloud
@@ -308,7 +308,7 @@ juju expose myapp
 
 it to the outside world.
 
-By default, juju services within the same environment can talk to each other on
+By default, Juju services within the same environment can talk to each other on
 any port over internal network interfaces.
 
 

--- a/src/en/howto-privatecloud.md
+++ b/src/en/howto-privatecloud.md
@@ -1,6 +1,6 @@
 Title: Setting up private clouds with Simplestreams  
 
-#  Set up a Private Cloud using Simplestreams
+#  Set up a private cloud using Simplestreams
 
 When Juju bootstraps a cloud, it needs two critical pieces of information:
 
@@ -20,7 +20,7 @@ implementation](https://launchpad.net/simplestreams)). Below we will discuss how
 Juju determines which metadata to use, and how to create your own images and
 tools and have Juju use them instead of the defaults.
 
-## Basic Workflow
+## Basic workflow
 
 Whether images or tools, Juju uses a search path to try and find suitable
 metadata. The path components (in order of lookup) are:
@@ -42,7 +42,7 @@ So out of the box, Juju will "Just Work" with any supported public cloud, using
 signed metadata. Setting up metadata for a private (eg Openstack) cloud requires
 metadata to be generated using tools which ship with Juju.
 
-## Image Metadata Contents
+## Image metadata contents
 
 Image metadata uses a simplestreams content type of "image-ids". The product id
 is formed as follows:
@@ -73,7 +73,7 @@ The index file must be called "index.(s)json" (sjson for signed). The various
 product files are named according to the Path values contained in the index
 file.
 
-# Tools Metadata Contents
+# Tools metadata contents
 
 Tools metadata uses a simplestreams content type of "content-download". The
 product id is formed as follows:
@@ -194,7 +194,7 @@ used if no matches are found earlier in any of the above locations. No user
 configuration is required.
 
 
-# Deploying Private Clouds
+# Deploying private clouds
 
 There are two main issues when deploying a private cloud:
 

--- a/src/en/howto-privatecloud.md
+++ b/src/en/howto-privatecloud.md
@@ -160,7 +160,7 @@ The (optional) directory structure inside the cloud storage is as follows:
 Of course, if only custom image metadata is required, the tools directory will
 not be required, and vice versa.
 
-Note that if juju bootstrap is run with the `--upload-tools` option, the tools
+Note that if `juju bootstrap` is run with the `--upload-tools` option, the tools
 and metadata are placed according to the above structure. That's why the tools
 are then available for Juju to use.
 

--- a/src/en/howto-rails.md
+++ b/src/en/howto-rails.md
@@ -1,6 +1,6 @@
 Title: Deploying Rails apps with Juju  
 
-#  Using Juju to Deploy your Rails Application
+#  Using Juju to deploy your Rails application
 
 One of Juju's main use cases is to deploy your application directly out of
 version control and into a cloud. Since Juju supports local and remote clouds,
@@ -19,7 +19,7 @@ an environment that more closely resembles production.
 Before moving on you should have gone through the [Getting Started](getting-started.html)
 section and installed and configured Juju.
 
-##  Basic Usage of the Ruby on Rails Charm
+##  Basic usage of the Ruby on Rails charm
 
 Create a YAML config file with your application's name and its git location
 
@@ -78,7 +78,7 @@ juju remove-unit myapp
 
 Or go even larger with `juju add-unit -n10 myapp` for 10 nodes.
 
-##  Local to Cloud Workflow
+##  Local to cloud workflow
 
 The previous example deploys your application quickly to the cloud, in this
 example we will show how to hack and test on an application locally on your
@@ -127,7 +127,7 @@ Now open up your browser and go to `http://localhost` to get your application
 loaded in your browser.
 
 
-###  Continuous Deployment
+###  Continuous deployment
 
 Continue to write your code, push to git as you land features and fixes. When
 you're ready to test it you can tell Juju to check the git repository again:
@@ -143,7 +143,7 @@ Repeat pushing to git and using the juju set command to keep a live instance of
 your application running in your local environment.
 
 
-###  Push to your Public/Private Cloud
+###  Push to your public/private cloud
 
 After you've repeatedly upgraded your application locally it's time to push it
 out to a place where your coworkers can see your app in all its glory, let's
@@ -197,7 +197,7 @@ juju destroy-environment -e local
 ```
 
 
-##  Charm Details
+##  Charm details
 
 This document just scratches the surface of what is possible with the Rails
 charm, for more deployment options, including support for more databases,

--- a/src/en/howto-rails.md
+++ b/src/en/howto-rails.md
@@ -139,7 +139,7 @@ juju set myapp repo=https://github.com/yourapplication
 The charm will then fetch the latest code and you can refresh your browser at
 `http://localhost`.
 
-Repeat pushing to git and using the juju set command to keep a live instance of
+Repeat pushing to git and using the `juju set` command to keep a live instance of
 your application running in your local environment.
 
 

--- a/src/en/howto-vagrant-workflow.md
+++ b/src/en/howto-vagrant-workflow.md
@@ -9,7 +9,7 @@ system level, however. The next best solution is to use a virtualization
 wrapper like [Vagrant](https://www.vagrantup.com).
 
 
-##  Getting Started
+##  Getting started
 
 Ensure the following software components are installed on your development
 machine:
@@ -44,7 +44,7 @@ mkdir -p ~/vagrant/charms/precise
 
 For the remainder of this tutorial Trusty will be used.
 
-###  Installing Charm Tools
+###  Installing charm tools
 
 Charm Tools offer a means for users and charm authors to create, search, fetch,
 update, and manage charms.
@@ -86,7 +86,7 @@ populate with your services deployment and orchestration logic.
 └── revision
 ```
 
-### Writing the Charm
+### Writing the charm
 
 Begin by editing the metadata.yaml file to populate the information about our
 charm.
@@ -108,7 +108,7 @@ charm.
 Now that Juju knows something about our service we're ready to start writing the
 hooks.
 
-####  Install Hook
+####  Install hook
 
 ```bash
 #!/bin/bash
@@ -118,7 +118,7 @@ apt-get install -y ruby1.9.3 rubygems-integration build-essential
 HOME=/root gem install genghisapp bson_ext --no-ri --no-rdoc
 ```
 
-####  Config-Changed Hook
+####  Config-Changed hook
 
 ```bash
 #!/bin/bash
@@ -128,7 +128,7 @@ sleep 2
 hooks/start
 ```
 
-####  Start Hook
+####  Start hook
 
 ```bash
 #!/bin/bash
@@ -140,7 +140,7 @@ fi
 open-port $PORT
 ```
 
-####  Stop Hook
+####  Stop hook
 
 ```bash
 #!/bin/bash
@@ -172,7 +172,7 @@ bootstrap.
 directory of our JujuBox.
 
 
-### Deploying our charm in vagrant
+### Deploying our charm in Vagrant
 
 You'll need to enter the Juju environment we just bootstrapped in $HOME/charms:
 
@@ -284,7 +284,7 @@ and update/test via normal means.
 Installing Juju, for deploying to non-local environments
 
 
-## Reporting issues with the Vagrant Image
+## Reporting issues with the Vagrant image
 
 If you encounter any issues with the Vagrant images, please
 [file a bug report](https://bugs.launchpad.net/juju-vagrant-images).

--- a/src/en/interface-mysql.md
+++ b/src/en/interface-mysql.md
@@ -6,7 +6,7 @@ The mysql interface is provided by the mysql charm, and is required by a number
 of charms currently in the Charm Store and elsewhere which would like to use or
 actually require a MySQL database.
 
-## Hook Implementation: relation-joined
+## Hook implementation: relation-joined
 
 ### In theory
 

--- a/src/en/juju-backups.md
+++ b/src/en/juju-backups.md
@@ -1,6 +1,6 @@
 Title: Back up and restore Juju  
 
-# Backing up And Restoring Juju
+# Backing up and restoring Juju
 
 It is always a good idea to keep backups, and it is possible to back up both the 
 Juju client environment and the Juju state server (bootstrap node) to be able to 

--- a/src/en/juju-managing.md
+++ b/src/en/juju-managing.md
@@ -3,7 +3,7 @@ Title: Managing Juju
 
 # Managing Juju
 
-Distinct from deploying and managing Juju Charms, there are many Juju commands 
+Distinct from deploying and managing Juju charms, there are many Juju commands 
 which deal with the management of Juju itself, covering actions from disabling
 certain commands, enabling high availability for the Juju state server.
 

--- a/src/en/juju-misc.md
+++ b/src/en/juju-misc.md
@@ -43,7 +43,7 @@ machines in the environment, even those created prior to the addition of the
 key. When a key is deleted, it is removed from all machines.
 
 
-## Configure Proxy Access
+## Configure proxy access
 
 Juju supports proxies and has special support for proxying APT. Proxies can be
 configured for the providers in the environments.yaml file, or added to an

--- a/src/en/juju-offline-charms.md
+++ b/src/en/juju-offline-charms.md
@@ -1,6 +1,6 @@
 Title: Deploying charms offline  
 
-# Deploying Charms Offline
+# Deploying charms offline
 
 Many private clouds have no direct access to the internet due to security
 reasons.
@@ -14,7 +14,7 @@ guarantee that a charm will work in a disconnected state. Some charms
 pull code from the outside world, such as github. We recommend modifying
 these charms to pull code from an internal server when appropriate.
 
-## Retrieving charms using the Charm Tools
+## Retrieving charms using the charm tools package
 
 ### Installation
 
@@ -27,11 +27,11 @@ sudo apt-get update && sudo apt-get install charm-tools
 
 ### Usage
 
-The Charm Tools comes packaged as both a stand alone tool and a juju plugin.
+The charm tools come packaged as both a stand alone tool and a Juju plugin.
 So you simply can call it with `charm` or as usual for Juju commands with
 `juju charm`.
 
-There are several tools available within the Charm Tools itself. At any time
+There are several tools available within the charm-tools package itself. At any time
 you can run `juju charm` to view the available subcommands and all subcommands
 have independent help pages, accessible using either the `-h` or `--help` flags.
 

--- a/src/en/juju-systemd.md
+++ b/src/en/juju-systemd.md
@@ -44,7 +44,7 @@ be updated to enforce the above automatically.
   (`cloud-init`) to use upstart set `JUJU_DEV_FEATURE_FLAGS=legacy-upstart` in
   the Juju user's shell environment.
 
-- For the Local Provider (LXC):
+- For the local provider (LXC):
 
     - a Vivid host does not bootstrap under upstart. See
       [LP #1450092](https://bugs.launchpad.net/juju-core/+bug/1450092).

--- a/src/en/reference-charm-hooks.md
+++ b/src/en/reference-charm-hooks.md
@@ -167,7 +167,7 @@ And, again, it's important to internalise the fact that there may be multiple
 runtime relations in play with the same name, and that they're independent: one
 `-broken` hook does not mean that _every_ such relation is broken.
 
-## Storage Charm Hooks
+## Storage charm hooks
 
 Juju can provides a variety of storage to charms. The charms can define several
 different types of storage that are allocated from Juju. To read more

--- a/src/en/reference-charm-hooks.md
+++ b/src/en/reference-charm-hooks.md
@@ -60,7 +60,7 @@ and take action when the leader sets values. For more information read the
 `start` runs immediately after the first `config-changed` hook. It should be
 used to ensure the charm's software is running. Note that the charm's software
 should be configured so as to persist through reboots without further
-intervention on juju's part.
+intervention on Juju's part.
 
 ### stop
 

--- a/src/en/reference-constraints.md
+++ b/src/en/reference-constraints.md
@@ -2,7 +2,7 @@ Title: Juju constraints
 
 # Constraints
 
-Constraints constrain the possible instances that may be started by juju
+Constraints constrain the possible instances that may be started by Juju
 commands. They are usually passed as a flag to commands that provision a
 new machine (such as bootstrap, deploy, and add-machine). See [using
 constraints](charms-constraints.html) for how to specify these in a
@@ -16,10 +16,10 @@ not exist.
 
 If a constraint is defined that cannot be fulfilled by any machine in the
 environment, no machine will be provisioned, and an error will be printed in the
-machine's entry in juju status.
+machine's entry in Juju status.
 
 Constraint defaults can be set on an environment or on specific services by
-using the set-constraints command (see juju help set-constraints).  Constraints
+using the set-constraints command (see `juju help set-constraints`).  Constraints
 set on the environment or on a service can be viewed by using the get-
 constraints command.  In addition, you can specify constraints when executing a
 command by using the --constraints flag (for commands that support it).
@@ -27,7 +27,7 @@ command by using the --constraints flag (for commands that support it).
 Constraints specified on the environment and service will be combined to
 determine the full list of constraints on the machine(s) to be provisioned by
 the command.  Service-specific constraints will override environment-specific
-constraints, which override the juju default constraints.
+constraints, which override the Juju default constraints.
 
 Constraints are specified as key value pairs separated by an equals sign, with
 multiple constraints delimited by a space.
@@ -111,7 +111,7 @@ multiple constraints delimited by a space.
 
 ## Legacy constraints
 
-In pre-1.0 juju some additional or differently named constraints were
+In pre-1.0 Juju some additional or differently named constraints were
 also supported, these need to be migrated when upgrading.
 
 - cpu
@@ -122,7 +122,7 @@ also supported, these need to be migrated when upgrading.
 - ec2-zone
 
     EC2 availability zone that a service unit must be deployed into. No
-    equivalent implemented as of juju 1.12, follow [bug
+    equivalent implemented as of Juju 1.12, follow [bug
     1183831](https://bugs.launchpad.net/juju-core/+bug/1183831).
 
 - maas-name

--- a/src/en/reference-environment-variables.md
+++ b/src/en/reference-environment-variables.md
@@ -12,12 +12,12 @@ Use header tags so we can link to these variables individually.
 
 ## Juju client
 
-These variables are available on the juju client in order to change its default
+These variables are available on the Juju client in order to change its default
 behavior.
 
 #### JUJU_ENV
 
-The current environment that juju will use by default. Juju has three ways it
+The current environment that Juju will use by default. Juju has three ways it
 will  determine current environment, in descending order:
 
 1. Check to see if `JUJU_ENV` is set.
@@ -52,7 +52,7 @@ This allows you to set the repository that Juju looks for charms in. This can
 also be done by passing `--repository=/path/to/charms` when running the command
 `juju deploy`.
 
-For example, if you are running juju in a Vagrant virtual machine, you could
+For example, if you are running Juju in a Vagrant virtual machine, you could
 set `JUJU_REPOSITORY` to your shared folder:
 
 ```
@@ -95,7 +95,7 @@ JUJU_STARTUP_LOGGING_CONFIG=TRACE juju bootstrap
 #### JUJU_CLI_VERSION
 
 This allows you to change the behavior of the command line interface (CLI)
-between major juju releases and exists as a compatibility flag for those users
+between major Juju releases and exists as a compatibility flag for those users
 wishing to enable the newer behavior of the Juju CLI. As the CLI output and
 behavior is stable between minor releases of Juju, setting JUJU_CLI_VERSION will
 enable developers and users to preview the newer behavior of the CLI.
@@ -154,7 +154,7 @@ JUJU_CHARM_DIR=/var/lib/juju/agents/unit-postgresql-0/charm
 
 #### JUJU_CONTEXT_ID
 
-Used by juju to communicate to ask a running agent to execute a command on juju's behalf.
+Used by Juju to communicate to ask a running agent to execute a command on Juju's behalf.
 ```
 JUJU_CONTEXT_ID=postgresql/0:db-relation-joined:34317605475203611
 ```
@@ -175,7 +175,7 @@ JUJU_ENV_NAME=local
 
 #### JUJU_ENV_UUID
 
-The unique identifier of the juju environment.
+The unique identifier of the Juju environment.
 ```
 JUJU_ENV_UUID=2c0896ce-fd6c-4647-8540-26f848e061f9
 ```

--- a/src/en/reference-environment-variables.md
+++ b/src/en/reference-environment-variables.md
@@ -10,7 +10,7 @@ Use header tags so we can link to these variables individually.
 
 # Environment Variables
 
-## Juju Client
+## Juju client
 
 These variables are available on the juju client in order to change its default
 behavior.
@@ -223,7 +223,7 @@ JUJU_UNIT_NAME=vanilla/0
 ```
 
 
-# Internal Use only
+# Internal use only
 
 #### JUJU_DUMMY_DELAY
 #### JUJU_NOTEST_MONGOJS

--- a/src/en/reference-numbering.md
+++ b/src/en/reference-numbering.md
@@ -1,6 +1,6 @@
 Title: Machine and unit numbering  
 
-# Machine and Unit numbering
+# Machine and unit numbering
 
 Within an environment juju keeps track of sequences for machines and units.
 (Prior to 1.25 just machines). This means that for the life of an environment the number

--- a/src/en/reference-release-notes.md
+++ b/src/en/reference-release-notes.md
@@ -1,6 +1,6 @@
 Title: Juju Release Notes  
 
-# Release Notes History
+# Release Notes history
 
 This section details all the available release notes for the stable series of
 `juju-core`.
@@ -25,7 +25,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.25.3
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -156,7 +156,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.25.0
 
 
-  ## Notable Changes
+  ## Notable changes
     * (Experimental) Improved networking features for AWS
       * New 'spaces' and 'subnet' commands
       * New 'spaces' constraints support
@@ -363,7 +363,7 @@ The versions covered here are:
      https://launchpad.net/juju-core/+milestone/1.24.7
 
 
-  ## Notable Changes
+  ## Notable changes
 
   ### The default EC2 instance is m3.medium
 
@@ -445,7 +445,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.24.6
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -508,7 +508,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.24.5
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -541,7 +541,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.24.4
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -584,7 +584,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.24.3
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -669,7 +669,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.24.2
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -739,7 +739,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.24.0
 
 
-  ## Notable Changes
+  ## Notable changes
 
     * VMWare (vSphere) Provider
     * Resource Tagging (EC2, OpenStack)
@@ -749,7 +749,7 @@ The versions covered here are:
     * Storage (experimental)
 
 
-  ### VMWare (vSphere) Provider
+  ### VMWare (vSphere) provider
 
   Juju now supports VMWare's vSphere ("Software-Defined Data Center")
   installations as a targetable cloud. It uses the vSphere API to interact
@@ -788,7 +788,7 @@ The versions covered here are:
   problem for most vSphere installations.
 
 
-  ### Resource Tagging (EC2, OpenStack)
+  ### Resource tagging (EC2, OpenStack)
 
   Juju now tags instances and volumes created by the EC2 and OpenStack
   providers with the Juju environment UUID. Juju also adds any user-
@@ -809,14 +809,14 @@ The versions covered here are:
   of the Juju machine or volume corresponding to the IaaS resource.
 
 
-  ### MAAS root-disk Constraint
+  ### MAAS root-disk constraint
 
   The MAAS provider now honours the root-disk constraint, if the targeted
   MAAS supports disk constraints. Support for disk constraints was added
   to MAAS 1.8.
 
 
-  ### Service Status
+  ### Service status
 
   Juju provides new hooks for charm authors to report service status, and
   'juju status' now includes the service status. This new functionality
@@ -952,7 +952,7 @@ The versions covered here are:
       01 May 2015 17:39:44+06:00  agent     idle
 
 
-  ### CentOS 7 Preview
+  ### CentOS 7 preview
 
   Juju 1.24.0 has initial CentOS support. This is experimental and has a
   number of known issues. However, most of the functionality of Juju
@@ -1020,7 +1020,7 @@ The versions covered here are:
   documented at https://jujucharms.com/docs/devel/wip-storage.
 
 
-  ### Storage (experimental) MAAS Provider Support
+  ### Storage (experimental) MAAS provider support
 
   The MAAS provider now supports storage. Storage directives are used to
   select machines which have the requisite number and size of volumes
@@ -1063,7 +1063,7 @@ The versions covered here are:
   documented at https://jujucharms.com/docs/devel/wip-storage.
 
 
-  ### Storage (experimental) Unit Placement
+  ### Storage (experimental) unit placement
 
   It is now possible to deploy units with storage to existing machines.
   This applies when using storage that is dynamically created, such as
@@ -1321,7 +1321,7 @@ The versions covered here are:
   https://launchpad.net/juju-core/+milestone/1.23.3
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -1378,7 +1378,7 @@ The versions covered here are:
   https://launchpad.net/juju-core/+milestone/1.23.2
 
 
-  ## Notable Changes
+  ## Notable changes
 
     * New Support for Google Compute Engine (GCE)
     * Support for systemd (and Vivid)
@@ -1390,7 +1390,7 @@ The versions covered here are:
     * Experimental: Addressable LXC Containers and KVM Instances on AWS and MAAS
 
 
-  ### New Support for Google Compute Engine (GCE)
+  ### New support for Google Compute Engine (GCE)
 
   A new provider has been added that supports hosting a Juju environment
   in GCE. This feature leverages the support for Ubuntu cloud-images that
@@ -1495,7 +1495,7 @@ The versions covered here are:
   vivid charms in a local charm repository.
 
 
-  ### New Style Restore
+  ### New style restore
 
   You can now restore a backup with the new 'backups restore' command,
   which is more reliable and fast. New restore supports backups generated
@@ -1525,7 +1525,7 @@ The versions covered here are:
   ```
 
 
-  ### Improved Proxy Support for Restrictive Networks
+  ### Improved proxy support for restrictive networks
 
   A few of issues around HTTP/HTTPS and apt proxy support were fixed (Lp
   1403225, Lp 1417617). Charm downloads from the charm store which could
@@ -1542,7 +1542,7 @@ The versions covered here are:
   used for https, ftp, and apt proxies).
 
 
-  ### New Charm Actions
+  ### New charm actions
 
   Juju charms can describe actions that users can take on deployed
   services. These actions are scripts that can be triggered on a unit by
@@ -1568,7 +1568,7 @@ The versions covered here are:
     * status - show results of actions filtered by optional ID prefix
 
 
-  ### New Blocks and Messages
+  ### New blocks and messages
 
   You can now specify block message when you enable a block. For example,
   you can add a message to 'destroy-environment':
@@ -1593,7 +1593,7 @@ The versions covered here are:
   blocks.
 
 
-  ### Experimental: Service Leader Elections
+  ### Experimental: Service leader elections
 
   Services can now coordinate leadership among the deployed units using
   Juju's service leader election support.
@@ -1620,7 +1620,7 @@ The versions covered here are:
   resolve a hook or upgrade error.
 
 
-  ### Experimental: Addressable LXC Containers and KVM Instances on AWS and MAAS
+  ### Experimental: Addressable LXC containers and KVM instances on AWS and MAAS
 
   The Juju AWS and MAAS providers now support starting LXC containers. The
   MAAS providers also supports networking on KVM. Containers and Virtual
@@ -1741,7 +1741,7 @@ The versions covered here are:
  
       https://launchpad.net/juju-core/+milestone/1.22.8
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -1775,7 +1775,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.22.6
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -1817,7 +1817,7 @@ The versions covered here are:
       https://launchpad.net/juju-core/+milestone/1.22.5
 
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -1866,7 +1866,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
   
@@ -1942,7 +1942,7 @@ The versions covered here are:
   https://launchpad.net/juju-core/+milestone/1.22.0
 
 
-  ## Notable Changes
+  ## Notable changes
 
     * Blocking changes to the environment
     * LXC image caching and the cached-images command
@@ -2341,7 +2341,7 @@ The versions covered here are:
   https://launchpad.net/juju-core/+milestone/1.21.3
   
   
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -2415,7 +2415,7 @@ The versions covered here are:
   https://launchpad.net/juju-core/+milestone/1.21.1
 
 
-  ## Notable Changes
+  ## Notable changes
 
     * Selecting provisioner harvest modes
     * Using apt mirrors
@@ -3160,7 +3160,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -3194,7 +3194,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -3218,7 +3218,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -3258,7 +3258,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -3287,7 +3287,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses packaging and documentation issues.
 
@@ -3311,7 +3311,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -3338,7 +3338,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  ## Notable Changes
+  ## Notable changes
 
   This releases addresses stability and performance issues.
 
@@ -3736,7 +3736,7 @@ The versions covered here are:
   details by running 'juju ensure-availability --help'
 
 
-  ### Availability Zone Placement
+  ### Availability zone placement
 
   Juju supports explicit placement of machines to availability zones
   (AZs), and implicitly spreads units across the available zones.
@@ -3917,7 +3917,7 @@ The versions covered here are:
   ```
 
 
-  ### Support for Multiple NICs with the Same MAC
+  ### Support for multiple NICs with the same MAC
 
   Juju now supports multiple physical and virtual network interfaces with
   the same MAC address on the same machine. Juju takes care of this
@@ -3942,7 +3942,7 @@ The versions covered here are:
   ```
 
 
-  ### MaaS Network Constraints and Deploy Argument
+  ### MaaS network constraints and deploy argument
 
   You can specify which networks to include or exclude as a constraint to
   the deploy command. The constraint is used to select a machine to deploy
@@ -3979,7 +3979,7 @@ The versions covered here are:
   the future.
 
 
-  ### MAAS Provider Supports Placement and add-machine
+  ### MAAS provider supports placement and add-machine
 
   You can specify which MAAS host to place the juju state-server on with
   the 'to' option. To bootstrap on a host named 'fnord', run this:
@@ -3997,7 +3997,7 @@ The versions covered here are:
   ```
 
 
-  ### Server Side API Versioning
+  ### Server side API versioning
 
   The Juju API server now has support for a Version field in requests that
   are made. For this release, there are no RPC calls that require anything
@@ -4165,7 +4165,7 @@ The versions covered here are:
   local juju environments without the juju-local package is not advised.
 
 
-  ### New and Notable
+  ### New and notable
 
     * Support for proxies
     * Managing authorised ssh keys
@@ -4475,7 +4475,7 @@ The versions covered here are:
     * Loading state on bootstrap ignores ssl-hostname-verification setting Lp 1268913
     * Provide remove-* aliases for destroy-service and destroy-machine Lp 1261628
 
-  ### Notable Changes
+  ### Notable changes
 
   This release addresses intermittent failures observed in recent weeks in
   Azure. Users may have seen “(request failed...307: Temporary Redirect)” when
@@ -4509,7 +4509,7 @@ The versions covered here are:
    * juju destroy-environment destroys other environments Lp 1257481
 
 
-  ### Notable Changes
+  ### Notable changes
 
   Juju may report the status of a service and machine that was terminated
   outside of Juju. Juju did not notice that the machine is gone. This release
@@ -4600,7 +4600,7 @@ The versions covered here are:
   net/%7Ejuju/+archive/stable)
 
 
-  ### New and Notable
+  ### New and notable
 
     * bootstrap now matches on major and minor version numbers when locating tools
     * public-bucket-url is deprecated, use tools-url and/or image-metadata-url instead
@@ -4732,7 +4732,7 @@ The versions covered here are:
 
   [https://launchpad.net/~juju/+archive/stable](https://launchpad.net/%7Ejuju/+archive/stable)
 
-  ### New and Notable
+  ### New and notable
 
     * The Microsoft Azure provider is now considered ready for use.
     * lp # 1184786 juju cli now gives a clearer error message when the deprecated default-image-id key is found.
@@ -4780,7 +4780,7 @@ The versions covered here are:
 
   [https://launchpad.net/~juju/+archive/stable](https://launchpad.net/%7Ejuju/+archive/stable)
 
-  ### New and Notable
+  ### New and notable
 
     * The Microsoft Azure provider is now considered ready for use.
     * lp # 1184786 juju cli now gives a clearer error message when the deprecated default-image-id key is found.

--- a/src/en/reference-releases.md
+++ b/src/en/reference-releases.md
@@ -1,7 +1,7 @@
 Title: Juju releases  
 
 
-# Get the Latest Juju
+# Get the latest Juju
 
 Juju is available for Ubuntu (and Debian-based OSes), Windows, and OS X.
 There can be 3 concurrent releases representing the stability of Juju's

--- a/src/en/reference-releases.md
+++ b/src/en/reference-releases.md
@@ -13,7 +13,7 @@ current stable release to manage cloud deployments.
 
 The current stable version of Juju is 1.25.3.
 
-Stable juju is suitable for everyday production use.
+Stable Juju is suitable for everyday production use.
 
 Ubuntu
 : <pre>sudo add-apt-repository ppa:juju/stable
@@ -68,7 +68,7 @@ Windows
 
 Proposed releases use the 'proposed' simple-streams. You must configure
 the 'agent-stream' option in your environments.yaml to use the matching
-juju agents.
+Juju agents.
 
 ```no-highlight
 agent-stream: proposed
@@ -105,7 +105,7 @@ Windows
 
 Development releases use the 'devel' simple-streams. You must configure
 the 'agent-stream' option in your environments.yaml to use the matching
-juju agents.
+Juju agents.
 
 ```no-highlight
 agent-stream: devel

--- a/src/en/reference-reviewers.md
+++ b/src/en/reference-reviewers.md
@@ -1,8 +1,8 @@
 Title: Reviewing charms and bundles  
 
-# Reviewing Charms and Bundles
+# Reviewing charms and bundles
 
-### Review Tips and Criteria
+### Review tips and criteria
 
 The goal is to _welcome_ the contributor and help them have a good experience
 getting fixes into Ubuntu; your first response should be to _thank them
@@ -41,12 +41,12 @@ You can see the currently pending requests at:
 - The [Review Queue](http://review.juju.solutions/) at
 <http://review.juju.solutions/> 
 
-### Updating the store with new Charms
+### Updating the store with new charms
 
 There are two methods of updating the store. One is promulgation of new charms,
 the other is updates to charms which already exist in the store:
 
-#### New Charms
+#### New charms
 
 So the charm has passed all criteria and is ready to land in the store. Before
 you can promulgate, you’ll need to run the following commands. (This is only
@@ -88,7 +88,7 @@ If you find anything that's lacking in the charm feel free to open bugs against
 that charm. This will help us curb the amount of charms to review during our
 audit.
 
-### Updating the store with Bundles
+### Updating the store with bundles
 
 Bundles are simpler to push to the store:
 
@@ -99,7 +99,7 @@ bzr push lp:~charmers/charms/bundles/$BUNDLES_NAME/bundle
 
 There is no promulgation step for bundles.
 
-## Join Us!
+## Join us!
 
 We also need help reviewing and testing charms. The Charmers team is granted
 write access to the Charm Collection and charm-tools. If you'd like to join that

--- a/src/en/temp-release-notes.md
+++ b/src/en/temp-release-notes.md
@@ -27,7 +27,7 @@ Upgrading from older releases to this development release is not
 supported.
 
 
-## Notable Changes
+## Notable changes
 
 * Terminology
 * Command Name Changes
@@ -64,7 +64,7 @@ will become
 The "state-server" from Juju 1.x becomes a "controller" in 2.0.
 
 
-### Command Name Changes
+### Command name changes
 
 After a while experimenting with nested command structures, the decision
 was made to go back to a flat command namespace as the nested commands
@@ -145,7 +145,7 @@ used for things that can be easily added back, whereas 'destroy' is used
 when it is not so easy to add back.
 
 
-### New Juju Home Directory
+### New Juju home directory
 
 The directory where Juju stores its working data has changed. We now
 follow the XDG directory specification. By default, the Juju data
@@ -156,7 +156,7 @@ Juju 2.0's data is not compatible with Juju 1.x. Do not set JUJU_DATA to
 the and old JUJU_HOME (~/.juju).
 
 
-### Multi-Model Support Active by Default
+### Multi-Model support active by default
 
 The multiple model support that was previously behind the "jes"
 developer feature flag is now enabled by default. Along with the
@@ -217,7 +217,7 @@ forcibly taking down a controller could leave other models running
 with no way to talk to an API server.
 
 
-### Native Support for Charm Bundles
+### Native support for charm bundles
 
 The Juju 'deploy' command can now deploy a bundle. The Juju Quickstart
 or Deployer plugins are not needed to deploy a bundle of charms. You can
@@ -270,7 +270,7 @@ you want each unit of ceph-osd to have 3x50GiB disks:
     juju deploy ./openstack/bundle.yaml --storage ceph-osd:osd-devices=3,50G
 
 
-### Multi Series Charms
+### Multi series charms
 
 Charms now have the capability to declare that they support more than
 one  series. Previously a separate copy of the charm was required for
@@ -331,7 +331,7 @@ units'):
     juju upgrade-charm mycharm --force-series
 
 
-### Improved Local Charm Deployment
+### Improved local charm deployment
 
 Local charms can be deployed directly from their source directory
 without  having to set up a pre-determined local repository file
@@ -355,13 +355,13 @@ structure can  be used, including simply pulling the charm source from a
 VCS, hacking on  the code, and deploying directly from the local repo.
 
 
-### LXC Local Provider No Longer Available
+### LXC local provider no longer available
 
 With the introduction of the LXD provider (below), the LXC version of
 the Local Provider is no longer supported.
 
 
-### LXD Provider
+### LXD provider
 
 The new LXD provider is the best way to use Juju locally.
 
@@ -405,7 +405,7 @@ controller and services.
 Logs are located at '/var/log/lxd/juju-{uuid}-machine-#/ ?
 
 
-#### Specifying a LXD Controller
+#### Specifying a LXD controller
 
 In your ~/.local/share/juju/environments.yaml, you'll now find a block
 for LXD providers:
@@ -451,7 +451,7 @@ for LXD providers:
         # client-key:
 
 
-### Microsoft Azure Resource Manager Provider
+### Microsoft Azure Resource Manager provider
 
 Juju now supports Microsoft Azure's new Resource Manager API. The Azure
 provider has effectively been rewritten, but old models are still
@@ -517,7 +517,7 @@ updating an  existing Azure account:
     azure provider register Microsoft.Storage
 
 
-### New Support for Rackspace
+### New support for Rackspace
 
 A new provider has been added that supports hosting a Juju model in
 Rackspace  Public Cloud As Rackspace  Cloud is based on OpenStack,
@@ -550,7 +550,7 @@ parameters.  If you use 'keypair' mode 'access-key' and 'secret-key'
 parameters must be  provided.
 
 
-### Bootstrap Constraints, Series
+### Bootstrap constraints, series
 
 While bootstrapping, you can now specify constraints for the bootstrap
 machine independently of the service constraints:
@@ -563,7 +563,7 @@ You can also specify the series of the bootstrap machine:
     juju bootstrap --bootstrap-series trusty
 
 
-### MAAS Spaces
+### MAAS spaces
 
 Spaces are automatically discovered from MAAS (1.9+) on bootstrap and
 available for binding or deployment.
@@ -574,7 +574,7 @@ updates its definitions when the controller starts, so forcing a restart
 of the controller is a workaround.
 
 
-### Juju Logging Improvements
+### Juju logging improvements
 
 Logs from Juju's machine and unit agents are now streamed to the Juju
 controllers over the Juju API in preference to using rsyslogd. This is
@@ -608,7 +608,7 @@ Juju 2.0 supports an alternate API long method based on macaroons. This
 will support the new charm publishing workflow coming future releases
 
 
-### Unit Agent Improvements
+### Unit agent improvements
 
 We've made improvements to worker lifecycle management in the unit agent
 in this release. The resource dependencies (API connections, locks,
@@ -622,7 +622,7 @@ contexts to execute concurrently, which supports features in development
 targeting 2.0.
 
 
-### Juju Status Improvements
+### Juju status improvements
 
 The default Juju status format is now tabular (not yaml). Yaml can still
 be output by using the '--format yaml' arguments. The deprecated agent-

--- a/src/en/tools-amulet.md
+++ b/src/en/tools-amulet.md
@@ -126,11 +126,11 @@ outside of of juju-deployer. So the same commands (add, relate, configure,
 expose) will instead interact directly with the environment by using either the
 Juju API or the juju commands.
 
-#### Deployer Class:
+#### Deployer class:
 
     Deployment(juju_env=None, series='precise', sentries=True, juju_deployer='juju-deployer', sentry_template=None)
 
-#### Deployer Methods:
+#### Deployer methods:
 
 ##### Deployment.add(service, charm=None, units=1)
 
@@ -339,7 +339,7 @@ If timeout is met prior to ready state, `TimeoutError` is raised.
 
 Each unit is assigned a UnitSentry
 
-#### UnitSentry Class:
+#### UnitSentry class:
 
 ##### UnitSentry.from_unitdata(unit, unit_data, port=9001, sentry=None)
 
@@ -348,7 +348,7 @@ Each unit is assigned a UnitSentry
   - `port` - Sentry port
   - `sentry` - RelationSentry
 
-#### UnitSentry Methods:
+#### UnitSentry methods:
 
 ##### UnitSentry.directory(dir)
 

--- a/src/en/tools-charm-helpers.md
+++ b/src/en/tools-charm-helpers.md
@@ -1,6 +1,6 @@
 Title: Charm helpers  
 
-# Charm Helpers
+# Charm helpers
 
 Charm Helpers is a Python library that simplifies charm development by
 providing a rich collection of helpful utilities for:
@@ -11,7 +11,7 @@ providing a rich collection of helpful utilities for:
 * Installing dependencies
 * Much, much more!
 
-## Getting Started
+## Getting started
 
 For instructions on installing and using Charm Helpers, along with
 examples and complete API documentation, please refer to the official

--- a/src/en/tools-charm-tools.md
+++ b/src/en/tools-charm-tools.md
@@ -44,9 +44,9 @@ the Windows Control Panel
 
 # Usage
 
-Charm Tools comes packaged as both a stand alone tool and a juju plugin. For the
+Charm Tools comes packaged as both a stand alone tool and a Juju plugin. For the
 sake of documentation purposes, the plugin syntax, `juju charm`, is shown. If
-you wish to use the stand alone client, or don't have juju installed, you can
+you wish to use the stand alone client, or don't have Juju installed, you can
 replace all instances of `juju charm` with just `charm`.
 
 There are several tools available within charm tools itself. At any time you can
@@ -258,7 +258,7 @@ independent help pages, accessible using either the `-h` or `--help` flags.
   be. `proof` will provide output at varying levels of severity. `I` is
   informational - these are things a charm could do but don't currently. `W` is a
   warning - these are items that violate charm store policy or have an adverse affect
-  on tools in the juju ecosystem. `E` is an error - these are items that are major
+  on tools in the Juju ecosystem. `E` is an error - these are items that are major
   and will result in a broken charm. Any charm with a Warning or Error will not
   pass charm store review policy.
 
@@ -267,7 +267,7 @@ independent help pages, accessible using either the `-h` or `--help` flags.
       juju charm review-queue [-h|--help]
 
   This provides a copy of the
-  [juju charms review queue](http://review.juju.solutions) which is used by 
+  [Juju charms review queue](http://review.juju.solutions) which is used by 
   ~charmers to identify which charms are available for review.
 
 

--- a/src/en/troubleshooting-local-lxc.md
+++ b/src/en/troubleshooting-local-lxc.md
@@ -1,9 +1,9 @@
 Title: Juju troubleshooting - Local Provider (LXC)  
 
 
-# Troubleshooting the Local Provider (LXC)
+# Troubleshooting the local provider (LXC)
 
-The LXC Local Provider uses LXC containers to provide nodes for you to deploy
+The LXC local provider uses LXC containers to provide nodes for you to deploy
 on. This section is a collection of best practices for diagnosing and solving
 LXC Local Provider issues.
 

--- a/src/en/wip-systems.md
+++ b/src/en/wip-systems.md
@@ -1,12 +1,12 @@
 Title: How to configure Juju to manage multiple environments  
 
-# The Juju Environment System
+# The Juju environment system
 
 Experimental in version 1.25, the Juju Environment System (JES) enables new 
 features for managing environments and controlling access to them through user 
 identities.
 
-## Enabling the Juju Environment System feature flag
+## Enabling the Juju environment system feature flag
 
 In order to use the multiple environment features of the Juju Environment System 
 (JES), you need to enable a development feature flag:

--- a/src/en/wip-users.md
+++ b/src/en/wip-users.md
@@ -9,7 +9,7 @@ entities in those environments
   1. **remote users**, those whose authentication
 is managed by an external service and reserved for future use.
 
-When a Juju System is bootstrapped, an initial user is created with the 
+When a Juju system is bootstrapped, an initial user is created with the 
 environment. This user is considered to be the administrator for the Juju
 System. Only this user can create other users until such a time as Juju has
 full fine grained role-based permissions.


### PR DESCRIPTION
There were a lot of inconsistent capitalizations not only across files but within the same file and even within a header. This patchset fixes up all the headers to use standard sentence capitalization (as was done for the titles and was the case for the majority of the files). There were a couple of other capitalization/consistency/typo fixups also thrown in where spotted (ongoing effort).

Still remaining:
- clean up use of 'Charm Store' and 'charm store' where appropriate
- clean up use of 'Charm Tools', 'Charm Helpers' (the latter two are confusing pages due to variance in name of feature, name of library, name of plugin, etc.). 