### PR TITLE
the command is charm proof not juju charm proof

### DIFF
--- a/src/en/authors-charm-writing.md
+++ b/src/en/authors-charm-writing.md
@@ -404,7 +404,7 @@ Another part of the Charm Tools plugin is a useful lint-like tool which will
 check for errors in the files of your charm. Run it like this:
 
 ```bash
-juju charm proof [CHARM_DIRECTORY]
+charm proof [CHARM_DIRECTORY]
 ```
 
 The output classifies messages as:

--- a/src/en/reference-reviewers.md
+++ b/src/en/reference-reviewers.md
@@ -11,7 +11,7 @@ and thus lighten the development workload on everyone.
 
 - Start your review by saying "Thanks", no matter what the outcome of the review is going to be.
 - If you recognise somebody you've worked with on IRC, thank them.
-- Run juju charm proof first. If there are serious problems with the charm based on the output of proof feel free to just stop the review there and tell them. You shouldn't promulgate a charm that has anything that’s a “WARNING” or more severe.
+- Run charm proof first. If there are serious problems with the charm based on the output of proof feel free to just stop the review there and tell them. You shouldn't promulgate a charm that has anything that’s a “WARNING” or more severe.
 - If the merge proposal or patch requires more work, encourage the contributor to join #juju and discuss the solution there.
 - Follow [these instructions](http://wiki.bazaar.canonical.com/PatchPilot) as well as you can.
 - If this is your first time patch piloting, you may feel more comfortable being a co-pilot your first few runs. Find a pilot in your timezone and reschedule your time to coincide with theirs.


### PR DESCRIPTION
Fixes #1545 
@juju/docs

I would especially like confirmation that it is only this charm command that loses the initial 'juju', as there are other instances of commands in the format 'juju charm _something_' that seem to be correct. I plead ignorance as to how to know the difference and would love to learn.