### PR TITLE
Fix broken links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,12 @@ check-links-production:
 	  --ignore-url=https://jujucharms.com/docs/stable \
 	  https://jujucharms.com/docs/devel/getting-started
 
+check-links-localhost:
+	linkchecker \
+	  --ignore-url=^http://localhost:6543/docs/devel \
+	  --ignore-url=^http://localhost:6543/docs/1.25 \
+	  --ignore-url=^http://localhost:6543/docs/2.0 \
+	  --ignore-url=http://localhost:6543/docs/stable \
+	  http://localhost:6543/docs/fix-404/getting-started
+
 .PHONY: build check-links-build check-links-production clean multi serve spell spell-commands sysdeps

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ spell:
 spell-commands:
 	spell -b src/en/commands.md | sort | uniq
 
-check-links-build:
+check-links-build: clean build
 	linkchecker htmldocs/en
 
 check-links-production:

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,4 @@ check-links-production:
 	  --ignore-url=https://jujucharms.com/docs/stable \
 	  https://jujucharms.com/docs/devel/getting-started
 
-check-links-localhost:
-	linkchecker \
-	  --ignore-url=^http://localhost:6543/docs/devel \
-	  --ignore-url=^http://localhost:6543/docs/1.25 \
-	  --ignore-url=^http://localhost:6543/docs/2.0 \
-	  --ignore-url=http://localhost:6543/docs/stable \
-	  http://localhost:6543/docs/fix-404/getting-started
-
 .PHONY: build check-links-build check-links-production clean multi serve spell spell-commands sysdeps

--- a/src/en/authors-charm-hooks.md
+++ b/src/en/authors-charm-hooks.md
@@ -129,8 +129,8 @@ services. Units of a single client service will surely want to connect to, and
 use, the same database; but if units of another client service were to use that
 same database, the consequences could be catastrophic for all concerned.
 
