### PR TITLE
Added an example of charm configurations options to bundles docs

### DIFF
--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -174,6 +174,29 @@ mysql:
       "gui-y": "168"
 ```
 
+## Setting charm configurations options in a bundle
+
+When deploying an application, the charm you use will often support or even
+require specific configuration options to be set. These options can be set in
+a bundle as a simple key addition to the application definition, using the
+configuration key/value pair.
+[See the documentation on application configuration](charms-config.html#discovering-application-configuration-options)
+on how to discover which options are available for the different charms.
+
+For example, to set the flavor of the MySQL charm to Percona in a bundle, the
+bundle file would have an additional `options` field with specific value:
+
+```yaml
+mysql:
+  charm: "cs:precise/mysql-27"
+  num_units: 1
+  options:
+    flavor: percona
+  annotations:
+      "gui-x": "139"
+      "gui-y": "168"
+```
+
 ## Bundle placement directives
 
 You can co-locate applications using the placement directive key in the bundle.

--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -180,8 +180,8 @@ When deploying an application, the charm you use will often support or even
 require specific configuration options to be set. These options can be set in
 a bundle as a simple key addition to the application definition, using the
 configuration key/value pair.
-[See the documentation on application configuration](charms-config.html#discovering-application-configuration-options)
-on how to discover which options are available for the different charms.
+[See the documentation on application configuration](./charms-config.html#discovering-application-configuration-options)
+to discover which options are available for the different charms.
 
 For example, to set the flavor of the MySQL charm to Percona in a bundle, the
 bundle file would have an additional `options` field with specific value:


### PR DESCRIPTION
Added an example of charm configuration options to the bundles docs.
I think this should fix #1346 

**NOTE:** I could not find a standard of how linking between documents is done so please double check that to confirm and/or fix it. 

