### PR TITLE
Added info for setting MongoDB memory profile during bootstrap

### DIFF
--- a/src/en/controllers-config.md
+++ b/src/en/controllers-config.md
@@ -54,7 +54,7 @@ ca-cert                      | string |          |                          | Th
 controller-uuid              | string |          |                          | The key for the UUID of the controller
 identity-public-key          | string |          |                          | Sets the public key of the identity manager
 identity-url                 | string |          |                          | Sets the URL of the identity manager
-mongo-memory-profile         | string | low      | low/default              | Sets whether mongo uses the least possible memory or the default mongo memory profile
+mongo-memory-profile         | string | low      | low/default              | Sets whether MongoDB uses the least possible memory or the default MongoDB memory profile
 set-numa-control-policy      | bool   | false    | false/true               | Sets whether numactl is preferred for running processes with a specific NUMA (Non-Uniform Memory Architecture) scheduling or memory placement policy for multiprocessor systems where memory is divided into multiple memory nodes
 state-port                   | integer | 37017   |                          | The port to use for mongo connections
 

--- a/src/en/controllers-creating.md
+++ b/src/en/controllers-creating.md
@@ -102,6 +102,17 @@ be named using the non-default region, specifically naming it `aws-us-west-2`:
 juju bootstrap aws/us-west-2
 ```
 
+## Create a controller using a different MongoDB profile
+
+MongoDB has two memory profile settings available, `default` and `low`. The
+first setting is the profile shipped by default with MongoDB. The second is a
+more conservative memory profile that uses less memory. To select which one
+your controller uses when it is created, use:
+
+```bash
+juju bootstrap --config mongo-memory-profile=low
+```
+
 ## Change timeout and retry delays
 
 You can change the default timeout and retry delays used by Juju 


### PR DESCRIPTION
Fixes #1722 
@juju/docs

I had this partically complete last week when I created https://jujucharms.com/docs/devel/controllers-config as the MongoDB setting is listed on the page. Today, I have also added this as an example in the list on https://jujucharms.com/docs/devel/controllers-creating.

I also fixed a couple mentions of MongoDB that failed to use the proper spelling/capitalisation of the name.