### PR TITLE
remove legacy constraints

### DIFF
--- a/src/en/reference-constraints.md
+++ b/src/en/reference-constraints.md
@@ -1,5 +1,4 @@
-Title: Juju constraints
-TODO:  Consider removing or editing Legacy section
+Title: Constraints
 
 # Constraints
 
@@ -161,43 +160,3 @@ in combination. Use this list to help you understand the differing needs.
 
 ###VSphere Provider:
 - Unsupported: [tags, virt-type]
-
-
-
-## Legacy constraints
-
-In earlier Juju releases some additional or differently named constraints were
-also supported, these need to be migrated when upgrading.
-
-- cpu
-
-    Number of CPU cores for most providers, but equivalent to an Amazon
-    vCPU on AWS. Use `cores` instead of `cpu` or `cpu-cores`.
-
-- ec2-zone
-
-    EC2 availability zone that an application unit must be deployed into. No
-    equivalent implemented as of juju 1.12, follow [bug
-    1183831](https://bugs.launchpad.net/juju-core/+bug/1183831).
-
-- maas-name
-
-    Specific MAAS machine name that an application unit must be deployed on.
-    Use `maas-tags` instead by preference.
-
-- maas-tags
-
-    List of tags a MAAS machine must have for an application unit to be
-    deployed on. See "tags" above.
-
-- networks
-
-    Comma-delimited list of networks that must be available to the
-    machine. Networks that must not be available to the machine are
-    prefixed with a "^". For example. "db,^dmz".
-    This was only supported by MAAS.
-
-- os-scheduler-hints
-
-    Experimental constraint exposing Openstack-specific scheduler hints
-    features. Do not use.


### PR DESCRIPTION
Fixes #1337 

I was told by the Juju team that these "legacy constraints" are probably not used in 2.x but, for sure, they are not used in Juju 2.2. I propose that we remove them for 2.2 only. That is, unless someone else definitely knows whether they are also not used for 2.0 and 2.1.