### PR TITLE
add JUJU_REPOSITORY deprecation notes

### DIFF
--- a/src/en/authors-charm-building.md
+++ b/src/en/authors-charm-building.md
@@ -245,7 +245,7 @@ Then we can deploy mysql and our new charm as usual:
 
 ```bash
 juju deploy mysql
-juju deploy local:trusty/vanilla
+juju deploy $JUJU_REPOSITORY/trusty/vanilla
 juju add-relation mysql vanilla
 juju expose vanilla
 ```

--- a/src/en/charm-review-process.md
+++ b/src/en/charm-review-process.md
@@ -164,19 +164,9 @@ While using the README as a reference, deploy the charm using the command
 below on your local model.
 
 ```bash
-juju deploy --repository=../../ local:precise/charm-name
-```
-
-Alternatively, you can set JUJU_REPOSITORY and deploy like the following:
-
-```bash
 export JUJU_REPOSITORY=/tmp
-juju deploy local:precise/charm-name
+juju deploy $JUJU_REPOSITORY/charm-name
 ```
-
-!!! Note: Remember to swap out `precise` for the series the charm is being
-tested for, like `trusty`.
-
 If the local deployment is successful, continue to the configuration section.
 
 !!! Note: If you have access to other cloud providers (like EC2), we

--- a/src/en/reference-environment-variables.md
+++ b/src/en/reference-environment-variables.md
@@ -35,19 +35,16 @@ where Juju kept configuration and other data.
 JUJU_HOME=~/.juju
 ```
 
-#### JUJU_REPOSITORY
+#### JUJU_REPOSITORY (Deprecated)
 
-This allows you to set the repository that Juju looks for charms in. This can
-also be done by passing `--repository=/path/to/charms` when running the command
+For versions prior to 2.0 allowed you to set a repository that Juju looked for
+charms in. It was also possible to use `--repository=/path/to/charms` when running
+the command
+
 `juju deploy`.
 
-For example, if you are running juju in a Vagrant virtual machine, you could
-set `JUJU_REPOSITORY` to your shared folder:
-
-```
-export JUJU_REPOSITORY=/vagrant
-juju deploy local:series/charm
-```
+Both the environment variable and the command line option are no longer functional
+in 2.x versions.
 
 #### JUJU_LOGGING_CONFIG
 


### PR DESCRIPTION
JUJU_REPOSITORY is no longer functional in the Juju code itself

https://bugs.launchpad.net/juju-core/+bug/906008/comments/4

charm-tools still reference and use this variable but there is no
handling in the Juju source code for this option anymore.

1.25.9:

cmd/juju/commands/deploy.go:    RepoPath     string // defaults to JUJU_REPOSITORY
cmd/juju/commands/upgradecharm.go:      RepoPath    string // defaults to JUJU_REPOSITORY
cmd/juju/commands/upgradecharm.go:$JUJU_REPOSITORY unless overridden by --repository.
cmd/juju/commands/upgradecharm.go:      f.StringVar(&c.RepoPath, "repository", os.Getenv("JUJU_REPOSITORY"), "local charm repository path")
cmd/juju/commands/upgradecharm_test.go: // Reset JUJU_REPOSITORY explicitly, because repoSuite.SetUpTest
cmd/juju/commands/upgradecharm_test.go: os.Setenv("JUJU_REPOSITORY", "")
juju/osenv/vars.go:     JujuRepositoryEnvKey    = "JUJU_REPOSITORY"
juju/testing/repo.go:// $JUJU_REPOSITORY to point to a local charm repository.
juju/testing/repo.go:   s.RepoPath = os.Getenv("JUJU_REPOSITORY")
juju/testing/repo.go:   os.Setenv("JUJU_REPOSITORY", repoPath)
juju/testing/repo.go:   os.Setenv("JUJU_REPOSITORY", s.RepoPath)

2.2.2 (the variable is only referenced in tests):
acceptancetests/assess_resources_charmstore.py:    if os.environ.get('JUJU_REPOSITORY') is None:
acceptancetests/assess_resources_charmstore.py:        raise AssertionError('JUJU_REPOSITORY required')
acceptancetests/chaos.py:        JUJU_REPOSITORY must be set in the OS environment so a local
acceptancetests/hammertime-job.bash:# JUJU_REPOSITORY must be a path providing dummy-source and dummy-sink
acceptancetests/jujucharm.py:        elif os.environ.get('JUJU_REPOSITORY'):
acceptancetests/jujucharm.py:                os.environ['JUJU_REPOSITORY'], charm_dir[platform])
acceptancetests/run-client-server-test-remote.bash:export JUJU_REPOSITORY=$HOME/repository
acceptancetests/run-deploy-job.bash:export JUJU_REPOSITORY=$HOME/repository
acceptancetests/run-maas-networking-remote.bash:export JUJU_REPOSITORY=$HOME/repository
acceptancetests/test-restricted-network:export JUJU_REPOSITORY="$HOME/repo"
acceptancetests/test-restricted-network:mkdir -p $JUJU_REPOSITORY/$SERIES
acceptancetests/test-restricted-network:bzr branch lp:charms/ubuntu $JUJU_REPOSITORY/$SERIES/ubuntu
acceptancetests/tests/test_assess_mixed_images.py:        # local_charm_path drops the series information.  When JUJU_REPOSITORY
acceptancetests/tests/test_assess_resources_charmstore.py:                with EnvironmentVariable('JUJU_REPOSITORY', ''):
acceptancetests/tests/test_deploy_stack.py:            with temp_os_env('JUJU_REPOSITORY', '/tmp/repo'):
acceptancetests/tests/test_deploy_stack.py:            with temp_os_env('JUJU_REPOSITORY', '/tmp/repo'):
acceptancetests/tests/test_deploy_stack.py:                        with temp_os_env('JUJU_REPOSITORY', '/tmp/repo'):
acceptancetests/tests/test_deploy_stack.py:                        with temp_os_env('JUJU_REPOSITORY', '/tmp/repo'):
acceptancetests/tests/test_jujucharm.py:        with temp_os_env('JUJU_REPOSITORY', '/home/foo/repository'):
acceptancetests/tests/test_jujucharm.py:        with temp_os_env('JUJU_REPOSITORY', '/home/foo/repository'):
acceptancetests/tests/test_jujucharm.py:        with temp_os_env('JUJU_REPOSITORY', '/home/foo/repository'):