### PR TITLE
Fixed broken link to interface layer page

### DIFF
--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -102,7 +102,7 @@ which to work. This involves creating three directories -- `layers`,
 
 The `layers` directory contains the source code of the layered charm covered in
 our examples. The `interfaces` directory is where you'd place any
-[interface-layers](./charms-layers-interfaces.md) you may wish to write, and the
+[interface-layers](./developer-layers-interfaces.md) you may wish to write, and the
 `charms` directory holds the assembled, ready to deploy charm.
 
 ```bash

--- a/src/en/developer-layers-interfaces.md
+++ b/src/en/developer-layers-interfaces.md
@@ -97,7 +97,7 @@ which to work. This involves creating three directories -- `layers`,
 
 The `layers` directory contains the source code of the layered charm covered in
 our examples. The `interfaces` directory is where you'd place any
-[interface-layers](./developer-layers-interfaces.md) you may wish to write, and the
+interface-layers you may wish to write, and the
 `charms` directory holds the assembled, ready to deploy charm.
 
 ```bash

--- a/src/en/developer-layers-interfaces.md
+++ b/src/en/developer-layers-interfaces.md
@@ -97,7 +97,7 @@ which to work. This involves creating three directories -- `layers`,
 
 The `layers` directory contains the source code of the layered charm covered in
 our examples. The `interfaces` directory is where you'd place any
-[interface-layers](./charms-layers-interfaces.md) you may wish to write, and the
+[interface-layers](./developer-layers-interfaces.md) you may wish to write, and the
 `charms` directory holds the assembled, ready to deploy charm.
 
 ```bash


### PR DESCRIPTION
Fixed link in developers-getting-started and removed link in developers-layers-interfaces entirely since it links to itself.