### PR TITLE
fixed command to be charm release instead of publish

### DIFF
--- a/src/en/about-juju.md
+++ b/src/en/about-juju.md
@@ -183,7 +183,7 @@ charms:
 
 ## Are charms open source? Under what license?
 
-Charms can be published under whatever license the author prefers, there are
+Charms can be released under whatever license the author prefers, there are
 charms under just about every kind of license out there today. In many cases,
 charms follow the license of the applications that they deploy, but this is
 not a requirement. There are open source charms that deploy proprietary

--- a/src/en/authors-charm-store.md
+++ b/src/en/authors-charm-store.md
@@ -203,8 +203,8 @@ The author could publish foo-9 to either the stable or development channel
 as follows, showing the commands for stable and development respectively:
 
 ```
-charm publish cs:~kirk/foo-9
-charm publish cs:~kirk/foo-9 --channel development
+charm release cs:~kirk/foo-9
+charm release cs:~kirk/foo-9 --channel development
 ```
 
 After running both commands, revision 9 exists in both the stable channel

--- a/src/en/authors-charm-store.md
+++ b/src/en/authors-charm-store.md
@@ -54,9 +54,9 @@ pushed 4 times, the revision history would look like this:
 entity: 0---1---2---3
 ```
 
-Channels group entity revisions into named streams. There are currently two
-released channels: stable and development. Each channel also tracks
-history of revisions. When a revision is released to a channel, that
+Channels group entity revisions into named streams. There are currently four
+released channels: edge, beta, candidate, and stable. Each channel also
+tracks history of revisions. When a revision is released to a channel, that
 channel pointer is changed and the history for the channel is updated.
 
 Building on the previous example, when a user released revision 2 to the
@@ -68,7 +68,7 @@ stable channel, the history would look like this:
 entity: 0---1---2---3
 ```
 
-If, then, revision 3 is released to the development channel the history
+If, then, revision 3 is released to the edge channel the history
 would look like this:
 
 ```
@@ -76,12 +76,12 @@ would look like this:
                  /
 entity: 0---1---2---3
                      \
-                      development (3)
+                      edge (3)
 ```
 
 During this time, more revisions can be pushed to the default, unreleased
 channel. This represents general development iterations. As iterations are
-pushed during development, the stable and development channels are not
+pushed during development, the stable and other channels are not
 updated.
 
 
@@ -90,29 +90,29 @@ updated.
                  /
 entity: 0---1---2---3---4---5---6
                      \
-                      development (3)
+                      edge (3)
 ```
 
 The author can, at any time, release a revision to a channel. Revisions
 can also exist in the same channel at the same time. For example, the
 author chooses to release revision 3 to the stable channel without
-updating the development channel:
+updating the edge channel:
 
 ```
                       stable (3, 2)
                      /
 entity: 0---1---2---3---4---5---6
                      \
-                      development (3)
+                      edge (3)
 ```
 
 In doing so, the stable channel is updated to point to revision 3 and
 revision 3 is added to the channel history. The author can continue to
 push and release. Since revisions are a constant stream there are
 scenarios where the stable channel may be pointed to a higher revision
-even though development revision is actually newer.
+even though edge revision is actually newer.
 
-In the following example revision 8 is development, a bug is found in the
+In the following example revision 8 is edge, a bug is found in the
 latest stable revision (5) so a hot fix is applied and pushed as 9.
 That revision is then released to the stable channel, like this:
 
@@ -121,12 +121,12 @@ That revision is then released to the stable channel, like this:
                                              /
 entity: 0---1---2---3---4---5---6---7---8---9
                                          \
-                                          development (8, 3)
+                                          edge (8, 3)
 ```
 
 While authors can release older versions to the channels it is not
 encouraged. For example, an author could mistakenly release revision 10 to
-the stable channel and not development, then the author could re-release
+the stable channel and not edge, then the author could re-release
 revision 9 to stable:
 
 ```
@@ -134,7 +134,7 @@ revision 9 to stable:
                                              /
 entity: 0---1---2---3---4---5---6---7---8---9---10
                                          \
-                                          development (8, 3)
+                                          edge (8, 3)
 ```
 
 If a user managed to deploy that first mistaken revision during the time
