### PR TITLE
Making note of the automatic retry in the docs.

### DIFF
--- a/src/en/authors-hook-debug.md
+++ b/src/en/authors-hook-debug.md
@@ -1,4 +1,4 @@
-Title: Debugging Juju charm hooks   
+Title: Debugging Juju charm hooks
 
 # Debugging hooks
 
@@ -27,7 +27,7 @@ check the `db-relation-joined` and `db-relation-broken` hooks:
 juju debug-hooks mysql/0 db-relation-joined db-relation-broken
 ```
 
-**Note:** It is possible and often desirable to run debug-hooks on more than
+!!! Note: It is possible and often desirable to run debug-hooks on more than
 one unit at a time. You should open a new terminal window for each.
 
 
@@ -71,9 +71,9 @@ queue until you exit your current window. See the  special considerations below.
 The queue for pending hooks will restart once you exit the window with an `exit`
 command.
 
-**Note:** To allow Juju to continue processing events normally, you **must**
-exit the hook execution window with the `exit` command, otherwise all further
-events on that unit will be paused indefinitely.
+!!! Note: To allow Juju to continue processing events normally, you **must**
+exit the hook execution with a zero return code (using the `exit` command),
+otherwise all further events on that unit may be paused indefinitely.
 
 The queue can be halted by exiting with an `exit 1` command, which will flag the
 hook as failed. Juju will revert to its normal behaviour of suspending
@@ -92,8 +92,10 @@ after the unit comes up, making it difficult to start a debug-hooks session in
 time to intercept them. If you're having difficulties, you can temporarily
 return an error code from your `install` hook (e.g. add an `exit 1` at the end
 of it), and start your session only when the unit reports an [error status
-](./authors-hook-errors.html). You should then run `juju resolved --retry` for
-the affected unit, and go back to the debug-hooks session to interact.
+](./authors-hook-errors.html). Juju version 2.0 and up will automatically retry
+the hooks in error. Earlier versions of Juju can be manually retried by issuing
+the command `juju resolved --retry unit-name\#` for the affected unit, and go
+back to the debug-hooks session to interact with the Juju environment. 
 
 
 ## Special considerations

--- a/src/en/authors-hook-debug.md
+++ b/src/en/authors-hook-debug.md
@@ -7,9 +7,6 @@ don't happen quite as you expected. That's why Juju includes two tools to help
 you debug charm hooks: The `juju debug-hooks` command and the `juju debug-log`
 command.
 
-The [dhx debugging plugin](./authors-hook-debug-dhx.html) is also available.
-
-
 ##  The 'debug-hooks' command
 
 The `juju debug-hooks` command accepts a unit and an optional list of hooks to
@@ -30,6 +27,9 @@ juju debug-hooks mysql/0 db-relation-joined db-relation-broken
 !!! Note: It is possible and often desirable to run debug-hooks on more than
 one unit at a time. You should open a new terminal window for each.
 
+For developers who use the debug-hooks environment often there is the
+[dhx debugging plugin](./authors-hook-debug-dhx.html) which allows some
+additional customisation and convenience while debugging hooks.
 
 ## Running a debug session
 
@@ -73,7 +73,7 @@ command.
 
 !!! Note: To allow Juju to continue processing events normally, you **must**
 exit the hook execution with a zero return code (using the `exit` command),
-otherwise all further events on that unit may be paused indefinitely.
+otherwise all further events on that unit may be blocked indefinitely.
 
 The queue can be halted by exiting with an `exit 1` command, which will flag the
 hook as failed. Juju will revert to its normal behaviour of suspending
@@ -85,6 +85,20 @@ You can finish your debugging session by closing all windows in the tmux
 session. Make sure to exit appropriately from all hook windows before
 terminating.
 
+### Retrying failed hooks
+
+Prior to version 2.0, hooks returning an error will block until the user
+takes an action to retry them manually, by issuing the command `juju resolved
+--retry unit-name/#` for the affected unit. Juju version 2.0 and up will
+automatically retry hooks in error periodically. However, the `juju resolved
+--retry` command may still be used to retry the hook immediately. After
+retrying, go back to the debug-hooks session to interact with he Juju
+environment.
+
+```bash
+juju resolved --retry mysql/0
+```
+
 ## Debugging early hooks
 
 The `install`, `config-changed`, and `start` hooks often execute quite soon
@@ -92,11 +106,7 @@ after the unit comes up, making it difficult to start a debug-hooks session in
 time to intercept them. If you're having difficulties, you can temporarily
 return an error code from your `install` hook (e.g. add an `exit 1` at the end
 of it), and start your session only when the unit reports an [error status
-](./authors-hook-errors.html). Juju version 2.0 and up will automatically retry
-the hooks in error. Earlier versions of Juju can be manually retried by issuing
-the command `juju resolved --retry unit-name\#` for the affected unit, and go
-back to the debug-hooks session to interact with the Juju environment. 
-
+](./authors-hook-errors.html).
 
 ## Special considerations
 
@@ -107,7 +117,6 @@ but you should be aware that multiple debug-hooks sessions for units assigned to
 the same machine will block one another, and that you can't control relative
 execution order directly (other than by erroring out of hooks you don't want to
 run yet, and retrying them later).
-
 
 ## The 'debug-log' command
 

