### PR TITLE
Use quotes when setting more than 1 constraint

### DIFF
--- a/src/en/charms-constraints.md
+++ b/src/en/charms-constraints.md
@@ -56,14 +56,10 @@ juju deploy mariadb --constraints mem=4G
 To further ensure that it also has at least 2 CPU cores:
   
 ```bash
-juju deploy mariadb --constraints mem=4G cores=2
-```
-
-or, if you prefer to enclose all contraints in quotes:
-
-```bash
 juju deploy mariadb --constraints "mem=4G cores=2"
 ```
+
+!!! Note: When setting more than one constraint you will need to utilize quotes.
 
 To ignore any constraints which may have been previously set, you can assign a 
 'null' value. If the application or model constraints for the 'mariadb' charm
@@ -71,7 +67,7 @@ have already been set to 8 cpu-cores for example, you can ignore that constraint
 at deploy time with:
   
 ```bash
-juju deploy mariadb --constraints mem=4G cores= 
+juju deploy mariadb --constraints "mem=4G cores=" 
 ```
 
 In the event that a constraint cannot be met, the unit will not be deployed.


### PR DESCRIPTION
In my recent usage of Juju 2.1.1-xenial-amd64 I found I needed to use quotes when setting more than one constraint:

```
arosales@x230:~$ juju deploy ubuntu --constraints mem=4G cores=2
error: invalid application name "cores=2"
arosales@x230:~$ juju deploy --constraints mem=4G cores=2 ubuntu
ERROR cannot parse URL "cores=2": name "cores=2" not valid
arosales@x230:~$ juju deploy --constraints "mem=4G cores=2" ubuntu
Located charm "cs:ubuntu-10".
Deploying charm "cs:ubuntu-10".
arosales@x230:~$ juju version
2.1.1-xenial-amd64
arosales@x230:~$ 
```

If this is indeed correct this pull add quotes when using more than one constraint.