### PR TITLE
Specify port range for python open_port

### DIFF
--- a/src/en/developer-hook-tools.md
+++ b/src/en/developer-hook-tools.md
@@ -294,8 +294,7 @@ from charmhelpers.core.hookenv import open_port
 open_port(80, protocol='TCP')
 
 # Open a range of ports
-for port in range(1000, 2000):
-    open_port(port, protocol='UDP')
+open_port("1000-2000", protocol='UDP')
 ```
 bash:  
 ```bash


### PR DESCRIPTION
We don't want to call `open_port` 1000 times, it's better to give `open_port` a port range as string.