### PR TITLE
Add new max-txn-log-size attribute

### DIFF
--- a/src/en/controllers-config.md
+++ b/src/en/controllers-config.md
@@ -54,8 +54,9 @@ ca-cert                      | string |          |                          | Th
 controller-uuid              | string |          |                          | The key for the UUID of the controller
 identity-public-key          | string |          |                          | Sets the public key of the identity manager
 identity-url                 | string |          |                          | Sets the URL of the identity manager
-max-logs-age                 | string |          | 72h, etc.                | Sets the maximum age for log entries before they are pruned, in human-readable time format
-max-logs-size                | string |          | 400M, 5G, etc.           | Sets the maximum size for the log collection, in human-readable memory format
+max-logs-age                 | string | 72h      | 72h, etc.                | Sets the maximum age for log entries before they are pruned, in human-readable time format
+max-logs-size                | string | 4G       | 400M, 5G, etc.           | Sets the maximum size for the log collection, in human-readable memory format
+max-txn-log-size             | string | 10M      | 100M, 1G, etc.           | Sets the maximum size for the capped txn log collection, in human-readable memory format
 mongo-memory-profile         | string | low      | low/default              | Sets whether MongoDB uses the least possible memory or the default MongoDB memory profile
 set-numa-control-policy      | bool   | false    | false/true               | Sets whether numactl is preferred for running processes with a specific NUMA (Non-Uniform Memory Architecture) scheduling or memory placement policy for multiprocessor systems where memory is divided into multiple memory nodes
 state-port                   | integer | 37017   |                          | The port to use for mongo connections


### PR DESCRIPTION
Controller config now has a max-txn-log-size attribute.
This defaults to 10M but should be set to something like 100M on larger systems expected to host many models.