### PR TITLE
review of ssh access

### DIFF
--- a/src/en/models.md
+++ b/src/en/models.md
@@ -120,14 +120,18 @@ Common model management tasks are summarized below.
 
 ^# Provide SSH access
    
-   Use the `juju add-ssh-key` command to provide SSH access to all machines,
-   present and future, in a model:
+   Use the `juju add-ssh-key` and `juju import-ssh-key` commands to provide SSH
+   access to all machines, present and future, in a model:
    
    `juju add-ssh-key <ssh-key>`
+
+   OR
+
+   `juju import-ssh-key <lp|gh>:<user identity>`
    
    For complete explanation and syntax, see the
-   [command reference page](./commands.html#add-ssh-key) or the `juju help
-   add-ssh-key` command.
+   [command reference page](./commands.html#add-ssh-key) or the
+   `juju help add-ssh-key` or the `juju help import-ssh-key` commands.
    
 
 

--- a/src/en/users-auth.md
+++ b/src/en/users-auth.md
@@ -49,26 +49,27 @@ account that public keys are added when using the Juju SSH commands (
 the 'root' user (passwordless sudo privileges), the granting of SSH access must
 be done with due consideration.
 
-### Native ssh
+It is possible to connect to a Juju machine in one of two ways:
 
-When using the native (OpenSSH) `ssh` client, if one's public key has been
-installed into a model, then, as expected, a connection to the 'ubuntu' user
-account can be made. All that is needed is the corresponding keypair and
-adequate network connectivity. 
+- Via Juju, using the `juju ssh` command
+- Direct access, using a standard SSH client (e.g `PuTTY` on Windows or `ssh`
+  [OpenSSH] on Linux)
 
-For example, to connect to a machine with an IP address of 10.149.29.143:
+Connecting via Juju involves a second degree of security, as explained below.
 
-```bash
-ssh ubuntu@10.149.29.143
-```
+Regardless of the method used to connect, a public SSH key must be added to the
+model. In the case of direct access, it remains possible for a key to be added
+to an individual machine using standard methods (manually copying a key to the
+`authorized_keys` file or by way of a command such as `ssh-import-id` for
+Debian-based Linux distributions such as Ubuntu).
 
 ### Juju ssh
  
-However, when using the `juju ssh` command, Juju's own user rights system
-imposes a second degree of security that will permit access solely from a Juju
-user, and only one with sufficient permissions. How this works depends on
-whether the user is an admin or a non-admin. See [Juju users][users] for a
-breakdown of the different user types.
+When using the `juju ssh` command, Juju's own user rights system imposes an
+extra degree of security by permitting access solely from a Juju user, and only
+one with sufficient permissions. How this works depends on whether the user is
+an admin or a non-admin. See [Juju users][users] for a breakdown of the
+different user types.
 
 For example, to connect to a machine with an id of '0':
 
@@ -93,6 +94,7 @@ he/she can connect to any machine with the `juju ssh` command.
 
 In order for a regular Juju user to connect with `juju ssh` the user must:
 
+- be created (`juju add-user`)
 - be registered (`juju register`)
 - be logged in (`juju login`)
 - have 'admin' rights to the model (`juju grant`)
@@ -103,6 +105,19 @@ In order for a regular Juju user to connect with `juju ssh` the user must:
 
 See [Users and models][models-users] for information on managing user
 permissions.
+
+### Direct SSH access
+
+When using a standard SSH client  if one's public key has been installed into a model, then, as
+expected, a connection to the 'ubuntu' user account can be made. All that is
+needed is the corresponding keypair and adequate network connectivity. 
+
+For example, to connect to a machine with an IP address of 10.149.29.143 with
+the OpenSSH client:
+
+```bash
+ssh ubuntu@10.149.29.143
+```
 
 
 <!-- LINKS -->

--- a/src/en/users-auth.md
+++ b/src/en/users-auth.md
@@ -43,9 +43,15 @@ SSH access is managed on a per-model basis. That is, if a public key is added
 to a model then that key is placed on all machines (present and future) in that
 model.
 
+Each Juju machine provides a user account named 'ubuntu' and it is to this
+account that public keys are added when using the Juju SSH commands (
+`juju add-ssh-key` and `juju import-ssh-key`). Because this user is effectively
+the 'root' user (passwordless sudo privileges), the granting of SSH access must
+be done with due consideration.
+
 ### Native ssh
 
-When using the native (OpenSSH) `ssh` command, if one's public key has been
+When using the native (OpenSSH) `ssh` client, if one's public key has been
 installed into a model, then, as expected, a connection to the 'ubuntu' user
 account can be made. All that is needed is the corresponding keypair and
 adequate network connectivity. 
@@ -62,7 +68,7 @@ However, when using the `juju ssh` command, Juju's own user rights system
 imposes a second degree of security that will permit access solely from a Juju
 user, and only one with sufficient permissions. How this works depends on
 whether the user is an admin or a non-admin. See [Juju users][users] for a
-breakdown of different user types.
+breakdown of the different user types.
 
 For example, to connect to a machine with an id of '0':
 
@@ -72,14 +78,16 @@ juju ssh 0
 
 #### Admin user
 
-When a controller is created a passphraseless SSH keypair will be generated and
-placed under `~/.local/share/juju/ssh`. The public key (`juju_id_rsa.pub`) will
-be installed in the 'ubuntu' account on every machine created within every
-model belonging to this controller. If there is an existing private key named
-`~/.ssh/id_rsa` then it will also be placed on every machine.
+When a controller is created (see
+[Creating a controller][controllers-creating]) a passphraseless SSH keypair
+will be generated and placed under `~/.local/share/juju/ssh`. The public key
+(`juju_id_rsa.pub`) will be installed in the 'ubuntu' account on every machine
+created within every model belonging to this controller. During creation, if
+there is an existing public key named `~/.ssh/id_rsa.pub` then it will also be
+placed on every machine.
 
-As long as the controller administrator has access to the above keys he/she can
-connect to any machine with the `juju ssh` command.
+As long as the controller administrator has access to either of the above keys
+he/she can connect to any machine with the `juju ssh` command.
 
 #### Regular user
 

--- a/src/en/users-auth.md
+++ b/src/en/users-auth.md
@@ -40,48 +40,67 @@ See [Cloud credentials][credentials] for more on this topic.
 ## SSH access
 
 SSH access is managed on a per-model basis. That is, if a public key is added
-to a model by an admin then that key is placed on all machines in that model,
-as well as on any subsequently-created machines. This is done with commands
-`juju add-ssh-key`, `juju import-ssh-key`, and `juju remove-ssh-key`, which
-refer to keys owned by ordinary people (non-Juju users). However, Juju's own
-user rights system imposes a second degree of security that only allows
-access from a Juju user with the correct model permissions. Additionally,
-connections can only be made via the `juju ssh` command.
+to a model then that key is placed on all machines (present and future) in that
+model.
 
-### Controller admins
+### Native ssh
 
-The controller admin is the system (e.g. Ubuntu) user that performed the
-initial controller-creation step.
+When using the native (OpenSSH) `ssh` command, if one's public key has been
+installed into a model, then, as expected, a connection to the 'ubuntu' user
+account can be made. All that is needed is the corresponding keypair and
+adequate network connectivity. 
 
-By default, a controller admin will be able to connect to any machine. When a
-controller is created a passphraseless SSH keypair will be created and placed
-under `~/.local/share/juju/ssh`:
+For example, to connect to a machine with an IP address of 10.149.29.143:
 
-```no-highlight
--rw------- 1 ubuntu ubuntu 1675 Sep 21 21:58 juju_id_rsa
--rw------- 1 ubuntu ubuntu  397 Sep 21 21:58 juju_id_rsa.pub 
+```bash
+ssh ubuntu@10.149.29.143
 ```
 
-The public key (`juju_id_rsa.pub`) will be placed on every machine created
-within every model belonging to this controller. If there is an existing
-private key named `~/.ssh/id_rsa` then it will also be placed on every machine.
+### Juju ssh
+ 
+However, when using the `juju ssh` command, Juju's own user rights system
+imposes a second degree of security that will permit access solely from a Juju
+user, and only one with sufficient permissions. How this works depends on
+whether the user is an admin or a non-admin. See [Juju users][users] for a
+breakdown of different user types.
 
-### Non-admin users
+For example, to connect to a machine with an id of '0':
 
-For SSH connections to work for a non-admin Juju user, the user must:
+```bash
+juju ssh 0
+```
+
+#### Admin user
+
+When a controller is created a passphraseless SSH keypair will be generated and
+placed under `~/.local/share/juju/ssh`. The public key (`juju_id_rsa.pub`) will
+be installed in the 'ubuntu' account on every machine created within every
+model belonging to this controller. If there is an existing private key named
+`~/.ssh/id_rsa` then it will also be placed on every machine.
+
+As long as the controller administrator has access to the above keys he/she can
+connect to any machine with the `juju ssh` command.
+
+#### Regular user
+
+In order for a regular Juju user to connect with `juju ssh` the user must:
 
 - be registered (`juju register`)
 - be logged in (`juju login`)
 - have 'admin' rights to the model (`juju grant`)
-- ensure their private key is named `id_rsa` (or use the `ssh-agent` utility)
+- have their public key added to the model by an admin (`juju add-ssh-key` or
+  `juju import-ssh-key`)
+- must be in possession of their private key and ensure it is named `id_rsa`
+  (or use `ssh-agent`)
 
-See [Users and models][models-users] for more information on managing
-user permissions.
+See [Users and models][models-users] for information on managing user
+permissions.
 
 
 <!-- LINKS -->
 
 [controllers-creating]: ./controllers-creating.html
 [credentials]: ./credentials.html
+[users]: ./users.html
 [models]: ./models.html
 [models-users]: ./users-models.html

--- a/src/en/users-auth.md
+++ b/src/en/users-auth.md
@@ -1,5 +1,6 @@
-Title: Juju users and authentication
-TODO: Stuff on user-created models (ssh key and credentials)
+Title: Users and authentication
+TODO:  Stuff on user-created models (ssh key and credentials)
+       bug tracking: https://pad.lv/1718775
 
 
 # Users and authentication
@@ -24,22 +25,63 @@ juju bootstrap aws mycontroller
 juju change-user-password
 ```
 
-See [Creating a controller](./controllers-creating.html) for details on
-controller creation.
+See [Creating a controller][controllers-creating] for details on controller
+creation.
 
+## Credentials
 
-## Credentials and SSH keys
-
-*Credentials* managed in Juju are related to the accessing of the chosen
+Credentials managed in Juju are related to the accessing of the chosen
 cloud-backed resource. They are not related to Juju users themselves in any
 way. Credentials added to Juju remain local to the system user (on Ubuntu:
 `~/.local/share/juju/credentials.yaml`).
 
-See [Cloud credentials](./credentials.html) for more on this topic.
+See [Cloud credentials][credentials] for more on this topic.
 
-*SSH keys* managed in Juju are related to the accessing of the machines Juju
-creates. It copies/removes public SSH keys (`juju add-ssh-key` and `juju
-import-ssh-key`) in order to provide/remove SSH access to individuals, external
-to Juju. These keys are also not related to internal Juju users. A Juju user,
-however, who has access to a model (he has been granted access to it) can log
-in to any machine in that model using Juju (`juju ssh`).
+## SSH access
+
+SSH access is managed on a per-model basis. That is, if a public key is added
+to a model by an admin then that key is placed on all machines in that model,
+as well as on any subsequently-created machines. This is done with commands
+`juju add-ssh-key`, `juju import-ssh-key`, and `juju remove-ssh-key`, which
+refer to keys owned by ordinary people (non-Juju users). However, Juju's own
+user rights system imposes a second degree of security that only allows
+access from a Juju user with the correct model permissions. Additionally,
+connections can only be made via the `juju ssh` command.
+
+### Controller admins
+
+The controller admin is the system (e.g. Ubuntu) user that performed the
+initial controller-creation step.
+
+By default, a controller admin will be able to connect to any machine. When a
+controller is created a passphraseless SSH keypair will be created and placed
+under `~/.local/share/juju/ssh`:
+
+```no-highlight
+-rw------- 1 ubuntu ubuntu 1675 Sep 21 21:58 juju_id_rsa
+-rw------- 1 ubuntu ubuntu  397 Sep 21 21:58 juju_id_rsa.pub 
+```
+
+The public key (`juju_id_rsa.pub`) will be placed on every machine created
+within every model belonging to this controller. If there is an existing
+private key named `~/.ssh/id_rsa` then it will also be placed on every machine.
+
+### Non-admin users
+
+For SSH connections to work for a non-admin Juju user, the user must:
+
+- be registered (`juju register`)
+- be logged in (`juju login`)
+- have 'admin' rights to the model (`juju grant`)
+- ensure their private key is named `id_rsa` (or use the `ssh-agent` utility)
+
+See [Users and models][models-users] for more information on managing
+user permissions.
+
+
+<!-- LINKS -->
+
+[controllers-creating]: ./controllers-creating.html
+[credentials]: ./credentials.html
+[models]: ./models.html
+[models-users]: ./users-models.html

--- a/src/en/users-models.md
+++ b/src/en/users-models.md
@@ -37,13 +37,14 @@ See [Adding a model][addmodel] for details on adding models.
 
 ## Models and user access
 
-An administrator can use the `grant` command to grant a user either read or write
-access to any model. 
+An administrator can use the `grant` command to grant a user 'read', 'write',
+or 'admin' access to any model. 
 
-- `read`: a user can view the state of a model with the `models`,
+- `read`: A user can view the state of a model with the `models`,
   `machines` and `status` commands.
-- `write`: a user can both view the state of a model and make any changes
-  required, though they can't create, backup or destroy models.
+- `write`: In addition to 'read' abilities, a user can modify/configure models.
+- `admin`: In addition to 'write' abilities, a user can backup/destroy models
+  and connect to machines via SSH.
 
 To give 'bob' read-only access to the model 'mymodel', for example, the
 administrator would enter the following:

--- a/src/en/users-models.md
+++ b/src/en/users-models.md
@@ -43,8 +43,8 @@ or 'admin' access to any model.
 - `read`: A user can view the state of a model with the `models`,
   `machines` and `status` commands.
 - `write`: In addition to 'read' abilities, a user can modify/configure models.
-- `admin`: In addition to 'write' abilities, a user can backup/destroy models
-  and connect to machines via SSH.
+- `admin`: In addition to 'write' abilities, a user can backup models and
+  connect to machines via the `juju ssh` command.
 
 To give 'bob' read-only access to the model 'mymodel', for example, the
 administrator would enter the following:


### PR DESCRIPTION
This is a significant update on how SSH works with Juju.

Fixes #2138 
Fixes #1417 

I could not destroy a model with 'admin' access so that's why I removed that ability. I'm not sure if this is a bug.