### PR TITLE
changed maas.ubuntu.com to maas.io

### DIFF
--- a/src/en/config-local.md
+++ b/src/en/config-local.md
@@ -5,7 +5,7 @@ Title: Using the local provider
 The purpose of the "local provider" is to provide a testing ground or sandbox
 for users to experiment with Juju and to speed up the process of writing
 charms. Although Juju is intended to work on bare metal (via
-[MAAS](http://maas.ubuntu.com)) or through a variety of cloud providers or your
+[MAAS](http://maas.io)) or through a variety of cloud providers or your
 own private cloud, it can also be configured to run solely on a local machine
 by means of containers or virtualisation.
 

--- a/src/en/config-maas.md
+++ b/src/en/config-maas.md
@@ -8,7 +8,7 @@ just as easily as virtual nodes. MAAS lets you treat physical servers like
 virtual machines in the cloud. Rather than having to manage each server
 individually, MAAS turns your bare metal into an elastic cloud-like resource.
 Specifically, MAAS allows for services to be deployed to bare metal via Juju.
-For more information about MAAS, see [maas.ubuntu.com](http://maas.ubuntu.com).
+For more information about MAAS, see [maas.io](http://maas.io).
 
 To enable Juju to work with MAAS, you should start by generating a generic
 configuration file using the command:


### PR DESCRIPTION
Note: there is one instance in /src/en/config-maas.md that was not changed as it is part of the URL to the docs, which are not migrated to maas.io. Quoting:

> For further information on using Juju with MAAS, see the
> [MAAS and Juju Quick Start guide](http://maas.ubuntu.com/docs/juju-quick-start.html).