### PR TITLE
added links from creds pages to jaas onboarding

### DIFF
--- a/src/en/help-aws.md
+++ b/src/en/help-aws.md
@@ -67,6 +67,9 @@ add them to Juju:
 juju add-credential aws
 ```
 
+Alternately, you can also use this credential with [Juju as a Service][jaas] and
+create and deploy your model using its GUI.
+
 ### 3. Create and use a YAML file
 
 Place the AWS information in a `~/.aws/credentials` file, or
@@ -101,4 +104,5 @@ Features supported by Juju-owned instances running within AWS:
 
 [aws]: http://console.aws.amazon.com
 [constraints]:./reference-constraints.html
+[jaas]: ./getting-started-jaas.html "Getting Started with Juju as a Service"
 [tagging]: ./config-tagging.html

--- a/src/en/help-azure.md
+++ b/src/en/help-azure.md
@@ -269,6 +269,9 @@ APP_PASSWORD
 
 You can now [create the controller](#create-controller).
 
+Alternately, you can also use this credential with [Juju as a Service][jaas] and
+create and deploy your model using its GUI.
+
 !!! Note: If you add more than one credential, you will also need to set the
 default one to use with `juju set-default-credential`
 
@@ -285,3 +288,4 @@ availability sets affect uptime guarantees.
 [subscriptionblade]: https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade
 [azuredeviceauth]: https://login.windows.net/common/oauth2/deviceauth
 [azureportal]: http://portal.azure.com
+[jaas]: ./getting-started-jaas.html "Getting Started with Juju as a Service"

--- a/src/en/help-google.md
+++ b/src/en/help-google.md
@@ -125,4 +125,8 @@ The command will interactively prompt you for information about the credentials
 being added. For the authentication type, choose 'json' and then give the full
 path to the file downloaded.
 
+Alternately, you can also use this credential with [Juju as a Service][jaas] and
+create and deploy your model using its GUI.
+
 [gce-docs]: https://console.cloud.google.com/start "GCE Getting Started"
+[jaas]: ./getting-started-jaas.html "Getting Started with Juju as a Service"


### PR DESCRIPTION
@evilnick 
I added the same info to each page, right after the individualized "creating credentials" portions. Rather than put the generic "here's how you add credentials in JAAS" on each page, linking back with a short statement of why a user might not continue on the current page seemed reasonable.

Happy to discuss further and change...