### PR TITLE
Adds a layer.yaml reference page.

### DIFF
--- a/src/en/reference-environment-variables.md
+++ b/src/en/reference-environment-variables.md
@@ -105,6 +105,32 @@ export JUJU_CLI_VERSION=2
 juju status
 ```
 
+# Building
+
+These variables are available to the `charm build` process.
+
+#### LAYER_PATH
+
+Sets the location to search for charm-layers. If
+no layer is found in this location, it defaults to searching the directory
+at `interfaces.juju.solutions` for the requested charm-layer.
+
+```
+LAYER_PATH=$JUJU_REPOSITORY/layers
+```
+
+#### INTERFACE_PATH
+
+Sets the location to search for interface-layers. If
+no interface is found in this location, it defaults to searching the directory
+at `interfaces.juju.solutions` for the requested interface-layer.
+
+
+```
+INTERFACE_PATH=$JUJU_REPOSITORY/interfaces
+```
+
+
 # Unit
 
 These variables are available to charms during hook execution.

--- a/src/en/reference-layer-yaml.md
+++ b/src/en/reference-layer-yaml.md
@@ -1,17 +1,19 @@
 Title: Charm Layer.yaml Reference  
 
-# Layer.yaml
+## Layer.yaml
 
 Each layer used to build a charm can have a `layer.yaml` file. The top layer
 (the one actually invoked from the command line) must. These tell the generator
-what do, ranging from which base layers to include, to which interfaces. They
+what do, ranging from which base layers, to which interfaces to include. They
 also allow for the inclusion of specialized directives for processing some
 types of files.
 
 
 ### Layer Options
 
-Any layer can define options in its `layer.yaml`. Those options can then be set by other layers to change the behavior of your layer. The options are defined using [jsonschema](http://json-schema.org/), which is the same way that action
+Any layer can define options in its `layer.yaml`. Those options can then be set
+by other layers to change the behavior of your layer. The options are defined
+using [jsonschema](http://json-schema.org/), which is the same way that action
 parameters are defined.
 
 For example, the foo layer could include the following option definitions:
@@ -37,7 +39,7 @@ options:
 
 ### Yaml Modifications
 
-config and metadata take optional lists of keys to remove from `config.yaml`
+Config and metadata take optional lists of keys to remove from `config.yaml`
 and `metadata.yaml` when generating their data. This allows for charms to,
 for example, narrow what they expose to clients.
 
@@ -55,14 +57,16 @@ Keys:
 
 ### Custom Tactics
 
-Each file in each layer gets matched by a single Tactic. Tactics implement how
-the data in a file moves from one layer to the next (and finally to the target
-charm). By default this will be a simple copy but in the cases of certain files
-(mostly known YAML files like `metadata.yaml` and `config.yaml`) each layer is
-combined with the previous layers before being written.
+This is an advanced topic - or a "Low Level Build interface". If you need to
+customize how certain file(s)/file types are handled during the charm build
+process your layer can include Tactics. Tactics represent how various build
+targets are assembled between layers. Usually you can ignore this entirely,
+but if you have very specific needs charm build can be customized by
+including custom tactics.
 
 Normally the default tactics are fine but you have the ability in the
 `layer.yaml` to list a set of Tactics objects that will be checked before
 the default and control how data moves from one layer to the next.
 
-To view more about tactics - you can look at the source in [charmtools/build/tactics.py](https://github.com/juju/charm-tools/blob/master/charmtools/build/tactics.py#L14)
+To view more about tactics - you can look at the source in
+[charmtools/build/tactics.py](https://github.com/juju/charm-tools/blob/master/charmtools/build/tactics.py#L14)

--- a/src/en/reference-layer-yaml.md
+++ b/src/en/reference-layer-yaml.md
@@ -1,6 +1,6 @@
 Title: Charm Layer.yaml Reference  
 
-## Layer.yaml
+# Layer.yaml
 
 Each layer used to build a charm can have a `layer.yaml` file. The top layer
 (the one actually invoked from the command line) must. These tell the generator
@@ -9,7 +9,7 @@ also allow for the inclusion of specialized directives for processing some
 types of files.
 
 
-### Layer Options
+## Layer Options
 
 Any layer can define options in its `layer.yaml`. Those options can then be set
 by other layers to change the behavior of your layer. The options are defined
@@ -37,7 +37,7 @@ options:
 ```
 
 
