### PR TITLE
fixed a couple pages which refer to services instead of applications

### DIFF
--- a/src/en/authors-charm-leadership.md
+++ b/src/en/authors-charm-leadership.md
@@ -2,12 +2,12 @@ Title: Implementing leadership in Juju charms
 
 # Leadership for the Charm author
 
-Leadership provides a mechanism whereby multiple units of a service can make
-use of a single, shared, authoritative source for charm-driven configuration
+Leadership provides a mechanism whereby multiple units of an application can
+make use of a single, shared, authoritative source for charm-driven configuration
 settings.
 
-Every service deployed by juju is guaranteed to have at most one leader at any
-time. This is true independent of what the charm author does; whether or not
+Every application deployed by juju is guaranteed to have at most one leader at
+any time. This is true independent of what the charm author does; whether or not
 you implement the hooks or use the tools, the unit agents will each seek to
 acquire leadership, and maintain it while they have it or wait for the current
 leader to drop out.
@@ -48,14 +48,14 @@ unprepossessing race scenarios.
     to verify continued leadership past lease expiry time, it would start to
     return false.
 
-Every service deployed by juju also has access to a pseudo-relation over which
-leader settings can be communicated with the following tools:
+Every application deployed by juju also has access to a pseudo-relation over
+which leader settings can be communicated with the following tools:
 
   * `leader-set` acts much like `relation-set`, in that it lets you write string
     key/value pairs (in which an empty value removes the key), but with the
     following differences:
 
-      * there's only one leader-settings bucket per service (not one per unit)
+      * there's only one leader-settings bucket per applicaiton (not one per unit)
       * only the leader can write to the bucket
       * only minions are informed of changes to the bucket
       * changes are propagated instantly, bypassing the sandbox
@@ -129,10 +129,11 @@ need additional synchronisation, you can use a peer relation to communicate
 minions' acknowledgements back to the leader.
 
 !!! Note: peer relation membership is not guaranteed to match current reality
-at any given time. To be resilient in the face of your service scaling at the
-same time as you (say) rebalance your service, your leader code will need to
-use the output of `status-get --service` to determine up-to-date membership,
-and wait for the set of acked units in the peer relation to match that list.
+at any given time. To be resilient in the face of your application scaling at
+the same time as you (say) rebalance your application, your leader code will
+need to use the output of `status-get --application` to determine up-to-date
+membership, and wait for the set of acked units in the peer relation to match
+that list.
 
 ### ...guarantee that a long-lived process runs on just one unit at once?
 

--- a/src/en/authors-charm-leadership.md
+++ b/src/en/authors-charm-leadership.md
@@ -6,7 +6,7 @@ Leadership provides a mechanism whereby multiple units of an application can
 make use of a single, shared, authoritative source for charm-driven configuration
 settings.
 
-Every application deployed by juju is guaranteed to have at most one leader at
+Every application deployed by Juju is guaranteed to have at most one leader at
 any time. This is true independent of what the charm author does; whether or not
 you implement the hooks or use the tools, the unit agents will each seek to
 acquire leadership, and maintain it while they have it or wait for the current
@@ -24,7 +24,7 @@ should implement the following hooks:
     some other unit writes leader settings).
 
 No particular guarantees can be made regarding the timeliness of the
-`leader-settings-changed` hook; it's always possible for the juju agent itself
+`leader-settings-changed` hook; it's always possible for the Juju agent itself
 to be taken out of commission at the wrong moment and not restarted for a long
 time.
 
@@ -48,14 +48,14 @@ unprepossessing race scenarios.
     to verify continued leadership past lease expiry time, it would start to
     return false.
 
-Every application deployed by juju also has access to a pseudo-relation over
+Every application deployed by Juju also has access to a pseudo-relation over
 which leader settings can be communicated with the following tools:
 
   * `leader-set` acts much like `relation-set`, in that it lets you write string
     key/value pairs (in which an empty value removes the key), but with the
     following differences:
 
-      * there's only one leader-settings bucket per applicaiton (not one per unit)
+      * there's only one leader-settings bucket per application (not one per unit)
       * only the leader can write to the bucket
       * only minions are informed of changes to the bucket
       * changes are propagated instantly, bypassing the sandbox
@@ -145,12 +145,12 @@ Juju's leadership concept is, by choice, relatively fine-grained, to ensure
 timely handover of agent-level responsibilities. That's why `is-leader` success
 guarantees only 30s of leadership; but it's no fun running a separate watchdog
 process to `juju-run is-leader` every 30s and kill your process when that stops
