### PR TITLE
Update tools-charm-tools.md

### DIFF
--- a/src/en/tools-charm-tools.md
+++ b/src/en/tools-charm-tools.md
@@ -14,7 +14,7 @@ The source project can be found at
 Install the charm snap:
 
 ```bash
-sudo snap install charm
+sudo snap install charm --classic
 ```
 
 ## Mac OSX


### PR DESCRIPTION
Fix the install string for the snap install.

The only other issue I ran into is that "--classic" is only supported if your snapd is new enough. It has been backported, but I did have to do "sudo apt upgrade" to get a new enough snapd. Probably we don't have to worry about that.