-If juju respected the `limit` field in relation [metadata](./authors-charm-
-metadata.html), it would be possible to work around this, but it's not a high-
+If juju respected the `limit` field in relation [metadata](./authors-charm-metadata.html),
+it would be possible to work around this, but it's not a high-
 priority [bug](https://bugs.launchpad.net/bugs/1089297): most provider services
 _should_ be able to handle multiple requirers anyway; and most requirers will
 only be connected to one provider anyway.
@@ -256,6 +256,6 @@ you can to the log before you do so.
   - They write only _very_ sparingly to the
 [charm directory](./authors-charm-components.html).
 
-We recommend you also familiarise yourself with the [best practices](./authors-
-charm-best-practice.html) and, if you plan to distribute your charm, the [charm
+We recommend you also familiarise yourself with the [best practices]
+(./authors-charm-best-practice.html) and, if you plan to distribute your charm, the [charm
 store policy](./authors-charm-policy.html).

--- a/src/en/authors-charm-icon.md
+++ b/src/en/authors-charm-icon.md
@@ -40,7 +40,7 @@ first place, then fear not, because we have an easy step-by-step guide for you.
 Before you start you will need:
 
   - A vector graphic editor. We strongly recommend the cross-platform and most excellent [ Inkscape ](http://www.inkscape.org) for all your vector graphic needs.
-  - The template file, [ which you can download from this link ](../media/icon.svg)
+  - The template file, [ which you can download from this link ](./media/icon.svg)
   - An existing logo you can import, or the ability to draw one in Inkscape
 
 Once you have those, fire up Inkscape and we can begin!

--- a/src/en/authors-charm-icon.md
+++ b/src/en/authors-charm-icon.md
@@ -40,7 +40,7 @@ first place, then fear not, because we have an easy step-by-step guide for you.
 Before you start you will need:
 
   - A vector graphic editor. We strongly recommend the cross-platform and most excellent [ Inkscape ](http://www.inkscape.org) for all your vector graphic needs.
-  - The template file, [ which you can download from this link ](./media/icon.svg)
+  - The template file, [ which you can download from this link ](../media/icon.svg)
   - An existing logo you can import, or the ability to draw one in Inkscape
 
 Once you have those, fire up Inkscape and we can begin!

--- a/src/en/authors-charm-metadata.md
+++ b/src/en/authors-charm-metadata.md
@@ -83,7 +83,7 @@ compatible with. This is useful when the code uses features introduced in a
 specific version of Juju. When supplied this value is the lowest version of
 Juju controller that will run the charm.
 
-[Storage](./developer-storage.md) can also be declared in a charm's metadata,
+[Storage](./developer-storage.html) can also be declared in a charm's metadata,
 as such:
 
 ```yaml

--- a/src/en/authors-charm-policy.md
+++ b/src/en/authors-charm-policy.md
@@ -1,4 +1,4 @@
-Title: Charm store policy  
+Title: Charm store policy
 
 # Charm store policy
 
@@ -29,7 +29,7 @@ Not following these guidelines will result in an ERROR (E:) in `charm test`:
         satisfies this due to the apt and yum sources including cryptographic
         signing information.
     - Third party repositories must be listed as a configuration option that
-        can be overridden by the user and not hard coded in the charm itself. 
+        can be overridden by the user and not hard coded in the charm itself.
     - Launchpad PPAs are acceptable as the `add-apt-repository` command
         retrieves the keys securely.
     - Other third party repositories are acceptable if the signing key is
@@ -46,7 +46,7 @@ Not following these guidelines will result in an ERROR (E:) in `charm test`:
 Not following these guidelines will result in a WARNING (W:) in `charm test`:
 
 - Should be built using [charm layers](authors-charm-building.html).
-- Should be delivered using Juju Resources by default. 
+- Should be delivered using Juju Resources by default.
 
 ## Testing and quality guidelines
 
@@ -98,7 +98,7 @@ Not following these guidelines will result in an ERROR (E:) in `charm test`:
   - Must define external dependencies, if applicable.
 
   <hr>
-  
+
 Not following these guidelines will result in a WARNING (W:) in `charm test`:
 
 - Should link to a recommend production usage bundle and recommended
@@ -117,7 +117,7 @@ Not following these guidelines will result in an ERROR (E:) in `charm test`:
   - `wget | sh` style is not ok.
 
   <hr>
-  
+
 Not following these guidelines will result in a WARNING (W:) in `charm test`:
 
 - Should make use of whatever Mandatory Access Control system is provided by
@@ -144,8 +144,9 @@ policy, and thus is removed from the recommended status in the Juju Charm Store.
 
 This file is an [important component](authors-charm-components.html) of a charm.
 
-Check out the [MySQL metadata.yaml](https://bazaar.launchpad.net/~charmers/charm
-s/precise/mysql/trunk/view/head:/metadata.yaml) as an example.
+Check out the [MySQL metadata.yaml]
+(https://bazaar.launchpad.net/~charmers/charms/precise/mysql/trunk/view/head:/metadata.yaml) 
+as an example.
 
 ## config.yaml
 

--- a/src/en/authors-relations.md
+++ b/src/en/authors-relations.md
@@ -25,7 +25,7 @@ They have to match.
 ### Provides and Requires
 
 The `provides` and `requires` keys defined in
-[metadata.yaml](./authors-charm-metadata) are used to define pairings of charms
+[metadata.yaml](./authors-charm-metadata.html) are used to define pairings of charms
 that are likely to be fruitful. Consider mongodb's metadata:
 
 ```no-highlight
@@ -109,7 +109,7 @@ controls the set of remote units that are reported to the unit as members of
 the relation: container-scoped relations are restricted to reporting details
 of a single principal unit to a single subordinate, and vice versa, while
 global relations consider all possible remote units.
-[Subordinate](authors-charm-subordinates.html) charms are only valid if they
+[Subordinate](./authors-subordinate-services.html) charms are only valid if they
 have at least one `requires` relation with `container` scope.
 
 - `limit` is ignored by Juju, but if present should be a positive integer N

--- a/src/en/authors-service-config.md
+++ b/src/en/authors-service-config.md
@@ -4,10 +4,13 @@ Title: Service configuration
 
 ## Introduction
 
-A [Charm](./charm.html) often will require access to specific options or
+A [Charm](./charms.html) often will require access to specific options or
 configuration. Charms allow for the manipulation of the various configuration
-options which the charm author has chosen to expose. juju provides tools to help manage these options and respond to changes in these options over the lifetime of the service deployment. These options apply to the entire service, as opposed to only a specific unit or relation. Configuration is modified by an
-administrator at deployment time or over the lifetime of the services.
+options which the charm author has chosen to expose. juju provides tools to
+help manage these options and respond to changes in these options over the
+lifetime of the service deployment. These options apply to the entire service,
+as opposed to only a specific unit or relation. Configuration is modified by
+an administrator at deployment time or over the lifetime of the services.
 
 As an example a wordpress service may expose a 'blog-title' option. This option
 would control the title of the blog being published. Changes to this option
@@ -21,9 +24,17 @@ provide a set command to aid the administrator in changing values.
 
     juju set <service name> option=value [option=value]
 
-This command allows changing options at runtime and takes one or more name/value pairs which will be set into the service options. Configuration options which are set together are delivered to the services for handling together. E.g. if you are changing a username and a password, changing them individually may yield bad results since the username will temporarily be set with an incorrect password.
+This command allows changing options at runtime and takes one or more
+name/value pairs which will be set into the service options. Configuration
+options which are set together are delivered to the services for handling
+together. E.g. if you are changing a username and a password, changing them
+individually may yield bad results since the username will temporarily be set
+with an incorrect password.
 
-While its possible to set multiple configuration options on the command line its also convenient to pass multiple configuration options via the --file argument which takes the name of a YAML file. The contents of this file will be applied as though these elements had been passed to juju set.
+While its possible to set multiple configuration options on the command line
+its also convenient to pass multiple configuration options via the --file
+argument which takes the name of a YAML file. The contents of this file will
+be applied as though these elements had been passed to juju set.
 
 A configuration file may be provided at deployment time using the --config
 option, as follows:
@@ -53,7 +64,12 @@ directory. The configuration options supported by a service are defined within
 its respective charm. juju will only allow the manipulation of options which
 were explicitly defined as supported.
 
-The specification of possible configuration values is intentionally minimal, but still evolving. Currently the charm define a list of names which they react. Information includes a human readable description and an optional default value. Additionally type may be specified. All options have a default type of 'str' which means its value will only be treated as a text string. Other valid options are 'int' and 'float'.
+The specification of possible configuration values is intentionally minimal,
+but still evolving. Currently the charm define a list of names which they
+react. Information includes a human readable description and an optional
+default value. Additionally type may be specified. All options have a default
+type of 'str' which means its value will only be treated as a text
+string. Other valid options are 'int' and 'float'.
 
 The following config.yaml would be included in the top level directory of a
 charm and includes a list of option definitions:
@@ -72,25 +88,42 @@ To access these configuration options from a hook we provide the following:
 
     config-get [option name]
 
-config-get returns all the configuration options for a service as JSON data when no option name is specified. If an option name is specified the value of that option is output according to the normal rules and obeying the --output and --format arguments. Hooks implicitly know the service they are executing for and config-get always gets values from the service of the hook.
+config-get returns all the configuration options for a service as JSON data
+when no option name is specified. If an option name is specified the value of
+that option is output according to the normal rules and obeying the --output
+and --format arguments. Hooks implicitly know the service they are executing
+for and config-get always gets values from the service of the hook.
 
 Changes to options (see previous section) trigger the charm's config-changed
-hook. The config-changed hook is guaranteed to run after any changes are made to the configuration, but it is possible that multiple changes will be observed at once. Because its possible to set many configuration options on a single command line invocation it is easily possible to ensure related options are available to the service at the same time.
+hook. The config-changed hook is guaranteed to run after any changes are made
+to the configuration, but it is possible that multiple changes will be
+observed at once. Because its possible to set many configuration options on a
+single command line invocation it is easily possible to ensure related options
+are available to the service at the same time.
 
-The config-changed hook must be written in such a way as to deal with changes to one or more options and deal gracefully with options that are required by the charm but not yet set by an administrator. Errors in the config-changed hook force juju to assume the service is no longer properly configured. If the
+The config-changed hook must be written in such a way as to deal with changes
+to one or more options and deal gracefully with options that are required by
+the charm but not yet set by an administrator. Errors in the config-changed
+hook force juju to assume the service is no longer properly configured. If the
 service is not already in a stopped state it will be stopped and taken out of
-service. The status command will be extended in the future to report on workflow and unit agent status which will help reveal error conditions of this nature.
+service. The status command will be extended in the future to report on
+workflow and unit agent status which will help reveal error conditions of this
+nature.
 
 When options are passed using juju deploy their values will be read in from a
 file and made available to the service prior to the invocation of the its
 install hook. The install and start hooks will have access to config-get and
-thus complete access to the configuration options during their execution. If theinstall or start hooks don't directly need to deal with options they can simply invoke the config-changed hook.
+thus complete access to the configuration options during their execution. If
+theinstall or start hooks don't directly need to deal with options they can
+simply invoke the config-changed hook.
 
 ## Internals
 
-**Note**: This section explains details useful to the implementation but not of interest to the casual reader.
+**Note**: This section explains details useful to the implementation but not
+  of interest to the casual reader.
 
 Hooks normally attempt to provide a consistent view of the shared state of the
 system and the handling of config options within hooks (config-changed and the
-relation hooks) is no different. The first access to the configuration data of a service will retain a cached copy of the service options. Cached data will be
-used for the duration of the hook invocation.
+relation hooks) is no different. The first access to the configuration data of
+a service will retain a cached copy of the service options. Cached data will
+be used for the duration of the hook invocation.

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -317,7 +317,7 @@ To use binding with bundles, see the related section in
 [Using and creating bundles](./charms-bundles.html).
 
 To learn about `extra-bindings`, which provide a way to declare an extra
-bindable endpoint that is not a relation, see [Charm metadata](./charm-metadata.html).
+bindable endpoint that is not a relation, see [Charm metadata](./authors-charm-metadata.html).
 
 
 ## Juju retry-provisioning

--- a/src/en/charms-scaling.md
+++ b/src/en/charms-scaling.md
@@ -1,5 +1,5 @@
 Title: Scaling applications
-TODO: Check final note still relevant for 2.0 release  
+TODO: Check final note still relevant for 2.0 release
 
 # Scaling applications
 
@@ -33,7 +33,7 @@ The command options are:
 
 ## Scaling behind a Load Balancer
 
-Usually you just can't add more units to an application and have it magically 
+Usually you just can't add more units to an application and have it magically
 cale - you need to use a load balancer. In this case you can just deploy a
 proxy in front of your units; let's deploy a load balanced MediaWiki:
 
@@ -47,7 +47,7 @@ juju expose haproxy
 ```
 
 The haproxy charm configures and installs an
-HAProxy ([http://haproxy.1wt.eu/](http://haproxy.1wt.eu/)) application, the 
+HAProxy ([http://haproxy.1wt.eu/](http://haproxy.1wt.eu/)) application, the
 widely used TCP/HTTP load balancer. When you add a relation between the
 MediaWiki instance and HAProxy, it will be configured to load balance requests
 to that application. Note that this means the web traffic should be directed to
@@ -127,14 +127,14 @@ juju add-unit mysql --to 23
 ```
 ...adds a unit to machine 23,
 
-```bash 
-juju add-unit mysql --to 24/lxc/3 
+```bash
+juju add-unit mysql --to 24/lxc/3
 ```
 ...adds a unit to lxc container 3 on host machine 24.
 
-It is worth noting that not all applications will happily co-exist and it is much 
+It is worth noting that not all applications will happily co-exist and it is much
 safer to create a new container when co-locating:
-  
+
 ```bash
 juju add-unit mysql --to lxc:25
 ```
@@ -183,7 +183,7 @@ remove multiple units in the same command:
 juju remove-unit mediawiki/1 mediawiki/2 mediawiki/3 mediawiki/4 mediawiki/5
 ```
 !!! Note: the unit numbers may not necessarily be sequential, see the
-[notes on machine/unit numbering](./reference-numbering)
+[notes on machine/unit numbering](./reference-numbering.html)
 
 
 The `remove-unit` command can be run to remove running units safely. The
@@ -191,14 +191,14 @@ running applications should automatically adjust to the change. If the machine
 the removed unit was running on is not being used as a controller, or hosting
 other Juju managed containers, it will be destroyed automatically.
 
-!!! Note: If a machine has no running units, controllers or containers, and 
+!!! Note: If a machine has no running units, controllers or containers, and
 hasn't been removed automatically, it can be removed with the `remove-machine`
 command. For example, to remove machine 1 that the unit `mediawiki/1` was
-housed on, use the command: 
-    
+housed on, use the command:
+
 ```bash
 juju remove-machine 1
 ```
 
 For more information on removing applications, please see the section on
-[destroying applications](charms-destroy.html).
+[destroying applications](./charms-destroy.html).

--- a/src/en/clouds-LXD.md
+++ b/src/en/clouds-LXD.md
@@ -1,8 +1,8 @@
 Title: Juju LXD local provider
 
-# Using LXD as a cloud 
+# Using LXD as a cloud
 
-LXD provides a fast, powerful, self-contained and largely configuration-free 
+LXD provides a fast, powerful, self-contained and largely configuration-free
 way to experiment with Juju. Using lightweight LXC containers as instances,
 even a moderately powerful laptop can create useful models, or serve as
 a development platform for your own charms.
@@ -62,9 +62,9 @@ See more examples of [Creating a controller][bootstrap].
 
 ## Next steps
 
-A controller is created with two models - the 'controller' model which 
-should be reserved for Juju's operations, and a model named 'default' 
-for deploying user workloads. 
+A controller is created with two models - the 'controller' model which
+should be reserved for Juju's operations, and a model named 'default'
+for deploying user workloads.
 
  - [More information on models][models]
  - [Using Charms to deploy applications][charms]
@@ -146,7 +146,7 @@ how to
 [configure the lxd daemon and containers][lxd-upstream]
 .
 
-For additional configuration of LXD controllers, please see the [Controllers 
+For additional configuration of LXD controllers, please see the [Controllers
 documentation][controllers].
 
 [models]: ./models.html

--- a/src/en/clouds-maas-manual.md
+++ b/src/en/clouds-maas-manual.md
@@ -64,4 +64,4 @@ testmaas           0                 maas        Metal As A Service
 It is necessary to add credentials for these clouds before bootstrapping them.
 See the [Documentation on MAAS credentials here][maas-credentials].
 
-[maas-credentials]: ./clouds-maas#adding-your-maas-credentials
+[maas-credentials]: ./clouds-maas.html#adding-your-maas-credentials

--- a/src/en/clouds-maas.md
+++ b/src/en/clouds-maas.md
@@ -3,12 +3,12 @@ Title: Using MAAS with Juju
 
 # Using a MAAS cloud
 
-Juju works closely with [MAAS][maas-site] to deliver the same experience 
+Juju works closely with [MAAS][maas-site] to deliver the same experience
 on bare metal that you would get using any other cloud.
 
 ## Registering a MAAS cloud with Juju
 
-Using the Juju `add-cloud` command, it is easy to add your MAAS clouds to 
+Using the Juju `add-cloud` command, it is easy to add your MAAS clouds to
 Juju's list of known clouds. The command is interactive, and will ask for
 a name and the endpoint to use. A sample session is shown below.
 
@@ -39,7 +39,7 @@ You may bootstrap with 'juju bootstrap mainmaas'
 
 This will add both the 'mainmaas' cloud, which you can confirm
 by running:
- 
+
 ```bash
 juju clouds
 ```
@@ -74,7 +74,7 @@ sudo maas-region apikey --username=<user>
 **Note:** Juju does not echo this key back to the screen.
 
 Now you can create a Juju controller with the bootstrap command:
- 
+
 ```bash
 juju bootstrap mainmaas mainmaas-controller
 ```
@@ -83,10 +83,10 @@ Above, the Juju controller was called 'mainmaas-controller'.
 
 ## Manually defining MAAS clouds
 
-If for any reason you would rather define all your MAAS clouds in a 
+If for any reason you would rather define all your MAAS clouds in a
 single YAML configuration file, Juju can also import cloud definitions.
-For more details on this, see the 
+For more details on this, see the
 [documentation on manually adding MAAS clouds][maas-manual]
 
 [maas-site]: https://maas.io
-[maas-manual]: ./clouds-maas-manual
+[maas-manual]: ./clouds-maas-manual.html

--- a/src/en/clouds-manual.md
+++ b/src/en/clouds-manual.md
@@ -2,15 +2,15 @@ Title: Adding a manual cloud
 
 # Using a "Manual" cloud
 
-Juju caters for the 
-case where you may not be able to access a more traditional cloud in a 
-straightforward way; maybe you can't create additional instances, or perhaps 
+Juju caters for the
+case where you may not be able to access a more traditional cloud in a
+straightforward way; maybe you can't create additional instances, or perhaps
 your cloud is really a collection of disparate hardware.
 
-Whatever the case, as long as Juju can log into these machines they can be used 
+Whatever the case, as long as Juju can log into these machines they can be used
 as part of a Juju cloud. It won't be _quite_ the same as using a standard cloud
 - without the ability to create new instances when they are desired, you will
-be missing out on some of the Juju magic. You can still deploy and manage 
+be missing out on some of the Juju magic. You can still deploy and manage
 applications though, with a bit of extra effort.
 
 ## Prerequisites for using a manual cloud:
@@ -23,9 +23,9 @@ applications though, with a bit of extra effort.
 
 ## Bootstrapping the cloud
 
-As with other clouds, Juju needs to create a controller to manage models and 
-other instances in the cloud. Bootstrapping is the same as for 'regular' 
-clouds, except in this case, after the cloud type you should supply the network 
+As with other clouds, Juju needs to create a controller to manage models and
+other instances in the cloud. Bootstrapping is the same as for 'regular'
+clouds, except in this case, after the cloud type you should supply the network
 address of the machine you wish to use as the controller:
 
 ```bash
@@ -38,16 +38,16 @@ Note that it is also possible to use the other common bootstrap parameters here
 ## Adding machines to the cloud
 
 The `bootstrap` command creates the controller and initial models that Juju
-uses. Deploying applications will require additional machines to be made 
+uses. Deploying applications will require additional machines to be made
 available though. The more conventional Juju cloud types can create machines
 automatically, but in the case of a manual cloud you will have to specify these
 resources.
 
-This is done by using the `add-machine` command in Juju. This will install the 
+This is done by using the `add-machine` command in Juju. This will install the
 default series on a given resource, and prepare it for
 deploying applications.
 
-For example, if you have a machine with the IP address 192.168.1.129, you could 
+For example, if you have a machine with the IP address 192.168.1.129, you could
 add it to your manual cloud with the command:
 
 ```bash
@@ -60,24 +60,24 @@ sudo privileges on the remote machine, you will be asked for the password once
 again as the installer initialises.
 
 The process should not take too long, and you will see messages on the screen as
-the various stages progress. Once the command has returned, you can check 
+the various stages progress. Once the command has returned, you can check
 the machine is available by running:
 
 ```bash
 juju status
 ```
 
-## Deploying 
+## Deploying
 
 Usually Juju will create machines as it needs them. By default, using a charm
-to deploy an application will automatically create a machine first and then 
-deploy the new application. 
+to deploy an application will automatically create a machine first and then
+deploy the new application.
 
 With a manual cloud, you need to create your machines in advance, so Juju will
 need to know which of the machines you wish to target when you deploy a charm
 (or scale out). This can be done with the use of the
-[placement directives][placement]: you need to use the 
-'--to' option to specify the destination, which is either a machine or a 
+[placement directives][placement]: you need to use the
+'--to' option to specify the destination, which is either a machine or a
 container on a machine:
 
 ```bash
@@ -89,7 +89,7 @@ juju deploy wordpress --to 0
 
 There are some additional things to note when using the Manual provider:
 
- - Machines are known to the model Juju is using. If you destroy the model and 
+ - Machines are known to the model Juju is using. If you destroy the model and
    create a new one, you will have to add the machines again to the new model.
  - To improve performance, consider running a local APT proxy (see also
    [configuring a model][models-config]).
@@ -97,5 +97,5 @@ There are some additional things to note when using the Manual provider:
 
 
 [models-config]: ./models-config.html
-[placement]: ./charms-deploying#deploying-to-specific-machines-and-containers
+[placement]: ./charms-deploying.html#deploying-to-specific-machines-and-containers
 [commands]: ./commands.html

--- a/src/en/clouds-openstack-manual.md
+++ b/src/en/clouds-openstack-manual.md
@@ -3,11 +3,11 @@ Title:Manually adding an OpenStack cloud
 
 # Manually adding an Openstack cloud
 
-There are cases where the cloud you want to use is not on Juju's list of known 
-clouds. In this case it is possible to create a [YAML][yaml] formatted file 
-with the information Juju requires and import this new definition. The file 
+There are cases where the cloud you want to use is not on Juju's list of known
+clouds. In this case it is possible to create a [YAML][yaml] formatted file
+with the information Juju requires and import this new definition. The file
 should follow this general format:
-  
+
 ```yaml
 clouds:
   <cloud_name>:
@@ -20,10 +20,10 @@ clouds:
 with the relevant values substituted in for the parts indicated
 (within '<' '>').
 
-For example, a typical OpenStack cloud on the local network you want to call 
+For example, a typical OpenStack cloud on the local network you want to call
 'mystack' would appear something like this:
 
-  
+
 ```yaml
 clouds:
     mystack:
@@ -34,27 +34,27 @@ clouds:
           endpoint: https://openstack.example.com:35574/v3.0/
 ```
 
-In this case the authentication url is at 
-https://openstack.example.com:35574/v3.0/, it has a region called 'dev1' and 
-the cloud accepts either access-key or username/password authentication 
+In this case the authentication url is at
+https://openstack.example.com:35574/v3.0/, it has a region called 'dev1' and
+the cloud accepts either access-key or username/password authentication
 methods.
 
-With the configuration file saved, you can add this cloud to Juju with the 
+With the configuration file saved, you can add this cloud to Juju with the
 `add-cloud` command:
 
 ```bash
 juju add-cloud <cloud-name> <config-file.yaml>
 ```
 
-The cloud name you supply here **must** match the name given in the YAML file, 
+The cloud name you supply here **must** match the name given in the YAML file,
 so for example:
 
 ```bash
 juju add-cloud mystack mystack-config.yaml
 ```
 
-Once the cloud has been added, it will appear on the list of known clouds 
-output by the `juju list-clouds` command. Note that the cloud name will be 
+Once the cloud has been added, it will appear on the list of known clouds
+output by the `juju list-clouds` command. Note that the cloud name will be
 highlighted to indicate that it is a locally added cloud.
 
 !["juju list-cloud with locally added cloud"](./media/list-clouds-local.png)
@@ -62,4 +62,4 @@ highlighted to indicate that it is a locally added cloud.
 It is necessary to add credentials for this cloud before Juju can bootstrap it.
 Please see the [Documentation on adding OpenStack credentials][openstack-credentials]
 
-[openstack-credentials]: ./help-openstack#adding-credentials
+[openstack-credentials]: ./help-openstack.html#adding-credentials

--- a/src/en/controllers.md
+++ b/src/en/controllers.md
@@ -32,11 +32,11 @@ Common tasks are summarized below.
 
 
 ^# Create a controller
-   
+
    Use the `juju bootstrap` command to create a controller.
 
          juju bootstrap [options] [filter pattern ...]
-   
+
    For examples see [Creating a controller](./controllers-creating.html).
 
    For complete explanation, syntax and examples see the
@@ -45,14 +45,14 @@ Common tasks are summarized below.
 
 
 ^# List controllers
-   
+
    Use the `juju controllers` command to list all controllers knowable by
    the current system user.
 
-         juju controllers [options] 
-   
+         juju controllers [options]
+
    The currently active controller is indicated in the list with an asterisk('*').
-   
+
    For complete explanation, syntax and examples see the
    [command reference page](./commands.html#controllers) or the `juju help
    controllers` command.
@@ -60,13 +60,13 @@ Common tasks are summarized below.
 
 
 ^# Show controller details
-   
+
    Use the `juju show-controller` command to show details for a controller.
    Information includes UUID, API endpoints, certificates, and bootstrap
    configuarion.
 
          juju show-controller [options]
-   
+
    For complete explanation, syntax and examples see the
    [command reference page](./commands.html#show-controller) or the `juju help
    show-controller` command.
@@ -74,15 +74,15 @@ Common tasks are summarized below.
 
 
 ^# Remove a controller
-   
+
    Use the `juju destroy-controller` command to remove a controller.
 
          juju destroy-controller [options]
-   
+
    For complete explanation, syntax and examples see the
    [command reference page](./commands.html#destroy-controller) or the `juju help
    destroy-controller` command.
-   
+
    Use the `juju kill-controller` command as a last resort if the controller is
    not accessible for some reason.
 
@@ -92,26 +92,26 @@ Common tasks are summarized below.
    provider tools/console. This command will first attempt to mimic the behaviour
    of the `juju destroy-controller` command and failover to the more drastic
    behaviour if that attempt fails.
-   
+
          juju kill-controller [options]
-   
+
    For complete explanation, syntax and examples see the
    [command reference page](./commands.html#kill-controller) or the `juju help
    kill-controller` command.
 
 
 ^# Use the Juju GUI
-   
+
    Each Juju controller creates a web-driven GUI as an alternative method of
    management. The GUI is capable of deploying, scaling and monitoring
    applications, as well as more advanced operations.
-   
-   More details on the GUI can be found in the [Juju GUI section][gui].
-   
 
-   
+   More details on the GUI can be found in the [Juju GUI section][gui].
+
+
+
 ^# Back up a controller
-   
+
    Juju allows one to create, restore and manage backup files containing the
    controller configuration/metadata. If the controller or its host machine
    fails, it is possible to recreate the controller from the backup.
@@ -120,9 +120,9 @@ Common tasks are summarized below.
 
    Note: coverage of client backups are included in the above resource.
 
-   
- 
- 
+
+
+
 ^# Implement HA (high availability)
 
    Each Juju controller can be made 'Highly Available' to add resilience to the
@@ -131,10 +131,10 @@ Common tasks are summarized below.
    HA for the applications deployed is a matter for the charms, and is covered
    in a separate topic,[charm HA][charm-ha].
 
-   
+
 
 ^# Restricting command usage
-   
+
    A controller administrator is responsible for granting permissions to
    users registered with a controller. This can be done by restricting what
    sorts of changes a user can make across the controller's models.
@@ -145,4 +145,4 @@ Common tasks are summarized below.
 
 [gui]: ./controllers-gui.html
 [ha]: ./controllers-ha.html
-[charm-ha]: ./charms-ha
+[charm-ha]: ./charms-ha.html

--- a/src/en/developer-debugging.md
+++ b/src/en/developer-debugging.md
@@ -1,4 +1,4 @@
-Title: Debugging Juju charm hooks  
+Title: Debugging Juju charm hooks
 
 # Debugging hooks
 
@@ -61,7 +61,7 @@ executes in. The `juju debug-hooks` command allows you to do exactly that,
 whether it's to debug a failed hook or to write and test new hook code.
 
 `juju debug-hooks` accepts a unit and an optional list of hooks to debug (which must be named individually
-in a space-delimited list) or no hook names, causing all hooks to be debugged:  
+in a space-delimited list) or no hook names, causing all hooks to be debugged:
 
 ```bash
 juju debug-hooks <application/unit> [hook-name hook-name2 ...]
@@ -155,11 +155,11 @@ back to the debug-hooks session to interact with the Juju environment.
 juju resolved mysql/0
 ```
 
-Starting with Juju version 2.0 hooks returning errors will be automatically 
+Starting with Juju version 2.0 hooks returning errors will be automatically
 retried periodically. However, the `juju resolved` command may still be
-used to retry the hook immediately. See the 
-[General configuration options](./models-config#retrying-failed-hooks)
-for more information on the automatic retry feature and how to disable this 
+used to retry the hook immediately. See the
+[General configuration options](./models-config.html#retrying-failed-hooks)
+for more information on the automatic retry feature and how to disable this
 behaviour.
 
 ## Debugging Reactive

--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -102,7 +102,7 @@ which to work. This involves creating three directories -- `layers`,
 
 The `layers` directory contains the source code of the layered charm covered in
 our examples. The `interfaces` directory is where you'd place any
-[interface-layers](./developer-layers-interfaces.md) you may wish to write, and the
+[interface-layers](./developer-layers-interfaces.html) you may wish to write, and the
 `charms` directory holds the assembled, ready to deploy charm.
 
 ```bash

--- a/src/en/developer-layers.md
+++ b/src/en/developer-layers.md
@@ -163,9 +163,9 @@ excellent example of how to write a layer for a PHP application.
 ## Building a layer into a charm
 
 The
-[Getting started guide](developer-getting-started#assemble-the-layers)
+[Getting started guide](./developer-getting-started.html#assemble-the-layers)
 contains steps on how to build a layer into a charm.
 
 !!! Note: You must have the
-[Charm Tools](developer-getting-started#charm-tools)
+[Charm Tools](./developer-getting-started.html#charm-tools)
 software installed to use the `charm build` command.

--- a/src/en/help-openstack.md
+++ b/src/en/help-openstack.md
@@ -2,13 +2,13 @@ Title: OpenStack clouds
 
 # OpenStack Clouds
 
-Although Juju doesn't have baked-in knowledge of *your* OpenStack cloud, it 
-does know how such clouds work in general. We just need to provide some 
+Although Juju doesn't have baked-in knowledge of *your* OpenStack cloud, it
+does know how such clouds work in general. We just need to provide some
 information to add it to the list of known clouds.
 
 ## Adding an OpenStack Cloud
 
-Using the Juju `add-cloud` command, it is easy to add your OpenStack clouds to 
+Using the Juju `add-cloud` command, it is easy to add your OpenStack clouds to
 Juju's list of known clouds. The command is interactive, and will ask for
 a name,endpoint,authorisation method(s) and regions to use. A sample session
 is shown below.
@@ -26,11 +26,11 @@ Cloud Types
  manual
  openstack
  vsphere
- 
+
 Select cloud type: openstack
-  
+
 Enter a name for your openstack cloud: devstack
-   
+
 Enter the API endpoint url for the cloud: https://openstack.example.com:35574/v3.0/
 
 Auth Types
@@ -38,34 +38,34 @@ Auth Types
  userpass
 
 Select one or more auth types separated by commas: access-key,userpass
- 
+
 Enter region name: dev1
-   
+
 Enter the API endpoint url for the region: https://openstack-dev.example.com:35574/v3.0/
-  
+
 Enter another region? (Y/n): n
 
 Cloud "devstack" successfully added
 You may bootstrap with 'juju bootstrap homestack'
 ```
 
-Note that it is possible to choose more than one authorisation method - just 
+Note that it is possible to choose more than one authorisation method - just
 separate the values with commas.
 
-Once the cloud has been added, it will appear on the list of known clouds 
-output by the `juju clouds` command. Note that the cloud name will be 
+Once the cloud has been added, it will appear on the list of known clouds
+output by the `juju clouds` command. Note that the cloud name will be
 highlighted to indicate that it is a locally added cloud.
 
 !["juju cloud with locally added cloud"](./media/list-clouds-local.png)
 
 It is also possible to define OpenStack clouds in a YAML formatted configuration
-file and register them with Juju. Please see the 
+file and register them with Juju. Please see the
 [documentation for manually adding Openstack clouds][manual-openstack] for details.
 
 ## Adding credentials
 
-If you source a novarc file for OpenStack, or use the default environmental 
-variables for accessing this cloud, you can simply get Juju to scan for the 
+If you source a novarc file for OpenStack, or use the default environmental
+variables for accessing this cloud, you can simply get Juju to scan for the
 credentials and add them.
 
 Run the command...
@@ -75,23 +75,23 @@ juju autoload-credentials
 ```
 
 Juju will search known locations, including environment variables, for
-credential information and present you with a set of choices for storing them. 
+credential information and present you with a set of choices for storing them.
 Simply follow the prompts.
 
-For other methods of adding credentials, please see the specific 
+For other methods of adding credentials, please see the specific
 [credentials documentation][credentials].
 
 
 
 ## Images and private clouds
 
-The above steps are all you need to use most OpenStack clouds which are 
-configured for general use. If this is your own cloud, you will also need to 
-additionally provide stream information so that the cloud can fetch the 
-relevant images for Juju to use. This is covered in the section on 
+The above steps are all you need to use most OpenStack clouds which are
+configured for general use. If this is your own cloud, you will also need to
+additionally provide stream information so that the cloud can fetch the
+relevant images for Juju to use. This is covered in the section on
 [private clouds][simplestreams].
 
 [yaml]: http://www.yaml.org/spec/1.2/spec.html
-[simplestreams]: ./howto-privatecloud
-[credentials]: ./credentials
-[manual-openstack]: ./clouds-openstack-manual
+[simplestreams]: ./howto-privatecloud.html
+[credentials]: ./credentials.html
+[manual-openstack]: ./clouds-openstack-manual.html

--- a/src/en/help-rackspace.md
+++ b/src/en/help-rackspace.md
@@ -5,20 +5,20 @@ Title: Help with Rackspace clouds
 Juju already has knowledge of the Rackspace cloud, so unlike previous versions there
 is no need to provide a specific configuration for it, it 'just works'. Rackspace
 will appear in the list of known clouds when you issue the command:
-  
+
 ```bash
 juju clouds
 ```
 And you can see more specific information (e.g. the supported regions and
 authentication types) by running:
-  
+
 ```bash
 juju show-cloud rackspace
 ```
-If at any point you believe Juju's information is out of date (e.g. Rackspace just 
+If at any point you believe Juju's information is out of date (e.g. Rackspace just
 announced support for a new region), you can update Juju's public cloud data by
 running:
-  
+
 ```bash
 juju update-clouds
 ```
@@ -29,13 +29,12 @@ Using Juju's interactive authentication, importing Rackspace credentials into
 Juju is a simple process. The only information you'll need is your Rackspace
 username, password and tenant name (which is actually a number):
 
- - **`username`** The name used to login to the 
-    [Rackspace cloud control panel](rscontrolpanel).
+ - **`username`** The name used to login to the Rackspace cloud control panel.
 
  - **`password`** The password used to login to the Rackspace cloud
-   control panel. 
+   control panel.
 
- - **`tenant-name`** The Rackspace account number. You can view this in 
+ - **`tenant-name`** The Rackspace account number. You can view this in
     the cloud control panel in the top-right corner (under your username), as
     shown in the following image:
 
@@ -51,7 +50,7 @@ juju add-credential rackspace
 The first question will ask for an arbitrary credential name, which you choose
 for yourself. This will be how you remember and refer to this Rackspace
 credential in Juju. The second question will ask you to select an 'Auth Type',
-with the options being either `access-key` or `userpass`. 
+with the options being either `access-key` or `userpass`.
 
 Enter `userpass` as the authentication type and then enter your username,
 password and tenant-name, as described above.
@@ -66,11 +65,10 @@ To create the controller, run the following command:
 juju bootstrap rackspace mycloud
 ```
 
-This will create a new controller called 'mycloud' with the configuration 
+This will create a new controller called 'mycloud' with the configuration
 values we entered earlier.
 
-This controller will now be visible in the
-[Rackspace cloud control panel](rscontrolpanel):
+This controller will now be visible in the Rackspace cloud control panel:
 
 ![bootstrap machine 0 in Rackspace portal](./media/config-rackspace_portal-machine_0.png)
 

--- a/src/en/reference-release-notes-1.md
+++ b/src/en/reference-release-notes-1.md
@@ -2,7 +2,7 @@ Title: Juju Release Notes
 
 # Release Notes History for 1.x series
 
-This section details all the available release notes for the 
+This section details all the available release notes for the
 1.x stable series of Juju
 
 The versions covered here are:
@@ -939,7 +939,7 @@ The versions covered here are:
   status-get --service
 
   set the status of the service:
-  status-set --service <maintenance | blocked | waiting | active> "message" 
+  status-set --service <maintenance | blocked | waiting | active> "message"
 
   The 'juju status' command includes the 'workload-status' and
   'service-status' in the report. for example:
@@ -985,9 +985,9 @@ The versions covered here are:
       export JUJU_CLI_VERSION=2
       juju status
 
-      NAME       STATUS  EXPOSED CHARM                      
-      mysql      unknown false   local:trusty/mysql-326     
-      wordpress  blocked false   local:trusty/wordpress-93  
+      NAME       STATUS  EXPOSED CHARM
+      mysql      unknown false   local:trusty/mysql-326
+      wordpress  blocked false   local:trusty/wordpress-93
 
   The legacy status values are omitted from output. You can use the
   '--yaml' option to see status in the Juju 1.x layout.
@@ -1470,7 +1470,7 @@ The versions covered here are:
     * New Style Restore
     * Improved Proxy Support for Restrictive Networks
     * New Charm Actions
-    * New blocks and Messages. 
+    * New blocks and Messages.
     * Experimental: Service Leader Elections
     * Experimental: Addressable LXC Containers and KVM Instances on AWS and MAAS
 
@@ -1529,30 +1529,30 @@ The versions covered here are:
   does so with the proper authentication scope.
 
   For more information please refer to
-  
+
   https://developers.google.com/accounts/docs/OAuth2ServiceAccount#creatinganaccount
-  
+
   and
-  
+
   https://developers.google.com/accounts/docs/OAuth2#serviceaccount
-  
+
 
   If the project's service account has any permissions problems go to the
   following page to fix them:
 
   https://console.developers.google.com/project/<project-id>/permissions
-  
+
   (remember to insert the *project id*)
 
   The GCE API should already be activated for the project. It it isn't,
   go to the following URL in your console:
- 
+
   https://console.developers.google.com/project/<project-name>/apiui/api
 
   (insert the *project name*)
 
   Also see step 2 on
-  
+
   https://cloud.google.com/compute/docs/api/how-tos/authorization.
 
   The following config options in your environments.yaml file are
@@ -1639,7 +1639,7 @@ The versions covered here are:
   the API and the unit level:
 
   https://jujucharms.com/docs/1.20/authors-charm-actions
-  
+
 
   CLI Actions are sub-commands of the 'juju action' command. For more
   details on their usage, 'juju action help' has examples and further
@@ -1703,13 +1703,13 @@ The versions covered here are:
   leader-settings-changed as soon as possible, delaying only doing so only
   to run the install hook; complete any queued or in-flight operation; or
   resolve a hook or upgrade error.
-   
-  Known limitations: 
+
+  Known limitations:
 
     * Amazon limits the number of addresses the containers an instance can
-      have based on its size. 
-    * Statically allocated addresses are not released on container shutdown. 
-    * Container addressability does not survive a host reboot. 
+      have based on its size.
+    * Statically allocated addresses are not released on container shutdown.
+    * Container addressability does not survive a host reboot.
     * No public IP address is added on AWS, and we don’t yet support
       dynamic port mapping -- so you can not yet expose containerized
       services on Amazon.
@@ -1803,7 +1803,7 @@ The versions covered here are:
       https://launchpad.net/~juju/+archive/1.22
 
   Windows and OS X users will find installers at:
- 
+
       https://launchpad.net/juju-core/+milestone/1.22.8
 
   ## Notable Changes
@@ -1934,10 +1934,10 @@ The versions covered here are:
   ## Notable Changes
 
   This releases addresses stability and performance issues.
-  
-  
+
+
   ### Vivid local-provider limitations
-  
+
   Juju 1.22.x on Vivid is suitable for creating and maintaining Juju
   environments in public and private clouds, including MAAS.
   Local-provider support for Vivid's default systemd installation will
@@ -1961,7 +1961,7 @@ The versions covered here are:
 
   https://launchpad.net/~juju/+archive/stable
 
-  And will appear in the release shortly thereafter. 
+  And will appear in the release shortly thereafter.
 
 
   ## Resolved issues
@@ -2400,12 +2400,12 @@ The versions covered here are:
   series in the following PPA:
 
   https://launchpad.net/~juju/+archive/stable
-  
+
   Windows and OS X users will find installers at:
-  
+
   https://launchpad.net/juju-core/+milestone/1.21.3
-  
-  
+
+
   ## Notable Changes
 
   This releases addresses stability and performance issues.
@@ -2708,7 +2708,7 @@ The versions covered here are:
   ### Choosing the nodes used to ensure high availability
 
   Just as ```juju bootstrap``` supports the ability to specify a particular
-  node using "--to" placement directives, so too can 
+  node using "--to" placement directives, so too can
   ```juju ensure-availability``` specify a comma separated list of machines to use
   for any newly required state servers. For example:
 
@@ -2764,7 +2764,7 @@ The versions covered here are:
   their own password.
 
   The user commands are grouped under the ```juju user``` command:
- 
+
   ```bash
   juju user
   usage: juju user <command> ...
@@ -3611,7 +3611,7 @@ The versions covered here are:
   * LXC template fails to stop
     Lp 1348386
 
-  * Distribution tarball has licensing problems that prevent 
+  * Distribution tarball has licensing problems that prevent
     redistribution
     Lp 1341589
 
@@ -3626,7 +3626,7 @@ The versions covered here are:
 
   juju-core 1.20.1 is available for utopic and backported to earlier
   series in the following PPA:
-  
+
   https://launchpad.net/~juju/+archive/stable
 
   ## Noteworthy
@@ -3813,7 +3813,7 @@ The versions covered here are:
   juju bootstrap --to zone=us-east-1b
   juju add-machine zone=us-east-1c
   ```
-  
+
   If you don't specify a zone explicitly, Juju will automatically and
   uniformly distribute units across the available zones within the region.
   Assuming the charm and the charm's service are well written, you can
@@ -3824,7 +3824,7 @@ The versions covered here are:
   ```bash
   juju deploy -n 10 <service>
   ```
-  
+
   When adding machines without an AZ explicitly specified, or when adding
   units to a service, the ec2 and openstack providers will now
   automatically spread instances across all available AZs in the region.
@@ -3852,11 +3852,11 @@ The versions covered here are:
   default. To revert to the previous behaviour, the
   'availability-sets-enabled' option must be set in environments.yaml like
   so:
-  
+
   ```yaml
   availability-sets-enabled: false
   ```
-  
+
   Placement is disabled when 'availability-sets-enabled' is true. The
   option cannot be disabled after the environment is bootstrapped.
 
@@ -3918,13 +3918,13 @@ The versions covered here are:
   message displayed. The module name is dotted. You can specify all or
   some of a module name to include or exclude messages from the log. This
   example progressively excludes more content from the logs
- 
+
   ```bash
   juju debug-log --exclude-module juju.state.apiserver
   juju debug-log --exclude-module juju.state
   juju debug-log --exclude-module juju
   ```
-  
+
   The 'include-module' and 'exclude-module' options can be used multiple
   times to select the modules you are interested in. For example, you can
   see the juju.cmd and juju.worker messages like this:
@@ -4098,7 +4098,7 @@ The versions covered here are:
   advised.
 
   ###Resolved issues
-  
+
   * juju sync-tools destroys the environment when given an invalid source Lp 1316869
   * Local provider behaves poorly when juju-mongodb is not installed
   on trusty Lp 1301538
@@ -4116,12 +4116,12 @@ The versions covered here are:
   juju-core 1.18.2 is available in trusty and backported to earlier
   series in the following PPA
     https://launchpad.net/~juju/+archive/stable
-  
+
   If you use the local provider, be sure to install the juju-local package
   if it is not already installed. Juju's local requirements have changed.
   Upgrading local juju environments without the juju-local package is not
   advised.
-  
+
 
   ###Resolved issues
 
@@ -4222,8 +4222,7 @@ The versions covered here are:
   ### Getting Juju
 
   juju-core 1.18.0 is available in trusty and backported to earlier series in
-  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launch
-  pad.net/%7Ejuju/+archive/stable)
+  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launchpad.net/%7Ejuju/+archive/stable)
 
   If you use the local provider, be sure to install the juju-local package if it
   is not already installed. Juju’s local requirements have changed. Upgrading
@@ -4602,8 +4601,7 @@ The versions covered here are:
   ### Getting Juju
 
   juju-core 1.16.4 is available in trusty and backported to earlier series in
-  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launch
-  pad.net/%7Ejuju/+archive/stable)
+  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launchpad.net/%7Ejuju/+archive/stable)
 
   ### Resolved issues
 
@@ -4620,8 +4618,7 @@ The versions covered here are:
   ### Getting Juju
 
   juju-core 1.16.3 is available in trusty and backported to earlier series in
-  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launch
-  pad.net/%7Ejuju/+archive/stable)
+  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launchpad.net/%7Ejuju/+archive/stable)
 
 
   ### Resolved issues
@@ -4637,8 +4634,7 @@ The versions covered here are:
   ### Getting Juju
 
   juju-core 1.16.2 is available in trusty and backported to earlier series in
-  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launch
-  pad.net/%7Ejuju/+archive/stable)
+  the following PPA [https://launchpad.net/~juju/+archive/stable](https://launchpad.net/%7Ejuju/+archive/stable)
 
 
   ### Resolved issues

--- a/src/en/tools-charm-tools.md
+++ b/src/en/tools-charm-tools.md
@@ -1,4 +1,4 @@
-Title: Charm tools  
+Title: Charm tools
 
 The 'Charm Tools' Juju Plugin is a collection of commands enabling users
 and charm authors to create, search, fetch, update, and
@@ -33,8 +33,8 @@ Charm Tools is available for, and tested on, Microsoft Windows 7 and 8. While
 the installer may work on previous versions of Windows there is no guarantee.
 
 To install, first download the Charm Tools installer from
-[launchpad](https://launchpad.net/charm-tools/1.2/1.2.9/+download/charm-
-tools_1.2.9.exe). Once downloaded, execute the installer and follow the on-
+[launchpad](https://launchpad.net/charm-tools/1.2/1.2.9/+download/charm-tools_1.2.9.exe).
+Once downloaded, execute the installer and follow the on-
 screen prompts. After installation you can access Charm Tools via the
 `charm` command from either the command line or PowerShell.
 

--- a/src/en/troubleshooting.md
+++ b/src/en/troubleshooting.md
@@ -7,7 +7,6 @@ This section is dedicated to the troubleshooting of Juju when things go wrong.
 Make sure you have [Juju installed](./getting-started.html#installation) and
 configured correctly.
 
-- [Troubleshooting Juju itself](./troubleshooting-juju.html) - `Coming soon!`
 - [Juju logs](./troubleshooting-logs.html)
 - [Troubleshooting model upgrades](./troubleshooting-upgrade.html) - help for
 upgrading Juju across a model.

--- a/src/en/users.md
+++ b/src/en/users.md
@@ -12,11 +12,11 @@ duplicated across controllers.
 Juju users are not related in any way to the localhost system users; they are
 purely Juju constructs.
 
-A *controller administrator* is a user who has access to the controller model. 
+A *controller administrator* is a user who has access to the controller model.
 This Juju user is called 'admin' and is set up as part of the
 controller creation step. Practically, this set of users is comprised of the
 controller creator and any user the creator/initial_admin has granted write
-access to the 'controller' model. There is no overarching 
+access to the 'controller' model. There is no overarching
 "Juju administrator" since multiple controllers, and therefore multiple
 administrators, are possible.
 
@@ -94,7 +94,7 @@ For write access, the user can begin with the following major commands:
 Further reading:
 
 - A walkthrough of typical commands is provided in
-  [Workflow scenarios](./users-workflows#basic_setup_and_single_user.html).
+  [Workflow scenarios](./users-workflows.html#basic_setup_and_single_user.html).
 - Other write commands are listed on the
   [command reference page](./commands.html).
 - An explanation of how users gain access to models is provided in


### PR DESCRIPTION
Fixes #1319.
All broken links are now fixed. `make check-links-build` gives one false positive as seen below. It is required to stay like this until the blues_browser script `get_jujudocs.py` is updated to modify `../media` links. Currently those are ignored but `./media` links are handled correctly.

Running linkchecker should be required before landing any documentation changes, either by the writers or by Jenkins if it is put in place. We cannot allow broken links to creep back into the tree.  Some of the fixes I've made here have existed for a very long time and could have never worked, such as the references to `.md` files instead of `.html`.