### PR TITLE
Fix typo in Juju retry provisioning section

### DIFF
--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -1,4 +1,4 @@
-Title: Deploying applications 
+Title: Deploying applications
 TODO: Add 'centos' and 'windows' stuff to series talk
       Downloading charms is shabby. See https://git.io/vwNLI . I therefore
         ommitted the "feature" of specifying a download dir
@@ -48,13 +48,13 @@ Where 'cs' denotes the charm store.
 !!! Note: A used charm gets cached on the controller's database to minimize
 network traffic for subsequent uses.
 
-### Channels	
+### Channels
 
 The charm store offers charms in different stages of development. Such stages
 are called *channels*.
 
-Channels offer a way for charm developers, and the users of charms, to manage 
-and offer charms at various stages of development. Some users may want the very 
+Channels offer a way for charm developers, and the users of charms, to manage
+and offer charms at various stages of development. Some users may want the very
 latest features, or be part of a beta test; others may want to only install the
 most reliable software. The channels are:
 
@@ -63,12 +63,12 @@ most reliable software. The channels are:
  - **beta**: A beta testing milestone release.
  - **edge**: The very latest version - expect bugs!
 
-As each new version of a charm is automatically versioned, these channels serve 
-as pointers to a specific version number. It may be that after time a beta 
-version becomes a candidate, or a candidate (hopefully) becomes the new stable 
-version. 
+As each new version of a charm is automatically versioned, these channels serve
+as pointers to a specific version number. It may be that after time a beta
+version becomes a candidate, or a candidate (hopefully) becomes the new stable
+version.
 
-By default you will get the 'stable' channel, but you can specify a channel 
+By default you will get the 'stable' channel, but you can specify a channel
 when using the `deploy` command:
 
 
@@ -76,10 +76,10 @@ when using the `deploy` command:
 juju deploy mysql --channel <channel_name>
 ```
 
-In the case of there being no version of the charm specified for that 
-channel, Juju will fall back to the next 'most stable'; e.g. if you were to 
+In the case of there being no version of the charm specified for that
+channel, Juju will fall back to the next 'most stable'; e.g. if you were to
 specify the 'beta' channel, but no charm version is set for that channel, Juju
-will try to deploy from the 'candidate' channel instead, and so on. This means 
+will try to deploy from the 'candidate' channel instead, and so on. This means
 that whenever you specify a channel, you will always end up with something that
 best approximates your choice if it is not available.
 
@@ -177,9 +177,9 @@ For example, to deploy vsftpd from a local filesystem:
 juju deploy ~/charms/vsftpd --series trusty
 ```
 
-Local charms may not have a specific declared series (charms fetched from the 
-store always have an implied series). You do not have to specify the series 
-if the charm contains a series declaration, or if you have specified a 
+Local charms may not have a specific declared series (charms fetched from the
+store always have an implied series). You do not have to specify the series
+if the charm contains a series declaration, or if you have specified a
 default series in the model configuration. For example:
 
 ```bash
@@ -195,8 +195,8 @@ explanation of local charms and how they can be managed.
 
 ## Deploying with a configuration file
 
-Deployed applications usually start with a sane default configuration. However, 
-for some applications it is desirable (and quicker) to configure them at 
+Deployed applications usually start with a sane default configuration. However,
+for some applications it is desirable (and quicker) to configure them at
 deployment time. This can be done by creating a YAML format file of
 configuration values and using the `--config=` switch:
 
@@ -211,11 +211,11 @@ See [application configuration](./charms-config.html) for more on this.
 
 It is possible to specify which machine or container an application is to be
 deployed to. One notable reason is to reduce costs when using a public cloud;
-applications can be consolidated instead of dedicating a machine per application 
+applications can be consolidated instead of dedicating a machine per application
 unit.
 
 Below, the `--constraints` option is used to create an LXD controller with
-enough memory for other applications to run. The `--to` option is used to 
+enough memory for other applications to run. The `--to` option is used to
 specify a machine:
 
 ```bash
@@ -260,7 +260,7 @@ juju add-unit --to 1 rabbitmq-server
 ```
 
 There should now be a second machine running both the openstack-dashboard
-application and a second unit of the rabbitmq-server application. The 
+application and a second unit of the rabbitmq-server application. The
 `juju status` command will show this.
 
 These two features make it much easier to deploy complex applications such as
@@ -268,7 +268,7 @@ OpenStack which use a large number of charms on a limited number of physical
 servers.
 
 As with deploy, the --to option used with `add-unit` also supports placement
-directives. A comma separated list of directives can be provided to cater for 
+directives. A comma separated list of directives can be provided to cater for
 the case where more than one unit is being added.
 
 ```bash
@@ -277,7 +277,7 @@ juju add-unit rabbitmq-server -n 4 --to host1,host2,host3,host4
 ```
 
 Any extra placement directives are ignored. If not enough placement directives
-are supplied, then the remaining units will be assigned as normal to a new, 
+are supplied, then the remaining units will be assigned as normal to a new,
 clean machine.
 
 
@@ -322,7 +322,7 @@ bindable endpoint that is not a relation, see [Charm metadata](./charm-metadata.
 
 ## Juju retry-provisioning
 
-You can use the `retry-provisioning` command in cases where deploying 
+You can use the `retry-provisioning` command in cases where deploying
 applications, adding units, or adding machines fails. It allows you to specify
 machines which should be retried to resolve errors reported with `juju status`.
 
@@ -331,7 +331,7 @@ machines '3', '27' and '57' could not be provisioned because of a 'rate limit
 exceeded' error. You can ask Juju to retry:
 
 ```bash
-juju retry-provisioning 3 27 5
+juju retry-provisioning 3 27 57
 ```
 
 
@@ -382,7 +382,7 @@ official Charm Store. Such cases include:
 !!! Note: Although this method will ensure that the charms themselves are
 available on systems without outside internet access, there is no guarantee
 that a charm will work in a disconnected state. Some charms will attempt to pull
-code from sources on the internet such as GitHub. 
+code from sources on the internet such as GitHub.
 
 ### Using Charm Tools
 


### PR DESCRIPTION
## Done
- Fixed the small typo in the example snippet in Juju retry-provisioning
- Seems there were some trailing white space. This is removed.

Fixes: https://github.com/CanonicalLtd/jujucharms.com/issues/333