### PR TITLE
deleted extra spaces and added = in a couple places where the help…

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -1,4 +1,4 @@
-Title: Writing your first Juju charm  
+Title: Writing your first Juju charm
 
 
 # Your first charm starts here!

--- a/src/en/howto-node.md
+++ b/src/en/howto-node.md
@@ -1,4 +1,4 @@
-Title: Deploying node.js apps with Juju  
+Title: Deploying node.js apps with Juju
 
 #  Using Juju to Deploy your Node.js Application
 

--- a/src/en/models-upgrade.md
+++ b/src/en/models-upgrade.md
@@ -1,4 +1,4 @@
-Title: Upgrading Juju software  
+Title: Upgrading Juju software
 
 
 # Upgrading Juju software
@@ -74,7 +74,7 @@ juju upgrade-juju --version 2.0.3
 Track the progress with:
 
 ```bash
-watch -n3 "juju status --format tabular"
+watch -n3 "juju status --format=tabular"
 ```
 
 For complete syntax, see the

--- a/src/en/temp-release-notes.md
+++ b/src/en/temp-release-notes.md
@@ -6,7 +6,7 @@ This release replaces version 2.0-beta10.
 ## What's New in Beta11
 
 * Config can now be associated with clouds in clouds.yaml
-* Consistent wire protocol for the Juju API. For more details, see:   
+* Consistent wire protocol for the Juju API. For more details, see:
   https://lists.ubuntu.com/archives/juju-dev/2016-June/005715.html
 * Initial support for:
     * Juju log forwarding
@@ -745,7 +745,7 @@ state of the machine as it transitions from allocating to deploying to
 deployed. For containers it also provides extra information about the
 container being created.
 
-    juju status --format yaml
+    juju status --format=yaml
 
         model: admin
         machines:


### PR DESCRIPTION
…output shows it should be even though the command switch works with or without the = sign

I checked all files and all instances of 'juju status' examples in the docs (on 31 different pages).

These few were the only ones needing adjustment, and even then it seems optional. I tested '--format <option>' and '--format=<option>' and both work. Since the help text and the list on commands.md show and equals sign, I went ahead and put it in for consistency.