--- a/src/en/developer-debugging.md
+++ b/src/en/developer-debugging.md
@@ -74,16 +74,14 @@ check the `db-relation-joined` and `db-relation-broken` hooks:
 juju debug-hooks mysql/0 db-relation-joined db-relation-broken
 ```
 
-Additionally, if your hook is already in an error state, you can enter in an
-interactive hook context using the `juju debug-hooks` command. Juju version 2.0
-and greater will automatically retry the hooks in error state. Earlier versions
-of Juju can be manually retried by issuing the command
-`juju resolved --retry unit-name\#` for the affected unit, and go
-back to the debug-hooks session to interact with the Juju environment.
-
-```bash
-juju resolved mysql/0 --retry
-```
+Additionally, if your hook is already in an error state, you can enter into an
+interactive hook context using the `juju debug-hooks` command. The session is
+interactive because Juju will block allowing you to run the hooks manually to
+check the return code or edit hook files before running the next hook. To
+reach the hook context Juju must retry the failed hook. You can retry a hook in
+error by issuing the `juju resolved --retry` command. See the  [Retrying failed
+hooks](#retrying-failed-hooks) section for more information about how to retry
+hooks.
 
 !!! Note: It is possible and often desirable to run debug-hooks on more than
 one unit at a time. You should open a new terminal window for each.
@@ -145,6 +143,20 @@ You can finish your debugging session by closing all windows in the tmux
 session. Make sure to exit appropriately from all hook windows before
 terminating.
 
+## Retrying failed hooks
+
+Prior to version 2.0, hooks returning an error will block until the user
+takes an action to retry them manually, by issuing the command `juju resolved
+--retry unit-name/#` for the affected unit. Juju version 2.0 and up will
+automatically retry hooks in error periodically. However, the `juju resolved
+--retry` command may still be used to retry the hook immediately. After
+retrying, go back to the debug-hooks session to interact with he Juju
+environment.
+
+```bash
+juju resolved --retry mysql/0
+```
+
 ## Debugging early hooks
 
 The `install`, `config-changed`, and `start` hooks often execute quite soon
@@ -152,9 +164,8 @@ after the unit comes up, making it difficult to start a debug-hooks session in
 time to intercept them. If you're having difficulties, you can temporarily
 return an error code from your `install` hook (e.g. add an `exit 1` at the end
 of it), and start your session only when the unit reports an [error status
-](./authors-hook-errors.html). You should then run `juju resolved --retry` for
-the affected unit, and go back to the debug-hooks session to interact.
-
+](./authors-hook-errors.html). Use a debug-hooks session to interact with the
+environment and run the hook again.
 
 ## Special considerations
 

--- a/src/en/developer-debugging.md
+++ b/src/en/developer-debugging.md
@@ -74,14 +74,18 @@ check the `db-relation-joined` and `db-relation-broken` hooks:
 juju debug-hooks mysql/0 db-relation-joined db-relation-broken
 ```
 
-Additionally, if your hook is already in an error state, you can tell Juju to
-retry the hook after running `juju debug-hooks`:
+Additionally, if your hook is already in an error state, you can enter in an
+interactive hook context using the `juju debug-hooks` command. Juju version 2.0
+and greater will automatically retry the hooks in error state. Earlier versions
+of Juju can be manually retried by issuing the command
+`juju resolved --retry unit-name\#` for the affected unit, and go
+back to the debug-hooks session to interact with the Juju environment.
 
 ```bash
 juju resolved mysql/0 --retry
 ```
 
-**Note:** It is possible and often desirable to run debug-hooks on more than
+!!! Note: It is possible and often desirable to run debug-hooks on more than
 one unit at a time. You should open a new terminal window for each.
 
 ## Running a debug session
@@ -127,7 +131,7 @@ queue until you exit your current window. See the special considerations below.
 The queue for pending hooks will restart once you exit the window with an `exit`
 command.
 
-**Note:** To allow Juju to continue processing events normally, you **must**
+!!! Note: To allow Juju to continue processing events normally, you **must**
 exit the hook execution window with the `exit` command, otherwise all further
 events on that unit will be paused indefinitely.
 

--- a/src/en/troubleshooting-upgrade.md
+++ b/src/en/troubleshooting-upgrade.md
@@ -53,5 +53,8 @@ sometimes lead to hook failures. Connect to that unit, see what is wrong, and
 retry with:
 
 ```bash
-juju resolved --retry
+juju resolved --retry unit-name/#
 ```
+
+Where unit-name is replaced with the name of the unit, and # is replaced with
+the unit number you wish to restart.

--- a/src/en/troubleshooting-upgrade.md
+++ b/src/en/troubleshooting-upgrade.md
@@ -49,12 +49,19 @@ sudo service jujud-machine-2 restart
 
 The restart of an agent, due to invoking `upgrade-juju` or by manual means (as
 above) may cause a hook for that particular unit/machine to be called. That can
-sometimes lead to hook failures. Connect to that unit, see what is wrong, and
-retry with:
+sometimes lead to hook failures. Connect to that unit using the
+`juju debug-hooks` command, see what is wrong, and retry the hook using the
+`juju resolved --retry` command:
 
 ```bash
-juju resolved --retry unit-name/#
+juju debug-hooks etcd/2
 ```
 
-Where unit-name is replaced with the name of the unit, and # is replaced with
-the unit number you wish to restart.
+In a different terminal retry the failed hook.
+
+```bash
+juju resolved --retry etcd/2
+```
+
+See [Debugging Juju charm hooks](./developer-debugging.html) for more
+information.


### PR DESCRIPTION
Fixes #831 

These are the best words I can find for this awkward topic. Juju automatically retries after version 2.0 but you still have to manually retry in earlier versions. If someone has better words I am interested in the assistance.

Also it should be noted the `authors-*` docs are older and replaced with the `developer-*` docs, but this fix includes changes to both.