### PR TITLE
added link to official GCE source for our cloud prep info

### DIFF
--- a/src/en/help-google.md
+++ b/src/en/help-google.md
@@ -27,7 +27,9 @@ juju update-clouds
 ## Preparing your GCE cloud for use by Juju
 
 Although Juju knows how GCE works, there are some tasks you must perform 
-manually in the GCE dashboard to prepare your account to work with Juju.
+manually in the GCE dashboard to prepare your account to work with Juju. We
+give an overview of the steps here. For greater detail, see the GCE site and
+the official [GCE documentation][gce-docs].
 
 ### Create a project
 
@@ -122,3 +124,5 @@ juju add-credential google
 The command will interactively prompt you for information about the credentials
 being added. For the authentication type, choose 'json' and then give the full
 path to the file downloaded.
+
+[gce-docs]: https://console.cloud.google.com/start "GCE Getting Started"


### PR DESCRIPTION
Fixes #1537 
@juju/docs

This seems like a reasonable thing to have in the page.