### PR TITLE
Added .conf extension to the vanilla config file

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -272,7 +272,7 @@ if [ -f /tmp/config.php ]; then
 fi
 chmod -R 777 /var/www/vanilla/conf /var/www/vanilla/uploads /var/www/vanilla/cache
 status-set maintenance "Creating apache2 configuration"
-cat <<EOF > /etc/apache2/sites-available/vanilla
+cat <<EOF > /etc/apache2/sites-available/vanilla.conf
 <VirtualHost *:80>
   ServerAdmin webmaster@localhost
   DocumentRoot /var/www/vanilla


### PR DESCRIPTION
Since Apache version 2.4 configuration files should have the extension `.conf` by default.
Source: http://askubuntu.com/a/451223/287964