### PR TITLE
List help pages for public clouds

### DIFF
--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -46,8 +46,8 @@ have more than one for a cloud:
 juju set-default-credential <cloud> <credential>
 ```
 
-If you are having difficulty finding the correct credential information for 
-your cloud, please see the [help pages][help].
+The default credentials do not need to be specified on the commandline for 
+bootstrap (creating a controller).  
 
 
 ### Scanning existing credentials
@@ -134,5 +134,4 @@ juju remove-credential aws bob
 
 
 [yaml]: http://www.yaml.org/spec/1.2/spec.html
-[help]: ./help-credentials.html
 [lxd]: ./clouds-LXD.html

--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -18,6 +18,16 @@ Currently, Juju can use one of three ways to get your credentials for a cloud:
 
 These methods are explained in more detail below.
 
+If you are having difficulty determining the credentials needed for your 
+particular cloud, you should find these pages on specific clouds helpful: 
+
+  [Amazon Web Services][aws]
+  [Microsoft Azure][azure]
+  [Google Compute Engine][gce]
+  [Joyent][joyent]
+  [Rackspace][rackspace]
+
+
 ### Adding credentials via the commandline
 
 You can add credentials by running the command:
@@ -135,3 +145,8 @@ juju remove-credential aws bob
 
 [yaml]: http://www.yaml.org/spec/1.2/spec.html
 [lxd]: ./clouds-LXD.html
+[aws]: ./help-aws.html
+[azure]: ./help-azure.html
+[gce]: ./help-google.html
+[joyent]: ./help-joyent.html
+[rackspace]: ./help-rackspace.html

--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -60,8 +60,9 @@ have more than one for a cloud:
 juju set-default-credential <cloud> <credential>
 ```
 
-The default credentials do not need to be specified on the commandline for 
-bootstrap (creating a controller).  
+Setting a default credential means this will be used by the bootstrap 
+command when creating a controller, without having to specify it with
+the `--credential` option.
 
 
 ### Scanning existing credentials

--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -22,9 +22,13 @@ If you are having difficulty determining the credentials needed for your
 particular cloud, you should find these pages on specific clouds helpful: 
 
   [Amazon Web Services][aws]
+  
   [Microsoft Azure][azure]
+  
   [Google Compute Engine][gce]
+  
   [Joyent][joyent]
+  
   [Rackspace][rackspace]
 
 


### PR DESCRIPTION
Fixes #983

We may have a generic help page which also lists these, but for now it suffices to list these in the credentials page