### PR TITLE
deleted an unnecessary sentence and added a link with description

### DIFF
--- a/src/en/controllers-config.md
+++ b/src/en/controllers-config.md
@@ -10,7 +10,7 @@ the database and keeps track of all the models in that environment.
 
 Controller configuration consists of a collection of keys and their respective
 values. An explanation of how to both view and set these key:value pairs is
-provided below. Notable examples are provided at the end.
+provided below.
 
 
 ## Getting and setting values

--- a/src/en/controllers.md
+++ b/src/en/controllers.md
@@ -79,7 +79,7 @@ Common tasks are summarized below.
    as whether the controller will record auditing information. Configuration
    must happen as the controller is bootstrapped.
 
-   This is a complex subject. See [Configuring controllers](./controllers-config.html).
+   This topic is covered in more depth in the [configuring controllers section](./controllers-config.html).
 
 
 

--- a/src/en/controllers.md
+++ b/src/en/controllers.md
@@ -73,6 +73,16 @@ Common tasks are summarized below.
 
 
 
+^# Configure a controller
+
+   There are several settings which can be adjusted from their defaults, such
+   as whether the controller will record auditing information. Configuration
+   must happen as the controller is bootstrapped.
+
+   This is a complex subject. See [Configuring controllers](./controllers-config.html).
+
+
+
 ^# Remove a controller
 
    Use the `juju destroy-controller` command to remove a controller.


### PR DESCRIPTION
The deleted sentence was a holdover from the configuring models page and didn't make sense in the configuring controllers page.

The link was added to the main Juju controllers page to the new config page, paralleling the link from the Juju models page to the models config page. The description may need to be massaged, but it is a start.