### PR TITLE
Update Juju2 metadata docs.

### DIFF
--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -104,7 +104,7 @@ and whether it's designed for deployment as a
   - if the charm is subordinate, it must contain at least one `requires`
     relation with container scope.
 
-`resources` defines ???
+`resources` allows you to add a blob that your charm can utilize.
 
 ```yaml
 resources:
@@ -114,12 +114,16 @@ resources:
     description: example resource
 ```
 
-`payloads` defines ???
+`payloads` allows you to register payloads such as LXC, KVM, and docker with
+Juju. This lets the operator better understand the purpose and function of these
+payloads on a given machine.
 
 ```yaml
 payloads:
-  example:
-    type: kvm
+    monitoring:
+        type: docker
+    kvm-guest:
+        type: kvm
 ```
 
 `extra-bindings` represents an extra bindable endpoint that is not a relation.

--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -136,8 +136,6 @@ endpoint name must be left out (i.e. "foo": <anything> is invalid).
 
 Other available fields are:
 
-  - `format` ???
-  - `categories` ???
   - `series` is a list of versions of Ubuntu this charm is compatible with.
   - `terms` lists the terms the user must agree to before using the charm.
   - `min-juju-version` the minimum version of Juju this charm is compatible with.

--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -92,7 +92,7 @@ storage:
     location: /srv/data
 ```
 
-Finally, a metadata file defines the charm's
+A metadata file defines the charm's
 [relations](./authors-relations.html),
 and whether it's designed for deployment as a
 [subordinate service](./authors-subordinate-services.html).
@@ -103,6 +103,44 @@ and whether it's designed for deployment as a
     will participate in.
   - if the charm is subordinate, it must contain at least one `requires`
     relation with container scope.
+
+`resources` defines ???
+
+```yaml
+resources:
+  example:
+    type: file # "file" is the only type supported currently
+    filename: example.tar.gz
+    description: example resource
+```
+
+`payloads` defines ???
+
+```yaml
+payloads:
+  example:
+    type: kvm
+```
+
+`extra-bindings` represents an extra bindable endpoint that is not a relation.
+
+```yaml
+extra-bindings:
+  endpoint1:
+  endpoint2:
+```
+
+Endpoint names are strings and must not match existing relation names from
+the Provides, Requires, or Peers metadata sections. The values beside each
+endpoint name must be left out (i.e. "foo": <anything> is invalid).
+
+Other available fields are:
+
+  - `format` ???
+  - `categories` ???
+  - `series` is a list of versions of Ubuntu this charm is compatible with.
+  - `terms` lists the terms the user must agree to before using the charm.
+  - `min-juju-version` the minimum version of Juju this charm is compatible with.
 
 Other field names should be considered to be reserved; please don't use any not
 listed above to avoid issues with future versions of Juju.

--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -136,7 +136,7 @@ extra-bindings:
 
 Endpoint names are strings and must not match existing relation names from
 the Provides, Requires, or Peers metadata sections. The values beside each
-endpoint name must be left out (i.e. "foo": <anything> is invalid).
+endpoint name must be left out (i.e. "foo": &lt;anything&gt; is invalid).
 
 Other available fields are:
 


### PR DESCRIPTION
Adds documentation for `resources`, `payloads`, `extra-bindings`, `series`, `terms`, and `min-juju-version`. #1079 