### PR TITLE
juju login needs a -u flag

### DIFF
--- a/src/en/users-creating.md
+++ b/src/en/users-creating.md
@@ -82,7 +82,7 @@ And to log back in, either on the same client system or not, using the same
 user we added earlier:
 
 ```bash
-juju login jon
+juju login -u jon
 ```
 
 Once a user logs in they become the current user. The following is a quick way

--- a/src/en/users-models.md
+++ b/src/en/users-models.md
@@ -152,9 +152,9 @@ owner and the external user, such as via email, and manually adding the
 controller information to the local user's `$HOME/.local/share/juju/controllers.yaml`
 in Ubuntu and other Linux distributions and the similar location in other OSes.
 
-The external user will log in from their machine with `juju login`. They will
-be directed to the URL for the external identity provider so that they may
-log in there and then will be granted access to the controller.
+The external user will log in from their machine with `juju login -u <username>`.
+They will be directed to the URL for the external identity provider so that
+they may log in there and then will be granted access to the controller.
 
 For the external user to create models from the controller, they must have
 credentials for that provider, for example, GCE or AWS. Any models created

--- a/src/en/users-sample-commands.md
+++ b/src/en/users-sample-commands.md
@@ -40,7 +40,7 @@ and switch to his controller:
 ```bash
 juju users
 juju switch lxd-sam
-juju login sam
+juju login -u sam
 ```
 
 The output becomes:


### PR DESCRIPTION
Will fix #1747 

I've made the obvious change to add `-u` to `juju login <user>` examples.

The commands.md page will be autogenerated after release by extracting help text, so any updates made to the help for `juju login` will be reflected in that automatically.

What I am unsure about is what does `juju login` do if we do not supply a username. Also, I'm not certain whether the users-models.md page needs an update.

@rogpeppe would you please review the small changes I've already made and then help me with the questions here?