@@ -187,10 +187,10 @@ Push will always increment the charm version in the unreleased channel.
 
 ## Releasing to channels
 
-The charm store supports two released channels: development and stable.
-Revisions are associated with channels by using the release charm command.
-Release is executed against an existing revision and places that revision
-as the channel pointer.
+The charm store supports four released channels: edge, beta, candidate, and
+stable. Revisions are associated with channels by using the release charm
+command. Release is executed against an existing revision and places that
+revision as the channel pointer.
 
 Given the following example:
 
@@ -199,21 +199,21 @@ $ charm push . foo
 cs:~kirk/foo-9
 ```
 
-The author could release foo-9 to either the stable or development channel
-as follows, showing the commands for stable and development respectively:
+The author could release foo-9 to either the stable or edge channel
+as follows, showing the commands for stable and edge respectively:
 
 ```
 charm release cs:~kirk/foo-9
-charm release cs:~kirk/foo-9 --channel development
+charm release cs:~kirk/foo-9 --channel edge
 ```
 
 After running both commands, revision 9 exists in both the stable channel
-and the development channel.
+and the edge channel.
 
 ## Sharing charms and bundles
 
-All channels (unreleased, development, and stable) have read and write
-ACLs. By default, only the owner of the entity exists in these ACLs.
+All channels have read and write ACLs. By default, only the owner of the
+entity exists in these ACLs.
 
 To update the ACL for an entity you must grant users an ACL to the channel
 you want them to access. By default, if you do not supply an entity when
@@ -225,11 +225,11 @@ stable channel of the cs:~kirk/foo entity.
 charm grant cs:~kirk/foo james
 ```
 
-If, instead you wanted to give write access to the development channel
-to lars, you would issue the following command:
+If, instead you wanted to give write access to the edge channel to lars, you
+would issue the following command:
 
 ```
-charm grant cs:~kirk/foo --channel development --acl write lars
+charm grant cs:~kirk/foo --channel edge --acl write lars
 ```
 
 Finally, to make the entity available for all to consume, there is a

--- a/src/en/authors-charm-store.md
+++ b/src/en/authors-charm-store.md
@@ -3,7 +3,7 @@ Title: The Juju charm store
 # The Juju Charm Store
 
 Juju includes a charm store where charms and bundles can be uploaded,
-published, and optionally shared with other users.
+released (published), and optionally shared with other users.
 
 The charm store is broken down into two main sections: Recommended and
 Community. Recommended charms have been vetted and reviewed by a Juju
@@ -45,8 +45,8 @@ recognized.
 
 When a charm or bundle, referred to as entity from this point forward, is
 pushed for the first time to the store, the entity is named version 0 in
-the unpublished channel. Every revision of an entity lives in the
-unpublished channel. Subsequent pushes of different content to the store
+the unreleased (unpublished) channel. Every revision of an entity lives in
+the unreleased channel. Subsequent pushes of different content to the store
 will automatically increment this number. So if an entity is changed and
 pushed 4 times, the revision history would look like this:
 
@@ -55,11 +55,11 @@ entity: 0---1---2---3
 ```
 
 Channels group entity revisions into named streams. There are currently two
-published channels: stable and development. Each channel also tracks
-history of revisions. When a revision is published to a channel, that
+released channels: stable and development. Each channel also tracks
+history of revisions. When a revision is released to a channel, that
 channel pointer is changed and the history for the channel is updated.
 
-Building on the previous example, when a user published revision 2 to the
+Building on the previous example, when a user released revision 2 to the
 stable channel, the history would look like this:
 
 ```
@@ -68,7 +68,7 @@ stable channel, the history would look like this:
 entity: 0---1---2---3
 ```
 
-If, then, revision 3 is published to the development channel the history
+If, then, revision 3 is released to the development channel the history
 would look like this:
 
 ```
@@ -79,7 +79,7 @@ entity: 0---1---2---3
                       development (3)
 ```
 
-During this time, more revisions can be pushed to the default, unpublished
+During this time, more revisions can be pushed to the default, unreleased
 channel. This represents general development iterations. As iterations are
 pushed during development, the stable and development channels are not
 updated.
@@ -93,9 +93,9 @@ entity: 0---1---2---3---4---5---6
                       development (3)
 ```
 
