### PR TITLE
Added description of why external user authentication may be useful

### DIFF
--- a/src/en/users-models.md
+++ b/src/en/users-models.md
@@ -115,7 +115,12 @@ jim                   add-model  2016-11-14    58 minutes ago
 ### Controller access for external users
 
 It is possible to give a user access to a controller without creating a local
-account for them. To do this, these criteria must first be met:
+account for them. Linking the controller to the external identity manager in
+this way provides the benefit of convenience, as the authentication system
+used may also be used for other systems. This reduces the number of login
+credentials that users must remember across multiple systems.
+
+To do this, these criteria must first be met:
 
 - The user must already have an account on an external identity manager,
   such as the Ubuntu SSO

--- a/src/en/users-models.md
+++ b/src/en/users-models.md
@@ -115,15 +115,14 @@ jim                   add-model  2016-11-14    58 minutes ago
 ### Controller access for external users
 
 It is possible to give a user access to a controller without creating a local
-account for them. Linking the controller to the external identity manager in
-this way provides the benefit of convenience, as the authentication system
-used may also be used for other systems. This reduces the number of login
-credentials that users must remember across multiple systems.
+account for them. Linking the controller to the external identity manager, such
+as the Ubuntu SSO, in this way provides the benefit of convenience, as the
+authentication system used may also be used for other systems. This reduces
+the number of login credentials that users must remember across multiple systems.
 
 To do this, these criteria must first be met:
 
-- The user must already have an account on an external identity manager,
-  such as the Ubuntu SSO
+- The user must already have an account on an external identity manager
 - The controller must have been created (bootstrapped) using the identity
   configuration option, like here where we use the URL for the Ubuntu SSO
   and Juju: `--config identity-url=https://api.jujucharms.com/identity`


### PR DESCRIPTION
Based on this comment in #1571 

> I think this is ok for a bare minimum of information that is required to use this feature. What I'd suggest though is that in next PR better explanation is given to why one would want to link the controller to the external identity provider, highlight the benefits and provide alternative comparison if admin of the controller manages the users without identity provider.

I think this description can be enhanced further before we merge. @urosj do you have any suggestions? Others?