### PR TITLE
Update the JAAS getting started docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+PY := .venv/bin/python
+PIP := .venv/bin/pip
+
 build:
 	tools/mdbuild.py
 
@@ -11,6 +14,12 @@ serve:
 
 todo:
 	tools/mdbuild.py --todo
+
+.venv: .venv/bin/python
+.venv/bin/python:
+	virtualenv -p python3 .venv
+	$(PIP) install html2text Markdown mdx-anchors-away mdx-callouts mdx-foldouts linkchecker
+
 sysdeps:
 	sudo apt-get install python-html2text python3-markdown python-pip python3-pip git spell ispell ibritish python3-setuptools
 	sudo pip3 install mdx-anchors-away mdx-callouts mdx-foldouts

--- a/src/en/getting-started-jaas.md
+++ b/src/en/getting-started-jaas.md
@@ -128,7 +128,7 @@ Use `juju --version` to double check your version of Juju.
 
 ## View your models
 
-Now that you're signed in to JAAS we can list your models running in any of the
+Now that you're signed in to JAAS you can list your models running in any of the
 supported clouds with:
 
 ```bash

--- a/src/en/getting-started-jaas.md
+++ b/src/en/getting-started-jaas.md
@@ -6,7 +6,7 @@ Juju as a Service (JAAS) is the fastest and easiest way to model and deploy
 your cloud-based applications. When you use JAAS, Canonical manages the Juju
 infrastructure. This frees you to concentrate on your software and solutions.
 With JAAS you can deploy, configure, and operate your applications on the
-largest public clouds [Amazon Web Services][aws], [Google Compute Engine][gce],
+largest public clouds: [Amazon Web Services][aws], [Google Compute Engine][gce],
 and [Microsoft Azure][azure].
 
 
@@ -90,20 +90,20 @@ Press the blue button to deploy the changes.
 
 </table>
 
-Adjust your model name, and choose a public cloud to deploy to.
+Adjust your model name and choose a public cloud to deploy to.
 Enter your cloud credentials. Scroll down and click Deploy.
 
 ![juju_jaas_choose_cloud](./media/juju_jaas_choose_cloud.png)
 
 
-Your model is now being deployed for you. Now let's wire up the command line
-so that we can see this model and operate against it.
+Your model is now being deployed for you. Now you can fire up the command line
+to see this model and operate against it.
 
 
 ## Accessing JAAS from the command line
 
-To use JAAS from the CLI requires that you install Juju on a local machine and
-connect that Juju install with your JAAS account.
+To use JAAS from the CLI requires that you install Juju and connect to your
+JAAS account.
 
 ## Install Juju
 
@@ -128,7 +128,7 @@ Use `juju --version` to double check your version of Juju.
 
 ## View your models
 
-Now that we're signed in to JAAS we can list our models running in any of the
+Now that you're signed in to JAAS we can list your models running in any of the
 supported clouds with:
 
 ```bash

--- a/src/en/getting-started-jaas.md
+++ b/src/en/getting-started-jaas.md
@@ -5,30 +5,17 @@ Title: Getting started with Juju as a Service
 Juju as a Service (JAAS) is the fastest and easiest way to model and deploy
 your cloud-based applications. When you use JAAS, Canonical manages the Juju
 infrastructure. This frees you to concentrate on your software and solutions.
-With JAAS you can deploy, configure, and operate your applications on public
-clouds like [Amazon Web Services][aws], [Google Compute Engine][gce], and
-[Microsoft Azure][azure].
+With JAAS you can deploy, configure, and operate your applications on the
+largest public clouds [Amazon Web Services][aws], [Google Compute Engine][gce],
+and [Microsoft Azure][azure].
 
-## Create an Ubuntu Single Sign On account
 
-JAAS uses [Ubuntu Single Sign On][ubuntuSSO] (SSO) for identity management. 
-If you don’t already have an Ubuntu SSO account, create one. The username
-you provide here is the one that will be used by JAAS.
+## Preparing your cloud credentials
 
-![juju-ubuntu-one.png](./media/jaas-ubuntu-one.png)
-
-## Obtain cloud credentials
-
-JAAS supports the following public clouds:
-
- * [Amazon Web Services (AWS)][aws]
- * [Google Compute Engine (GCE)][gce]
- * [Microsoft Azure][azure]
-
-We recommend that you use each public cloud's identity and access management
-(IAM) tool to generate a new set of credentials exclusively for use with JAAS.
-See [Cloud credentials][credentials] for more information, along with the
-following links for your specific cloud.
+We recommend that you use best practices and leverage each public cloud's
+identity and access management (IAM) tool to generate a new set of credentials
+exclusively for use with JAAS.  See [Cloud credentials][credentials] for more
+details, along with the following links for your specific cloud.
 
  * [AWS][awscreds]
  * [GCE][gcecreds]