-The author can, at any time, publish a revision to a channel. Revisions
+The author can, at any time, release a revision to a channel. Revisions
 can also exist in the same channel at the same time. For example, the
-author chooses to publish revision 3 to the stable channel without
+author chooses to release revision 3 to the stable channel without
 updating the development channel:
 
 ```
@@ -108,13 +108,13 @@ entity: 0---1---2---3---4---5---6
 
 In doing so, the stable channel is updated to point to revision 3 and
 revision 3 is added to the channel history. The author can continue to
-push and publish. Since revisions are a constant stream there are
+push and release. Since revisions are a constant stream there are
 scenarios where the stable channel may be pointed to a higher revision
 even though development revision is actually newer.
 
 In the following example revision 8 is development, a bug is found in the
 latest stable revision (5) so a hot fix is applied and pushed as 9.
-That revision is then published to the stable channel, like this:
+That revision is then released to the stable channel, like this:
 
 ```
                                               stable (9, 5, 3, 2)
@@ -124,9 +124,9 @@ entity: 0---1---2---3---4---5---6---7---8---9
                                           development (8, 3)
 ```
 
-While authors can publish older versions to the channels it is not
-encouraged. For example, an author could mistakenly publish revision 10 to
-the stable channel and not development, then the author could re-publish
+While authors can release older versions to the channels it is not
+encouraged. For example, an author could mistakenly release revision 10 to
+the stable channel and not development, then the author could re-release
 revision 9 to stable:
 
 ```
@@ -183,13 +183,13 @@ charm push . ~charm-examples/charm-name
 charm push . cs:~charm-examples/charm-name
 ```
 
-Push will always increment the charm version in the unpublished channel.
+Push will always increment the charm version in the unreleased channel.
 
-## Publishing to channels
+## Releasing to channels
 
-The charm store supports two published channels: development and stable.
-Revisions are associated with channels by using the publish charm command.
-Publish is executed against an existing revision and places that revision
+The charm store supports two released channels: development and stable.
+Revisions are associated with channels by using the release charm command.
+Release is executed against an existing revision and places that revision
 as the channel pointer.
 
 Given the following example:
@@ -199,7 +199,7 @@ $ charm push . foo
 cs:~kirk/foo-9
 ```
 
