### PR TITLE
update juju 1.25 metadata docs

### DIFF
--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -76,7 +76,21 @@ keep the Charm Store organised.
 
 ![Juju Charm Store metadata Listing](./media/authors-metadata-display.png)
 
-Finally, a metadata file defines the charm's 
+[Storage](./developer-storage.md) can also be declared in a charm's metadata,
+as such:
+
+```yaml
+storage:
+  data:
+    type: filesystem
+    description: junk storage
+    shared: false # not yet supported, see description below
+    read-only: false # not yet supported, see description below
+    minimum-size: 100M
+    location: /srv/data
+```
+
+A metadata file defines the charm's
 [relations](./authors-relations.html),
 and whether it's designed for deployment as a
 [subordinate service](./authors-subordinate-services.html).
@@ -87,6 +101,22 @@ and whether it's designed for deployment as a
     will participate in.
   - if the charm is subordinate, it must contain at least one `requires`
     relation with container scope.
+
+`payloads` allows you to register payloads such as LXC, KVM, and docker with
+Juju. This lets the operator better understand the purpose and function of these
+payloads on a given machine.
+
+```yaml
+payloads:
+    monitoring:
+        type: docker
+    kvm-guest:
+        type: kvm
+```
+
+Other available fields are:
+
+  - `series` is a list of versions of Ubuntu this charm is compatible with.
 
 Other field names should be considered to be reserved; please don't use any not
 listed above to avoid issues with future versions of Juju.

--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -76,8 +76,7 @@ keep the Charm Store organised.
 
 ![Juju Charm Store metadata Listing](./media/authors-metadata-display.png)
 
-[Storage](./developer-storage.md) can also be declared in a charm's metadata,
-as such:
+Storage can also be declared in a charm's metadata, as such:
 
 ```yaml
 storage:


### PR DESCRIPTION
Add docs for `storage`, `payload`, `series`.

Related to #1100 which is for Juju2 docs - I pulled these definitions straight out of there.

Issue: #1079 