### PR TITLE
clarification on the directory

### DIFF
--- a/src/en/authors-testing.md
+++ b/src/en/authors-testing.md
@@ -50,7 +50,7 @@ with a predictable environment. The tests can make the following assumptions:
 - A version of juju is installed and available in the system path.
 - A juju environment with no services deployed inside it is already 
   bootstrapped, and will be the default for command line usage.
-- The CWD is the `tests` directory off the charm root.
+- The CWD is the `tests` directory inside the charm root.
 - Full network access to deployed nodes will be allowed.
 - the bare name of any charm in arguments to juju will be resolved to a charm 
   url and/or repository arguments of the test runner's choice. This means that 


### PR DESCRIPTION
Not sure whether the CWD is meant to be the one where the test scripts are located, or the one from where the test is executed.
In the second case, the sentence could be rewritten as "The tests are executed from the root directory of the charm containing the `tests` directory"