### PR TITLE
Removed reference to deprecated local url scheme.

### DIFF
--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -164,7 +164,7 @@ Then we can deploy mariadb and the new charm:
 
 ```bash
 juju deploy mariadb
-juju deploy local:trusty/vanilla
+juju deploy $JUJU_REPOSITORY/trusty/vanilla --series trusty
 juju add-relation mariadb vanilla
 juju expose vanilla
 ```


### PR DESCRIPTION
Juju 2.0 no longer supports invocations like "juju deploy
local:trusty/somecharm". Changed the instructions to instead reference
"juju deploy $JUJU_REPOSITORY/trusty/somecharm --series trusty".