### PR TITLE
log forwarding and audit logging

### DIFF
--- a/src/en/controllers-creating.md
+++ b/src/en/controllers-creating.md
@@ -150,6 +150,23 @@ new controller from being automatically selected. For example:
 juju bootstrap --no-switch localhost lxd-new
 ```
 
+### Configuring/enabling a remote syslog server
+
+Create an Azure controller and configure for log forwarding:
+
+```bash
+juju bootstrap azure --config logconfig.yaml
+```
+
+To enable forwarding on all the controller's models by default:
+
+```bash
+juju bootstrap azure --config logforward-enabled=true --config logconfig.yaml
+```
+
+See [Remote logging][troubleshooting-logs-remote] for a more thorough treatment
+of log forwarding.
+
 
 <!-- LINKS -->
 
@@ -158,3 +175,4 @@ juju bootstrap --no-switch localhost lxd-new
 [commands]: ./commands.html#juju-bootstrap
 [controlconfig]: ./controllers-config.html "Configuring Juju controllers"
 [modelconfig]: ./models-config.html "Configuring Juju models"
+[troubleshooting-logs-remote]: ./troubleshooting-logs-remote.html

--- a/src/en/troubleshooting-logs-remote.md
+++ b/src/en/troubleshooting-logs-remote.md
@@ -1,0 +1,62 @@
+Title: Remote logging
+TODO:  Strongly consider adding a sub-page (rsyslog TLS tutorial)
+       Need to state whether client-side auth is a requirement
+
+
+# Remote logging
+
+On a per-model basis log messages can optionally be forwarded to a remote
+syslog server over a secure TLS connection.
+
+See [Rsyslog documentation][upstream-rsyslog-tls-tutorial] for help with
+security-related files (certificates, keys) and the configuration of the
+remote syslog server.
+
+## Configuring
+
+Remote logging is configured during the controller-creation step by supplying
+a YAML format configuration file:
+
+```bash
+juju bootstrap <cloud> --config logconfig.yaml
+```
+
+The contents of the YAML file is of the form:
+
+```no-highlight
+syslog-host: <host>:<port>
+syslog-ca-cert: |
+-----BEGIN CERTIFICATE-----
+ <cert-contents>
+-----END CERTIFICATE-----
+syslog-client-cert: |
+-----BEGIN CERTIFICATE-----
+ <cert-contents>
+-----END CERTIFICATE-----
+syslog-client-key: |
+-----BEGIN PRIVATE KEY-----
+ <cert-contents>
+-----END PRIVATE KEY-----
+```
+
+## Enabling
+
+To actually enable remote logging for a model a configuration key needs to be
+set for that model:
+
+`juju model-config -m <model> logforward-enabled=True`
+
+An initial 100 (maximum) existing log lines will be forwarded.
+
+See [Configuring models][models-config] for extra help on configuring a model.
+
+Note that it is possible to configure *and* enable forwarding on *all* the
+controller's models in one step:
+
+`juju bootstrap <cloud> --config logforward-enabled=True --config logconfig.yaml`
+
+
+<!-- LINKS -->
+
+[upstream-rsyslog-tls-tutorial]: http://www.rsyslog.com/doc/v8-stable/tutorials/tls_cert_summary.html
+[models-config]: ./models-config.html

--- a/src/en/troubleshooting-logs-remote.md
+++ b/src/en/troubleshooting-logs-remote.md
@@ -1,6 +1,6 @@
 Title: Remote logging
 TODO:  Strongly consider adding a sub-page (rsyslog TLS tutorial)
-       Need to state whether client-side auth is a requirement
+       Need to state whether server-side and/or client-side auth is a requirement
 
 
 # Remote logging

--- a/src/en/troubleshooting-logs.md
+++ b/src/en/troubleshooting-logs.md
@@ -12,6 +12,9 @@ is provided here.
 See [Juju high availability](./controllers-ha.html#ha-and-logging) when viewing logs
 in an HA context.
 
+See [Remote logging][troubleshooting-logs-remote] for instructions on setting
+up a remote logging server for Juju.
+
 
 ## Juju agents
 
@@ -192,9 +195,8 @@ Output:
 -rw------- 1 syslog syslog 345K Apr 28 16:58 unit-nfs2-0.log
 ```
 
-There is a special log file on each controller (`logsink.log`) that is used for
-the consolidated model messages used by `juju debug-log` (its contents get sent
-to the database):
+There are two extra log files on each controller: `logsink.log` and
+`audit.log`:
 
 ```bash
 juju ssh -m controller 0 ls -lh /var/log/juju
@@ -203,15 +205,25 @@ juju ssh -m controller 0 ls -lh /var/log/juju
 Output:
 
 ```no-highlight