@@ -38,9 +25,9 @@ following links for your specific cloud.
 
 Open the [JAAS login page][jaaslogin] to begin.
 
-Log in to JAAS using your Ubuntu SSO account. This will open a second tab in
-your web browser to log you in. If the tab does not open, check and disable any
-pop-up blockers that may be running and try again.
+Log in to JAAS using your [Ubuntu SSO account][ubuntuSSO]. This will open a
+second tab in your web browser to log you in. If the tab does not open, check
+and disable any pop-up blockers that may be running and try again.
 
 <style>
 table th, table td {
@@ -75,9 +62,8 @@ Press the green button to get started...
 
 Press the green + button on the page to start building your model.
 
-You will be shown a list of available charms and bundles with a description of
-each. Select a charm or bundle to learn more about it and decide whether to
-use it.
+Browse the store for the applications you need in your model. Once added to
+your model you can configure, scale, and relate it to connected applications.
 
 
 ![juju_jaas_charms_bundles](./media/jaas-search.png)
@@ -104,29 +90,63 @@ Press the blue button to deploy the changes.
 
 </table>
 
-Adjust your model name, if you desire, then choose a public cloud to deploy to.
+Adjust your model name, and choose a public cloud to deploy to.
 Enter your cloud credentials. Scroll down and click Deploy.
 
 ![juju_jaas_choose_cloud](./media/juju_jaas_choose_cloud.png)
 
-## Collaborate
 
-To share your model with another JAAS user you can share the standard Juju way,
-as described in [Users and models][users], or you can share directly from the
-JAAS GUI, like this.
+Your model is now being deployed for you. Now let's wire up the command line
+so that we can see this model and operate against it.
 
-Click the share button.
 
-![juju_jaas_top_panel](./media/juju_jaas_share_button.png)
+## Accessing JAAS from the command line
 
-Enter the username and set the permissions for the new user.
+To use JAAS from the CLI requires that you install Juju on a local machine and
+connect that Juju install with your JAAS account.
 
-![juju_jaas_share_screen](./media/juju_jaas_share_screen.png)
+## Install Juju
+
+Follow [these instructions][installjuju] to install Juju on your local machine.
+
+## Register or login to JAAS from Juju
+
+If you are using Juju 2.1, use:
+
+```bash
+juju register jimm.jujucharms.com
+```
+
+If you are using Juju 2.2, use:
+
+```bash
+juju login jaas
+```
+
+Use `juju --version` to double check your version of Juju.
+
+
+## View your models
+
+Now that we're signed in to JAAS we can list our models running in any of the
+supported clouds with:
+
+```bash
+juju models
+```
+
+To learn more about model related tasks, see [Models][models].
+
 
 ## Next steps
 
-Most users find the flexibility and power of using JAAS and Juju from the CLI
-rewarding. See [Using JAAS from the command line][jaascli] for more information.
+Now that you have a Juju powered model, it is time to explore the other
+amazing things you can do!
+
+We suggest you continue your journey by discovering
+[how to add controllers for additional clouds][tut-cloud].
+
+
 
 [azure]: ./help-azure.html "Using the Microsoft Azure public cloud"
 [azurecreds]: ./help-azure#credentials "Help with Azure credentials"
@@ -135,9 +155,12 @@ rewarding. See [Using JAAS from the command line][jaascli] for more information.
 [credentials]: ./credentials.html
 [gce]: ./help-google.html "Using the Google Compute Engine public cloud"
 [gcecreds]: ./help-google#download-credentials "Help with GCE credentials"
+[installjuju]: ./getting-started-general.html
 [jaascli]: ./jaas-cli.html "Using JAAS from the command line"
 [jaaslogin]: https://jujucharms.com/login "JAAS login page"
+[models]: ./models.html
 [ubuntuSSO]: https://login.ubuntu.com/ "Ubuntu single sign on"
+[tut-cloud]: ./tut-google.html
 [users]: ./users-models.html "Users and models"
 
 


### PR DESCRIPTION
- Try to make it a bit more smooth/jaas centric
- Add links and suggestions for putting it in place as the new default
getting-started page.
- Add back the CLI part in order to get users going along there.
- Update the Makefile so there's a venv option vs sysdeps so building works on
other systems.