### PR TITLE
Corrected snap instructions for installing beta and edge juju versions

### DIFF
--- a/src/en/reference-install.md
+++ b/src/en/reference-install.md
@@ -106,13 +106,13 @@ You can update to the non-stable channels of Juju releases by using the snap
 command.
 
 ```bash
-   snap install <snap> --beta
+   sudo snap install juju --beta --classic
 ```
 
 Or you can get a daily build using the edge channel.
 
 ```bash
-   snap install <snap> --edge
+   sudo snap install juju --edge --classic
 ```
 
 


### PR DESCRIPTION
Minor change to correct the snap instructions required for installing beta or edge versions in Ubuntu