### PR TITLE
Updates to model keys and bootstrap options

### DIFF
--- a/src/en/controllers-creating.md
+++ b/src/en/controllers-creating.md
@@ -102,10 +102,10 @@ be named using the non-default region, specifically naming it `aws-us-west-2`:
 juju bootstrap aws/us-west-2
 ```
 
-## Changing timeout and retry delays
+## Change timeout and retry delays
 
-You can change the default timeout and retry delays used during the
-bootstrap by changing the following settings in your configuration:
+You can change the default timeout and retry delays used by Juju 
+by setting the following keys in your configuration:
 
 | Key                        | Default (seconds) | Purpose |
 |:---------------------------|-------------------|:---------|

--- a/src/en/controllers-creating.md
+++ b/src/en/controllers-creating.md
@@ -108,7 +108,7 @@ You can change the default timeout and retry delays used by Juju
 by setting the following keys in your configuration:
 
 | Key                        | Default (seconds) | Purpose |
-|:---------------------------|-------------------|:---------|
+|:---------------------------|:------------------|:---------|
 bootstrap-timeout            | 600    | How long to wait for a connection to the controller
 bootstrap-retry-delay        | 5      | How long to wait between connection attempts to a controller
 bootstrap-address-delay      | 10     | How often to refresh controller addresses from the API server

--- a/src/en/controllers-creating.md
+++ b/src/en/controllers-creating.md
@@ -101,3 +101,22 @@ be named using the non-default region, specifically naming it `aws-us-west-2`:
 ```bash
 juju bootstrap aws/us-west-2
 ```
+
+## Changing timeout and retry delays
+
+You can change the default timeout and retry delays used during the
+bootstrap by changing the following settings in your configuration:
+
+| Key                        | Default (seconds) | Purpose |
+|:---------------------------|-------------------|:---------|
+bootstrap-timeout            | 600    | How long to wait for a connection to the controller
+bootstrap-retry-delay        | 5      | How long to wait between connection attempts to a controller
+bootstrap-address-delay      | 10     | How often to refresh controller addresses from the API server
+ 
+For example, to increase the timeout between the client and the controller
+from 10 minutes to 15, enter the value in seconds:
+
+```bash
+juju bootstrap --config bootstrap-timeout=900 lxd lxd-faraway
+```
+

--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -3,6 +3,7 @@ TODO: Check accuracy of key table
       Confirm 'all' harvest mode state. Seems it should be "'Dead' or
 	'Unknown'" OR "a combination of modes 'destroyed' and 'unknown'".
       Make the table more space-efficient. Damn it's bulbous.
+      Provide an example of using model-defaults to set a per-region attribute.
 
 
 # Configuring models
@@ -60,7 +61,7 @@ To set a value for `ftp-proxy`, for instance, you would enter the following:
 juju model-defaults ftp-proxy=10.0.0.1:8000
 ```
 
-While to see both the default values and what they've been changed to, you
+To see both the default values and what they've been changed to, you
 would use:
 
 ```bash

--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -53,7 +53,7 @@ juju model-config --reset test-mode
 After deployment, the `model-defaults` command allows a user to display the
 configuration values for a model as well as set and unset those values for use
 with any new models. These values can even be specified for each cloud region
-instead of just the controller
+instead of just the controller.
 
 To set a value for `ftp-proxy`, for instance, you would enter the following:
 

--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -55,6 +55,13 @@ To view the default settings and keys, use:
 juju model-defaults
 ```
 
+These values can also be passed to a new controller for use
+with the default model it creates. To do this, use the `--config` argument with
+bootstrap:
+
+```bash
+juju bootstrap --config image-stream=daily lxd lxd-daily
+```
 
 ## List of model keys
 

--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -49,15 +49,25 @@ specifying the key names:
 juju model-config --reset test-mode
 ```
 
-To view the default settings and keys, use:
+After deployment, the `model-defaults` command allows a user to display the
+configuration values for a model as well as set and unset those values for use
+with any new models. These values can even be specified for each cloud region
+instead of just the controller
+
+To set a value for `ftp-proxy`, for instance, you would enter the following:
+
+```bash
+juju model-defaults ftp-proxy=10.0.0.1:8000
+```
+
+While to see both the default values and what they've been changed to, you
+would use:
 
 ```bash
 juju model-defaults
 ```
-
-These values can also be passed to a new controller for use
-with the default model it creates. To do this, use the `--config` argument with
-bootstrap:
+These values can also be passed to a new controller for use with the default
+model it creates. To do this, use the `--config` argument with bootstrap:
 
 ```bash
 juju bootstrap --config image-stream=daily lxd lxd-daily


### PR DESCRIPTION
in reference to #1166 

- updated docs to account for model keys passed via bootstrap no longer being inherited by new models and 'model-defaults' now being used to serve this purpose. 
- clarified and updated missing bootstrap keys.
