### PR TITLE
updated info on getting and setting model config values

### DIFF
--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -65,22 +65,11 @@ The table below lists all the model keys which may be assigned a value.
 agent-metadata-url           | string |          |                          | URL of private stream
 agent-stream                 | string | released | released/devel/proposed  | Version of Juju to use for deploy/upgrades
 agent-version                | string |          |                          | The desired Juju agent version to use
-allow-lxc-loop-mounts        | bool   | false    |                          | whether loop devices are allowed to be mounted inside lxc containers
-api-port                     | int    | 17070    |                          | The TCP port for the API servers to listen on
 apt-ftp-proxy                | string |          |                          | The APT FTP proxy for the model
 apt-http-proxy               | string |          |                          | The APT HTTP proxy for the model
 apt-https-proxy              | string |          |                          | The APT HTTPS proxy for the model
 apt-mirror                   | string |          |                          | The APT mirror for the model
-authorized-keys              | string |          |                          | Any authorized SSH public keys for the model, as found in a ~/.ssh/authorized_keys file
-authorized-keys-path         | string |          |                          | Path to file containing SSH authorized keys
 automatically-retry-hooks    | bool   | true     |                          | Set policy on retying failed hooks. See [addition info below](#retrying-failed-hooks).
-block-all-changes            | bool   |          |                          | Whether all changes to the model will be prevented
-block-destroy-model          | bool   |          |                          | Whether the model will be prevented from destruction
-block-remove-object          | bool   |          |                          | Whether remove operations (machine, service, unit or relation) will be prevented
-ca-cert                      | string |          |                          | The certificate of the CA that signed the state server certificate, in PEM format
-ca-cert-path                 | string |          |                          | Path to file containing CA certificate
-ca-private-key               | string |          |                          | The private key of the CA that signed the state server certificate, in PEM format
-ca-private-key-path          | string |          |                          | Path to file containing CA private key
 default-series               | string |          | valid series name, e.g. 'xenial' | The default series of Ubuntu to use for deploying charms
 development                  | bool   | false    |                          | Whether the model is in development mode
 disable-network-management   | bool   | false    |                          | Whether to give network control to the provider instead of Juju controlling configuration. This can only be used with MAAS models and should otherwise be set to false(default) unless you want to take over network control from Juju because you have unique and well-defined needs. Setting this to 'true' with MAAS gives you the same behavior with containers as you already have with other providers: one machine-local address on a single network interface, bridged to the default bridge.
@@ -90,27 +79,18 @@ firewall-mode                | string | instance | instance/global/none     | Th
 ftp-proxy                    | string |          | url                      | The FTP proxy value to configure on instances, in the FTP_PROXY environment variable
 http-proxy                   | string |          | url                      | The HTTP proxy value to configure on instances, in the HTTP_PROXY environment variable
 https-proxy                  | string |          | url                      | The HTTPS proxy value to configure on instances, in the HTTPS_PROXY environment variable
+ignore-machine-addresses     | bool   | false    |                          | When true, the machine worker will not look up or discover any machine addresses
 image-metadata-url           | string |          | url                      | The URL at which the metadata used to locate OS image ids is located
 image-stream                 | string |          |                          | The simplestreams stream used to identify which image ids to search when starting an instance
+logforward-enabled           | bool   | false    |                          | Whether the log forward function is enabled
 logging-config               | string |          |                          | The configuration string to use when configuring Juju agent logging (see [this link](http://godoc.org/github.com/juju/loggo#ParseConfigurationString) for details)
-lxc-clone                    | bool   |          |                          | Whether to use lxc-clone to create new LXC containers
-lxc-clone-aufs               | bool   | false    |                          | Whether the LXC provisioner should create an LXC clone using AUFS if available
-lxc-default-mtu              | int    |          |                          | The MTU setting to use for network interfaces in LXC containers
-name                         | string |          |                          | The name of the current model
 no-proxy                     | string |          |                          | List of domain addresses not to be proxied (comma-separated)
 provisioner-harvest-mode     | string | destroyed| all/none/unknown/destroyed | What to do with unknown machines. See [harvesting section](#juju-lifecycle-and-harvesting)
 proxy-ssh                    | bool   | false    |                          | Whether SSH commands should be proxied through the API server
 resource-tags                | string | none     |                          | Space-separated list of key=value pairs used to apply as tags on supported cloud models
-rsyslog-ca-cert              | string |          |                          | The certificate of the CA that signed the rsyslog certificate, in PEM format
-rsyslog-ca-key               | string |          |                          | The private key of the CA that signed the rsyslog certificate, in PEM format
-set-numa-control-policy      | bool   | false    |                          | Tune Juju state-server to work with NUMA if present
 ssl-hostname-verification    | bool   | true     |                          | Whether SSL hostname verification is enabled 
-state-port                   | int    | 37017    |                          | Port for the API server to listen on
-storage-default-block-source | string |          |                          | The default block storage source for the model
-syslog-port                  | int    | 6514     |                          | Port for the syslog UDP/TCP listener to listen on
 test-mode                    | bool   | false    |                          | Whether the model is intended for testing. If true, accessing the charm store does not affect statistical data of the store
-type                         | string |          | any of the supported provider types | Type of model, e.g. local, ec2
-uuid                         | string |          |                          | The UUID of the model
+transmit-vendor-metrics      | bool   | true     |                          | Whether the controller will send metrics collected from this model for use in anonymized aggregate analytics
 
 Some of these keys deserve further explanation. These are explored below.
 

--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -21,33 +21,38 @@ provided below. Notable examples are provided at the end.
 You can display the current model settings by running the command:
 
 ```bash
-juju get-model-config
+juju model-config
 ```
 
 This will include all the currently set key values - whether they were set
 by you, inherited as a default value or dynamically set by Juju. 
 
-A key's value may be set for the current model using the `set-model-config`
-command:
+A key's value may be set for the current model using the same command:
 
 ```bash
-juju set-model-config noproxy=jujucharms.com
+juju model-config noproxy=jujucharms.com
 ```
 
 It is also possible to specify a list of key-value pairs:
   
 ```bash
-juju set-model-config test-mode=true enable-os-upgrade=false
+juju model-config test-mode=true enable-os-upgrade=false
 ```
 
 !!! Note: Juju does not currently check that the provided key is a valid
 setting, so make sure you spell it correctly.
 
-To return a value to the default setting the `unset-model-config` command is
-used, specifying the key names:
+To return a value to the default setting the `--reset` flag is used,
+specifying the key names:
   
 ```bash
-juju unset-model-config test-mode
+juju model-config --reset test-mode
+```
+
+To view the default settings and keys, use:
+
+```bash
+juju model-defaults
 ```
 
 
@@ -117,7 +122,7 @@ the services they deploy. It is possible to set a specific mirror for the APT
 packages to use, by setting 'apt-mirror':
 
 ```bash
-juju set-model-config apt-mirror=http://archive.ubuntu.com/ubuntu/
+juju model-config apt-mirror=http://archive.ubuntu.com/ubuntu/
 ```
 
 It is also possible to set this to a local mirror if desired.
@@ -125,7 +130,7 @@ It is also possible to set this to a local mirror if desired.
 You may also run:
 
 ```bash
-juju unset-model-config apt-mirror
+juju model-config --reset apt-mirror
 ```
 
 to restore the default behaviour in a running model.
@@ -227,5 +232,5 @@ The default mode is **destroyed**.
 Below, the harvest mode key for the current model is set to 'none':
 
 ```bash
-juju set-model-config provisioner-harvest-mode=none
+juju model-config provisioner-harvest-mode=none
 ```


### PR DESCRIPTION
Fixes #1351 
During review, please help me figure out whether the table on the page needs updating. This is the current output in 2.0rc1, but I do not know whether this list is exhaustive. These entries on the page appear to be correct, but the page contains many items not listed here.

```bash
ubuntu@20160921-rc1:~$ juju model-config
ATTRIBUTE                   FROM     VALUE
agent-metadata-url          default  ""
agent-stream                default  released
agent-version               model    2.0-rc1
apt-ftp-proxy               default  ""
apt-http-proxy              default  ""
apt-https-proxy             default  ""
apt-mirror                  default  ""
automatically-retry-hooks   default  true
default-series              default  xenial
development                 default  false
disable-network-management  default  false
enable-os-refresh-update    default  true
enable-os-upgrade           default  true
firewall-mode               default  instance
ftp-proxy                   default  ""
http-proxy                  default  ""
https-proxy                 default  ""
ignore-machine-addresses    default  false
image-metadata-url          default  ""
image-stream                default  released
logforward-enabled          default  false
logging-config              model    <root>=INFO;unit=DEBUG
no-proxy                    default  ""
provisioner-harvest-mode    default  destroyed
proxy-ssh                   default  false
resource-tags               model    {}
ssl-hostname-verification   default  true
test-mode                   default  false
transmit-vendor-metrics     default  true
```