### PR TITLE
Fix typo in authors-hook-environment.md

### DIFF
--- a/src/en/authors-hook-environment.md
+++ b/src/en/authors-hook-environment.md
@@ -507,12 +507,13 @@ To use `juju run` with `relation-ids` to see all the reverse proxy relations
 for an haproxy unit, for example, use:
 
 ```bash
-juju run --unit haproxy/0 'relation-ids reverseproxy'reverseproxy:110
+juju run --unit haproxy/0 'relation-ids reverseproxy'
 ```
 
 Which returns output like this:
 
 ```bash
+reverseproxy:110
 reverseproxy:111
 reverseproxy:112
 reverseproxy:113


### PR DESCRIPTION
This fixes a small typo in the example to show all the `relation-ids` for the `haproxy` unit