+-rw------- 1 syslog syslog    0 Apr 28 17:04 audit.log
 -rw------- 1 syslog syslog 2.3M Apr 28 17:05 logsink.log
 -rw------- 1 syslog syslog  85K Apr 28 17:03 machine-0.log
 ```
 
-Notice that the controller model was chosen with `juju ssh`. Also, a combination of
-commands `juju controllers` and `juju machines` yielded that the
-controller here has a machine id of '0' (typical).
+- `logsink.log` contains logs for all models (its contents get sent to the
+  database).
+- `audit.log` contains the API calls of authenticated users.
 
 !!! Note: 
-    In a [High availability](./controllers-ha.html) scenario, file `logsink.log`
-    is not guaranteed to contain all messages since agents have a choice of several
-    controllers to send their logs to.
+    In a [High availability][controllers-ha] scenario, `audit.log` and
+    `logsink.log` are not guaranteed to contain all messages since agents have a
+    choice of several controllers to send their logs to. For `audit.log`, the
+    collation of files across controllers may be required to access all
+    information (a future release may address this). For `logsink.log`, the
+    `debug-log` command should be used to access consolidated data.
+
+
+<!-- LINKS -->
+
+[troubleshooting-logs-remote]: ./troubleshooting-logs-remote.html
+[controllers-ha]: ./controllers-ha.html 

--- a/src/en/troubleshooting-logs.md
+++ b/src/en/troubleshooting-logs.md
@@ -209,13 +209,14 @@ Output:
 ```
 
 File `logsink.log` contains logs for all models managed by the controller. Its
-contents get sent to the database.
+contents get sent to the database where it is consumed by the `debug-log`
+command.
 
 !!! Note: 
     In a [High availability][controllers-ha] scenario, `logsink.log` is not
     guaranteed to contain all messages since agents have a choice of several
     controllers to send their logs to. The `debug-log` command should be used
-    for accessing consolidated data.
+    for accessing consolidated data across all controllers.
 
 
 <!-- LINKS -->

--- a/src/en/troubleshooting-logs.md
+++ b/src/en/troubleshooting-logs.md
@@ -205,22 +205,18 @@ juju ssh -m controller 0 ls -lh /var/log/juju
 Output:
 
 ```no-highlight
--rw------- 1 syslog syslog    0 Apr 28 17:04 audit.log
 -rw------- 1 syslog syslog 2.3M Apr 28 17:05 logsink.log
 -rw------- 1 syslog syslog  85K Apr 28 17:03 machine-0.log
 ```
 
-- `logsink.log` contains logs for all models (its contents get sent to the
-  database).
-- `audit.log` contains the API calls of authenticated users.
+File `logsink.log` contains logs for all models. Its contents get sent to the
+database.
 
 !!! Note: 
-    In a [High availability][controllers-ha] scenario, `audit.log` and
-    `logsink.log` are not guaranteed to contain all messages since agents have a
-    choice of several controllers to send their logs to. For `audit.log`, the
-    collation of files across controllers may be required to access all
-    information (a future release may address this). For `logsink.log`, the
-    `debug-log` command should be used to access consolidated data.
+    In a [High availability][controllers-ha] scenario, `logsink.log` is not
+    guaranteed to contain all messages since agents have a choice of several
+    controllers to send their logs to. The `debug-log` command should be used
+    for accessing consolidated data.
 
 
 <!-- LINKS -->

--- a/src/en/troubleshooting-logs.md
+++ b/src/en/troubleshooting-logs.md
@@ -195,8 +195,7 @@ Output:
 -rw------- 1 syslog syslog 345K Apr 28 16:58 unit-nfs2-0.log
 ```
 
-There are two extra log files on each controller: `logsink.log` and
-`audit.log`:
+There is one extra log file on each controller: `logsink.log`:
 
 ```bash
 juju ssh -m controller 0 ls -lh /var/log/juju
@@ -209,8 +208,8 @@ Output:
 -rw------- 1 syslog syslog  85K Apr 28 17:03 machine-0.log
 ```
 
-File `logsink.log` contains logs for all models. Its contents get sent to the
-database.
+File `logsink.log` contains logs for all models managed by the controller. Its
+contents get sent to the database.
 
 !!! Note: 
     In a [High availability][controllers-ha] scenario, `logsink.log` is not


### PR DESCRIPTION
Fixes #1229 

New page: troubleshooting-logs-remote.md

I was compelled to not include audit logging as it is "not ready" (since 2.0). This feature also needs to be turned on but there is no mention of how to do that. Adventurous users will find file `audit.log` on their controller with a constant size of "0".