### PR TITLE
housecleaning updates due to networking changes

### DIFF
--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -1,4 +1,4 @@
-Title: General configuration options  
+Title: General configuration options
 TODO: Check accuracy of key table
       Confirm 'all' harvest mode state. Seems it should be "'Dead' or
 	'Unknown'" OR "a combination of modes 'destroyed' and 'unknown'".
@@ -92,9 +92,8 @@ lxc-clone-aufs | bool | false |  | Whether the LXC provisioner should create an 
 lxc-default-mtu | int |  |  | The MTU setting to use for network interfaces in LXC containers
 name | string |  |  | The name of the current model
 no-proxy | string |  |  | List of domain addresses not to be proxied (comma-separated)
-prefer-ipv6 | bool | false |  | Whether to prefer IPv6 over IPv4 addresses for API endpoints and machines
 provisioner-harvest-mode | string | destroyed | all/none/unknown/destroyed | What to do with unknown machines. See [harvesting section](#juju-lifecycle-and-harvesting)
-proxy-ssh | bool |  |  | Whether SSH commands should be proxied through the API server
+proxy-ssh | bool | false |  | Whether SSH commands should be proxied through the API server
 resource-tags | string | none | | Space-separated list of key=value pairs used to apply as tags on supported cloud models
 rsyslog-ca-cert | string |  |  | The certificate of the CA that signed the rsyslog certificate, in PEM format
 rsyslog-ca-key | string |  |  | The private key of the CA that signed the rsyslog certificate, in PEM format

--- a/src/en/reference-release-notes.md
+++ b/src/en/reference-release-notes.md
@@ -1,4 +1,4 @@
-Title: Juju Release Notes  
+Title: Juju Release Notes
 
 # Release Notes History
 
@@ -185,10 +185,6 @@ The versions covered here are:
     * Juju can't find daily image streams from cloud-
       images.ubuntu.com/daily
       Lp 1513982
-
-    * Rsyslog certificate fails when using ipv6/4 dual stack with
-      prefer-ipv6: true
-      Lp 1478943
 
     * Improper address:port joining
       Lp 1518128


### PR DESCRIPTION
models-config.md and refrence-release-notes.md - drop references to prefer-ipv6 as it is no longer present in Juju 2.0

models-config.md - proxy-ssh is now false by default

@juju/docs for review