-The author could publish foo-9 to either the stable or development channel
+The author could release foo-9 to either the stable or development channel
 as follows, showing the commands for stable and development respectively:
 
 ```
@@ -212,7 +212,7 @@ and the development channel.
 
 ## Sharing charms and bundles
 
-All channels (unpublished, development, and stable) have read and write
+All channels (unreleased, development, and stable) have read and write
 ACLs. By default, only the owner of the entity exists in these ACLs.
 
 To update the ACL for an entity you must grant users an ACL to the channel

--- a/src/en/charms-bundles.md
+++ b/src/en/charms-bundles.md
@@ -327,7 +327,7 @@ application endpoints. The workaround is to list all endpoints explicitly.
 
 ## Sharing your Bundle with the Community
 
-After you have tested and deployed your bundle you need to publish it to share
+After you have tested and deployed your bundle you need to release it to share
 it with people, this is covered in the
 [charm store documentation][store-docs]. 
 

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -158,7 +158,7 @@ juju deploy mycharm --to 1 --force
 
 It may be required to use `--force` when upgrading charms. For example, in a
 case where an application is initially deployed using a charm that supports
-`precise` and `trusty`. If a new version of the charm is published that only
+`precise` and `trusty`. If a new version of the charm is released that only
 supports `trusty` and `xenial` then it will be allowed to upgrade applications
 deployed on `precise`, but only using `--force-series`, like this:
 

--- a/src/en/tools-charm-tools.md
+++ b/src/en/tools-charm-tools.md
@@ -282,9 +282,9 @@ independent help pages, accessible using either the `-h` or `--help` flags.
 
 ^# publish
 
-      charm publish [options] <charm or bundle id> [--channel <channel>]
+      charm release [options] <charm or bundle id> [--channel <channel>]
 
-  The publish command publishes a charm or bundle in the charm store.
+  The release command publishes a charm or bundle in the charm store.
   Publishing is the action of assigning one channel to a specific charm
   or bundle revision (revision need to be specified), so that it can be shared
   with other users and also referenced without specifying the revision.
@@ -292,19 +292,19 @@ independent help pages, accessible using either the `-h` or `--help` flags.
   Two channels are supported: "stable" and "development"; the "stable" channel is
   used by default.
 
-      charm publish ~lars/xenial/wordpress
+      charm release ~lars/xenial/wordpress
 
   To select another channel, use the `--channel` option, for instance:
 
-      charm publish ~lars/xenial/wordpress --channel stable
-      charm publish xenial/django-42 -c development --resource website-3 --resource data-2
+      charm release ~lars/xenial/wordpress --channel stable
+      charm release xenial/django-42 -c development --resource website-3 --resource data-2
 
   If your charm uses resources, you must specify what revision of each resource
   will be published along with the charm, using the --resource flag (one per
   resource). Note that resource info is embedded in bundles, so you cannot use
   this flag with bundles.
 
-      charm publish xenial/django-42 --resource website-3 --resource data-2
+      charm release xenial/django-42 --resource website-3 --resource data-2
 
 ^# pull
 

--- a/src/en/tools-charm-tools.md
+++ b/src/en/tools-charm-tools.md
@@ -280,12 +280,12 @@ independent help pages, accessible using either the `-h` or `--help` flags.
   charm store review policy. The charm store itself will not accept a push that
   has an error.
 
-^# publish
+^# release
 
       charm release [options] <charm or bundle id> [--channel <channel>]
 
-  The release command publishes a charm or bundle in the charm store.
-  Publishing is the action of assigning one channel to a specific charm
+  The release command releases a charm or bundle in the charm store.
+  Releasing is the action of assigning one channel to a specific charm
   or bundle revision (revision need to be specified), so that it can be shared
   with other users and also referenced without specifying the revision.
 
@@ -300,7 +300,7 @@ independent help pages, accessible using either the `-h` or `--help` flags.
       charm release xenial/django-42 -c development --resource website-3 --resource data-2
 
   If your charm uses resources, you must specify what revision of each resource
-  will be published along with the charm, using the --resource flag (one per
+  will be released along with the charm, using the --resource flag (one per
   resource). Note that resource info is embedded in bundles, so you cannot use
   this flag with bundles.
 
@@ -385,8 +385,8 @@ independent help pages, accessible using either the `-h` or `--help` flags.
   If the id is not specified, the current logged-in charm store user name is
   used, and the charm or bundle name is taken from the provided directory name.
 
-  The pushed charm or bundle is unpublished and therefore usually only available
-  to a restricted set of users. See the publish command for info on how to make
+  The pushed charm or bundle is unreleased and therefore usually only available
+  to a restricted set of users. See the release command for info on how to make
   charms and bundles available to others.
 
       	charm push .

--- a/src/en/tut-google.md
+++ b/src/en/tut-google.md
@@ -130,7 +130,7 @@ their relationships. Bundles are ideal for deploying [OpenStack][bundleopenstack
 or [Kubernetes][bundlekubernetes]. 
 
 It's also possible to [write your own charms][diycharm] and deploy locally, or
-publish via the [Charm Store][charmstore].
+release via the [Charm Store][charmstore].
 
 Deploying a charm is as simple as searching for your required application on
 the [Charm Store][charmstore], and using the 'juju' command to grab and deploy it


### PR DESCRIPTION
Will eventually fix #1555, but IMO this PR isn't ready yet.

I have fixed the command to be `juju release` instead of `juju publish`, but the context in these pages as well as other places in our documentation need to be massaged further. I would like to know whether we are completely abandoning the idea of "publishing to the Charm Store" and need to change our terminology throughout our docs to instead say "releasing to the Charm Store" or whether changing just the command is adequate (I strongly suspect and recommend a complete change).

I would appreciate comments from ecoteam members as well as from @juju/docs before pushing on with an additional draft.