### PR TITLE
fixed outdated link and a link with broken formatting

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -189,8 +189,8 @@ interconnecting services in a cluster
 
 ## Writing hooks
 
-As you will know from your thorough reading of the [charm components](./authors-
-charm-components.html), the hooks are the important scripts that actually do
+As you will know from your thorough reading of the [charm components](./authors-charm-components.html),
+the hooks are the important scripts that actually do
 things. You can write hooks in whatever language you can reasonably expect to
 execute on your deployed environment (e.g. Ubuntu Server).
 
@@ -363,8 +363,8 @@ corresponding hooks to find out. In this case we know that when connected, the
 username and password.
 
 Interfaces in general are determined by the consensus of the charms which use
-them. There is a lot [more information on decoding interfaces here](./authors-
-charm-interfaces.html). Some of the major interfaces are being documented to
+them. There is a lot [more information on decoding interfaces here](./authors-relations.html).
+Some of the major interfaces are being documented to
 make it easier to use them, and fortunately, mysql is one of them - [You can
 find a description of the mysql interface here](./interface-mysql.html).
 


### PR DESCRIPTION
This is the same as #1405, but for the 1.x series. See the comment there for details.

Fixes #1108 for the 1.x series.