### PR TITLE
updated page title and added links to remove models and controllers

### DIFF
--- a/src/en/charms-destroy.md
+++ b/src/en/charms-destroy.md
@@ -5,8 +5,8 @@ Title: Removing applications, units, and machines in Juju
 
 Juju can sanely and efficiently remove something when you no longer need it.
 This section looks at how to remove applications, units, and machines. To 
-remove a model see the [models documentation](./models.html). To remove a controller,
-see the [controllers documentation](./controllers.html).
+remove a model see the [models documentation][models]. To remove a controller,
+see the [controllers documentation][controllers].
 
 
 ## Removing an application
@@ -21,7 +21,7 @@ juju remove-application <application-name>
 running application will terminate that relation. Charms are written
 to handle this, but be aware that the other application may no 
 longer work as expected. To remove relations between deployed applications,
-see [Charm relations](charms-relations.html#removing-relations).
+see [Charm relations][charmrelations].
 
 This is the order of events for removing an application:
 
@@ -103,3 +103,7 @@ There may be errors on other units caused by the breaking of relations that
 occur when removing a unit or application. Therefore also verify that the
 associated units are not in an error state and apply the above command to them
 if they are.
+
+[charmrelations]: ./charms-relations.html#removing-relations
+[controllers]: ./controllers.html
+[models]: ./models.html

--- a/src/en/charms-destroy.md
+++ b/src/en/charms-destroy.md
@@ -1,11 +1,12 @@
-Title: Removing applications, units and machines in Juju  
+Title: Removing applications, units, and machines in Juju
 
 
-# Removing applications, units and environments
+# Removing applications, units, and machines
 
 Juju can sanely and efficiently remove something when you no longer need it.
-This section looks at how to remove applications, units and environments. To 
-remove a model see the [models documentation][models].
+This section looks at how to remove applications, units, and machines. To 
+remove a model see the [models documentation](./models.html). To remove a controller,
+see the [controllers documentation](./controllers.html).
 
 
 ## Removing an application
@@ -19,7 +20,8 @@ juju remove-application <application-name>
 !!! Note: Removing an application which has active relations with another
 running application will terminate that relation. Charms are written
 to handle this, but be aware that the other application may no 
-longer work as expected.
+longer work as expected. To remove relations between deployed applications,
+see [Charm relations](charms-relations.html#removing-relations).
 
 This is the order of events for removing an application:
 
@@ -79,12 +81,6 @@ error: no machines were destroyed: machine 3 has unit "mysql/0" assigned
 ```
 
 
-## Removing relations
-
-To remove relations between deployed applications, see
-[Charm relations](charms-relations.html#removing-relations).
-
-
 ## Caveats
 
 These are caveats which you may encounter while removing items.
@@ -107,6 +103,3 @@ There may be errors on other units caused by the breaking of relations that
 occur when removing a unit or application. Therefore also verify that the
 associated units are not in an error state and apply the above command to them
 if they are.
-
-
-[models]: ./models-destroying.html


### PR DESCRIPTION
Several small changes:
- Removed "environments" from the page as we no longer destroy-environments.
- Added Oxford commas.
- Fixed broken link to models documentation.
- Added link to controllers documentation.
- Moved info about removing relations out of separate section because the section was far away from where the info was useful; placed the info in the Note under Removing an application which mentions the possible need to do this.