-### Yaml Modifications
+## Yaml Modifications
 
 Config and metadata take optional lists of keys to remove from `config.yaml`
 and `metadata.yaml` when generating their data. This allows for charms to,
@@ -55,7 +55,7 @@ Keys:
 ```
 
 
-### Custom Tactics
+## Custom Tactics
 
 This is an advanced topic - or a "Low Level Build interface". If you need to
 customize how certain file(s)/file types are handled during the charm build

--- a/src/en/reference-layer-yaml.md
+++ b/src/en/reference-layer-yaml.md
@@ -1,0 +1,68 @@
+Title: Charm Layer.yaml Reference  
+
+# Layer.yaml
+
+Each layer used to build a charm can have a `layer.yaml` file. The top layer
+(the one actually invoked from the command line) must. These tell the generator
+what do, ranging from which base layers to include, to which interfaces. They
+also allow for the inclusion of specialized directives for processing some
+types of files.
+
+
+### Layer Options
+
+Any layer can define options in its `layer.yaml`. Those options can then be set by other layers to change the behavior of your layer. The options are defined using [jsonschema](http://json-schema.org/), which is the same way that action
+parameters are defined.
+
+For example, the foo layer could include the following option definitions:
+
+```yaml
+includes: ['layer:basic']
+defines:  # define some options for this layer (the layer "foo")
+  enable-bar:  # define an "enable-bar" option for this layer
+    description: If true, enable support for "bar".
+    type: boolean
+    default: false
+```
+
+A layer using foo could then set it:
+
+```yaml
+includes: ['layer:foo']
+options:
+  foo:  # setting options for the "foo" layer
+    enable-bar: true  # set the "enable-bar" option to true
+```
+
+
+### Yaml Modifications
+
+config and metadata take optional lists of keys to remove from `config.yaml`
+and `metadata.yaml` when generating their data. This allows for charms to,
+for example, narrow what they expose to clients.
+
+```yaml
+Keys:
+  includes: ["layer:basic", "interface:mysql"]
+  config:
+    deletes:
+        - key names
+  metadata:
+    deletes:
+        - key names
+```
+
+
+### Custom Tactics
+
+Each file in each layer gets matched by a single Tactic. Tactics implement how
+the data in a file moves from one layer to the next (and finally to the target
+charm). By default this will be a simple copy but in the cases of certain files
+(mostly known YAML files like `metadata.yaml` and `config.yaml`) each layer is
+combined with the previous layers before being written.
+
+Normally the default tactics are fine but you have the ability in the
+`layer.yaml` to list a set of Tactics objects that will be checked before
+the default and control how data moves from one layer to the next.
+
+To view more about tactics - you can look at the source in [charmtools/build/tactics.py](https://github.com/juju/charm-tools/blob/master/charmtools/build/tactics.py#L14)

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -183,7 +183,7 @@
                   <li><a href="reference-charm-hooks.html">Juju Charm Hooks</a></li>
                   <li><a href="reference-environment-variables.html">Juju environment variables</a></li>
                   <li><a href="reference-hook-tools.html">Juju Hook Tools</a></li>
-                  <li><a href="reference-layer-yaml.html">Juju Hook Tools</a></li>
+                  <li><a href="reference-layer-yaml.html">Layer.yaml</a></li>
                   <li><a href="http://godoc.org/github.com/juju/juju/api">Juju API docs</a></li>
                   <li><a href="reference-releases.html">Releases</a></li>
                   <li><a href="reference-release-notes.html">Release notes</a></li>

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -183,6 +183,7 @@
                   <li><a href="reference-charm-hooks.html">Juju Charm Hooks</a></li>
                   <li><a href="reference-environment-variables.html">Juju environment variables</a></li>
                   <li><a href="reference-hook-tools.html">Juju Hook Tools</a></li>
+                  <li><a href="reference-layer-yaml.html">Juju Hook Tools</a></li>
                   <li><a href="http://godoc.org/github.com/juju/juju/api">Juju API docs</a></li>
                   <li><a href="reference-releases.html">Releases</a></li>
                   <li><a href="reference-release-notes.html">Release notes</a></li>


### PR DESCRIPTION
This is a first pass, and consumes information from both the baselayer
readme and the charm-build docs in the source.

Prelim work for #913