### PR TITLE
Added credential info for add-model, remove outdated bug reports

### DIFF
--- a/src/en/models-adding.md
+++ b/src/en/models-adding.md
@@ -1,42 +1,44 @@
-Title: Adding a Juju Model
-TODO: Review again soon (created: March 2016)
-      Remove Note re bug 1552469 when fixed; remove Note and --config option from Rackspace example
-
+Title: Adding a model
 
 # Adding a model
 
-Use the `juju add-model` command to add a *hosted model* for a given
-provider:
+A Juju [controller][controller] can host multiple models to accomodate
+different workloads or use cases. When a controller is created, it creates
+an initial model called 'default', but more models can be added to the
+controller using the `juju add-model` command:
 
-`juju add-model [options] <model name> [key=[value] ...]`
+```
+juju add-model [options] <model name>
+```
 
 See `juju help add-model` for details on this command or see the
-[command reference page](./commands.html#juju-add-model).
-
-## Notes
-
-!!! Note: Due to
-[LP #1552469](https://bugs.launchpad.net/juju-core/+bug/1552469) credentials
-already set during the creation of the controller model are not utilised
-automatically when adding a new model. Depending on provider, you may need to
-supply credentials.
-
+[command reference page][commands].
 
 ## Examples
 
-**1.** Add model 'rackspace-prod' for the current (Rackspace) controller:
-
-!!! Note: Because of 
-[LP #1552469](https://bugs.launchpad.net/juju-core/+bug/1552469) 
-you will need to create a 3-line file for these parameters:
-`username`, `password`, and `tenant-name` and then refer to it.
-
-```bash
-juju add-model --config=~/config-rackspace_creds.yaml rackspace-prod
-```
-
-**2.** Add model 'lxd-trusty-staging' for the current (LXD) controller:
+Add a model named 'lxd-trusty-staging' for the current (LXD) controller:
 
 ```bash
 juju add-model lxd-trusty-staging
 ```
+
+It is possible to add a model for a controller different to the current one, by 
+specifying the controller to use. To add a model named 'gce-test' for the 
+non-current 'gce' controller:
+
+```bash
+juju add-model gce-test --controller gce 
+```
+
+Add a model named 'rackspace-prod' for the current (Rackspace) controller,
+specifying an existing credential ('mysecret'):
+
+```bash
+juju add-model rackspace-prod --credential mysecret
+```
+
+
+
+
+[controller]: ./controllers.html
+[commands]: ./commands.html#juju-add-model


### PR DESCRIPTION
Fixes #1174 

There is certainly potential to expand this further, but at the moment this at least gives examples of --credential usage, and using the non-current controller