### PR TITLE
juju run executes as root user on machines

### DIFF
--- a/src/en/charms-working-with-units.md
+++ b/src/en/charms-working-with-units.md
@@ -88,6 +88,8 @@ juju run "uptime" --application=mysql
 
 !!! Note: When using `juju run` with the `--application` option, keep in mind
 that whichever command you pass will run on *every unit* of that application.
+When using `juju run` with the `--machine` option, the command is run as the
+`root` user on the remote machine.
 
 When used in combination with certain applications you can script certain tasks.
 For instance, in the 'hadoop' charm you can use `juju run` to initiate a

--- a/src/en/commands.md
+++ b/src/en/commands.md
@@ -5716,7 +5716,7 @@ Click on the expander to see details for each command.
    Multiple values can be set for --machine, --application, and --unit by using
    comma separated values.
 
-   If the target is a machine, the command is run as the "ubuntu" user on
+   If the target is a machine, the command is run as the "root" user on
    the remote machine.
 
    If the target is an application, the command is run on all units for that


### PR DESCRIPTION
Fixes #1708 
I realize that commands.md is auto-generated from the juju help text when we have new releases, but it was a one-word change, so I changed it manually now anyway to match the new help text.

There were no other mentions of which user would be used on the remote machine when using `juju run`, so I added one on the page that discusses `juju run` in detail.
@juju/docs