### PR TITLE
fixed outdated link and a link with broken formatting

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -189,8 +189,8 @@ interconnecting applications in a cluster
 
 ## Writing hooks
 
-As you will know from your thorough reading of the [charm components](./authors-
-charm-components.html), the hooks are the important scripts that actually do
+As you will know from your thorough reading of the [charm components](./authors-charm-components.html),
+the hooks are the important scripts that actually do
 things. You can write hooks in whatever language you can reasonably expect to
 execute on your deployed environment (e.g. Ubuntu Server).
 
@@ -364,8 +364,8 @@ corresponding hooks to find out. In this case we know that when connected, the
 a username and password.
 
 Interfaces in general are determined by the consensus of the charms which use
-them. There is a lot [more information on decoding interfaces here](./authors-
-charm-interfaces.html). Some of the major interfaces are being documented to
+them. There is a lot [more information on decoding interfaces here](./authors-relations.html).
+Some of the major interfaces are being documented to
 make it easier to use them, and fortunately, mysql is one of them - [You can
 find a description of the mysql interface here](./interface-mysql.html).
 


### PR DESCRIPTION
Fixes #1108 for 2.0 docs.

The problem was that the linked-to page was deprecated over a year ago in #434. The link has been to a 404 that whole time. The reason is discussed a bit in #289

I also found and fixed a link that was broken due to someone having line-wrapping turned on in their text editor.