-working (apart from anything else, your juju-run could be blocked by other
+working (apart from anything else, your `juju-run` could be blocked by other
 operations, so you can't guarantee a run every 30s anyway).
 
 And we don't plan to allow coarser-grained leadership requests. This is because
 if one unit could declare itself leader for a day (or even an hour) a failed
-leader will leave other parts of juju blocked for that length of time, and we're
+leader will leave other parts of Juju blocked for that length of time, and we're
 not willing to take on that cost; the 30-60s handover delay is bad enough
 already.
 
@@ -169,20 +169,10 @@ If you start your long-lived process in `leader-elected`, and stop it in
 `leader-settings-changed`, this will *usually* do what you want, but is
 vulnerable to a number of failure modes -- both because hook execution may be
 blocked until after the leadership lease has actually expired, *and* because
-total juju failure could also cause the hook not to run (but leave the workload
+total Juju failure could also cause the hook not to run (but leave the workload
 untouched).
 
 In the future, we may implement a `leader-deposed` hook, that can run with
 *stronger* timeliness guarantees; but even if we do, it's a fundamentally
 unreliable approach. Seriously, if you possibly can, go with the charmed-up
 `hacluster` solution.
-
-
-
-
-
-
-
-
-
-

--- a/src/en/authors-hook-environment.md
+++ b/src/en/authors-hook-environment.md
@@ -1,4 +1,4 @@
-Title: The hook environment, hook tools and how hooks are run  
+Title: The hook environment, hook tools and how hooks are run
 
 # How hooks are run
 
@@ -46,7 +46,7 @@ In addition, every relation hook makes available relation-specific variables:
   - The `$JUJU_RELATION_ID` variable holds an opaque relation identifier, used
   to distinguish between multiple relations with the same name. It is vitally
   important, because it's the only reasonable way of telling the difference
-  between (say) a database service's many independent clients.
+  between (say) a database application's many independent clients.
 
 ...and, if that relation hook is not a 
 [-broken](authors-charm-hooks.html#[name]-relation-broken) hook:
@@ -156,7 +156,7 @@ foo.example.com
 
 ### config-get
 
-`config-get` returns information about the service configuration (as defined by
+`config-get` returns information about the application configuration (as defined by
 the charm). If called without arguments, it returns a dictionary containing all
 config settings that are either explicitly set, or which have a non-nil default
 value. If the `--all` flag is passed, it returns a dictionary containing all
@@ -325,7 +325,7 @@ relation-set deprecated-or-unused=
 ```
 
 `relation-set` is the single tool at your disposal for communicating your own
-configuration to units of related services. At least by convention, the charm
+configuration to units of related applications. At least by convention, the charm
 that `provides` an interface is likely to set values, and a charm that
 `requires` that interface will read them; but there's nothing forcing this.
 Whatever information you need to propagate for the remote charm to work must be
@@ -333,7 +333,7 @@ propagated via relation-set, with the single exception of the `private-address`
 key, which is always set before the unit joins.
 
 You may wish to overwrite the `private-address` setting, for example if you're
-writing a charm that serves as a proxy for some external service; but you 
+writing a charm that serves as a proxy for some external application; but you 
 should in general avoid _removing_ that key, because most charms expect that
 value to exist unconditionally.
 
@@ -417,10 +417,10 @@ the lifetime of the relation.
 
 !!! Note: `relation-get` currently has a
 [bug](https://bugs.launchpad.net/juju-core/+bug/1223339)
-that allows units of the same service to see each other's
+that allows units of the same application to see each other's
 settings outside of a peer relation. Depending on this behaviour inadvisable: if
-you need to share settings between units of the same service, always use a peer
-relation to do so, or you may be seriously inconvenienced when
+you need to share settings between units of the same application, always use a
+peer relation to do so, or you may be seriously inconvenienced when
 the hole is closed without notice.
 
 ### relation-list
@@ -454,7 +454,7 @@ relation-list -r website:2
 
 ### relation-ids
 
-`relation-ids` outputs a list of the related **services** with a relation 
+`relation-ids` outputs a list of the related **applications** with a relation 
 name. Accepts a single argument (relation-name) which, in a relation hook, 
 defaults to the name of the current relation. The output is useful as input 
 to the `relation-list`, `relation-get`, and `relation-set` commands to read 
@@ -494,12 +494,12 @@ the `status-set` hook tool.
 This hook tool takes 2 arguments. The first is the status to report, which can 
 be one of the following:
 
-  - maintenance (the unit is not currently providing a service, but expects to 
-    be soon, E.g. when first installing)
+  - maintenance (the unit is not currently providing a application, but expects
+    to be soon, E.g. when first installing)
   - blocked (the unit cannot continue without user input)
   - waiting (the unit itself is not in error and requires no intervention, 
     but it is not currently in service as it depends on some external factor, 
-    e.g. a service to which it is related is not running)
+    e.g. an application to which it is related is not running)
   - active (This unit believes it is correctly offering all the services it is
     primarily installed to provide)
 
@@ -514,7 +514,7 @@ can contain any useful information.
 This status message provides valuable feedback to the user about what is
 happening. Changes in the status message are not broadcast to peers and
 counterpart units - they are for the benefit of humans only, so tools
-representing Juju services (e.g. the Juju GUI) should check occasionally 
+representing Juju applications (e.g. the Juju GUI) should check occasionally 
 and be told the current status message.
 
 Spamming the status with many changes per second would not be welcome

--- a/src/en/developer-terms.md
+++ b/src/en/developer-terms.md
@@ -167,8 +167,8 @@ The output displays each term revision the user has agreed to:
 ## Upgrading terms
 
 Deployed charms will run under the terms they were installed with. If the terms
-have been revised, running `juju upgrade-charm <service>` will require the user
-to accept the new terms before the upgrade will run.
+have been revised, running `juju upgrade-charm <application>` will require the
+user to accept the new terms before the upgrade will run.
 
 
 # Caveats


### PR DESCRIPTION
Fixes #1645 
This is a short term fix for a bigger issue. The charms docs are outdated. We know this and are working toward a massive overhaul. In the meanwhile, this fixes references on a few pages. Much more work is needed and forthcoming.