### PR TITLE
Make `make serve` work on OS X

### DIFF
--- a/tools/serve.py
+++ b/tools/serve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import os
 import sys


### PR DESCRIPTION
Fix `make serve` on platforms where /usr/bin/python2 doesn't exist (OS X and potentially Xenial, where python2 isn't installed by default)