### PR TITLE
`charm create` instead of `juju charm create`

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -39,6 +39,7 @@ our charm quickly and easily:
 ```bash
 juju charm create vanilla
 ```
+!!! Note: In some versions, the previous command should be executed as `charm create vanilla`
 
 This not only creates the directory structure, it also populates it with
 template files for you to edit. Your directory will now look like this:


### PR DESCRIPTION
It seems that the command `juju` (1.25.5-wily-amd64) does not have the option `charm`. However, the same action can be achieved with the `charm create` or `charm-create` commands.