### PR TITLE
Fixes 1449 - added example showing setting model config per region

### DIFF
--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -43,13 +43,6 @@ juju model-config test-mode=true enable-os-upgrade=false
 !!! Note: Juju does not currently check that the provided key is a valid
 setting, so make sure you spell it correctly.
 
-To set values for all models in a specific controller region, state the
-region in the command:
-
-```bash
-juju model-config us-east-1 test-mode=true enable-os-upgrade=false
-```
-
 To return a value to the default setting the `--reset` flag is used,
 specifying the key names:
   
@@ -73,6 +66,14 @@ would use:
 
 ```bash
 juju model-defaults
+```
+
+To set default values for all models in a specific controller region, state
+the region in the command, shown here using the same example settings as our
+previous `model-config` key-value pairs example above:
+
+```bash
+juju model-defaults us-east-1 test-mode=true enable-os-upgrade=false
 ```
 
 These values can also be passed to a new controller for use with the default

--- a/src/en/models-config.md
+++ b/src/en/models-config.md
@@ -43,6 +43,13 @@ juju model-config test-mode=true enable-os-upgrade=false
 !!! Note: Juju does not currently check that the provided key is a valid
 setting, so make sure you spell it correctly.
 
+To set values for all models in a specific controller region, state the
+region in the command:
+
+```bash
+juju model-config us-east-1 test-mode=true enable-os-upgrade=false
+```
+
 To return a value to the default setting the `--reset` flag is used,
 specifying the key names:
   
@@ -67,6 +74,7 @@ would use:
 ```bash
 juju model-defaults
 ```
+
 These values can also be passed to a new controller for use with the default
 model it creates. To do this, use the `--config` argument with bootstrap:
 


### PR DESCRIPTION
Fixes #1449 

The original issues asks for 'examples' and I only added one because it fit so smoothly in the existing set of examples for 'model-config'

As I am writing this, I realized that the issue uses 'model-defaults' and I used 'model-config' in the PR, so this requires one more change from me before review. Coming shortly.