### PR TITLE
Cleanup of #1570

### DIFF
--- a/src/en/developer-hook-tools.md
+++ b/src/en/developer-hook-tools.md
@@ -81,7 +81,7 @@ from charmhelpers.core.hookenv import close_port
 close_port(80, protocol="UDP")
 
 # Close a range of ports
-for port in xrange(9000, 9999):
+for port in range(9000, 9999):
     close_port(port, protocol="UDP")
 ```
 bash:  
@@ -294,7 +294,7 @@ from charmhelpers.core.hookenv import open_port
 open_port(80, protocol='TCP')
 
 # Open a range of ports
-for port in xrange(1000, 2000):
+for port in range(1000, 2000):
     open_port(port, protocol='UDP')
 ```
 bash:  


### PR DESCRIPTION
According to the python3 docs, it was the python2 range() function that
was deprecated and the python3 range() is equivalent to the python2
xrange function. I've removed the extra characters to reflect this
change.

I feel that python3 being the default for our recommended way to write
charms, this becomes a correct representation of an implementation.