### PR TITLE
replace ryslog with rsyslog-forwarder and refactor

### DIFF
--- a/src/en/authors-implicit-relations.md
+++ b/src/en/authors-implicit-relations.md
@@ -31,11 +31,12 @@ remote unit in a relation through its `juju-info` relation
 
 ## Relationship resolution
 
-`rsyslog` is a [_subordinate charm_](./authors-subordinate-applications.html) and
-requires a valid `scope: container` relationship in order to deploy. It can take
-advantage of optional support from the principal charm but in the event that the
-principal charm doesn't provide this support it will still require a
-`scope: container` relationship. In this event the logging charm author can take
+`rsyslog-forwarder` is a
+[_subordinate charm_](./authors-subordinate-applications.html) and requires a
+valid `scope: container` relationship in order to deploy. It can take advantage
+of optional support from the principal charm but in the event that the
+principal charm doesn't provide this support it will still require a `scope:
+container` relationship. In this event the logging charm author can take
 advantage of the implicit relationship offered by all charms, `juju-info`.
 
     requires:
@@ -48,7 +49,7 @@ advantage of the implicit relationship offered by all charms, `juju-info`.
 
 The admin then issues the following
 
-    juju add-relation wordpress rsyslog
+    juju add-relation wordpress rsyslog-forwarder
 
 If the wordpress charm author doesn't define the `logging-directory` interface,
 Juju will use the less-specific (in the sense that it likely provides less

--- a/src/en/authors-subordinate-applications.md
+++ b/src/en/authors-subordinate-applications.md
@@ -117,7 +117,7 @@ containers holding the mysql and wordpress units. The rsyslog-forwarder
 application has a standard client-server relation to both wordpress and mysql
 but these new relationships are implemented only between the principal unit and
 the subordinate unit. A subordinate unit may still have standard relations
-established with any unit in its environment as usual.
+established with any unit as usual.
 
 ## Status of subordinates
 
@@ -127,9 +127,10 @@ subordinate unit's output matches the formatting of existing unit entries but
 omits machine, public-address and subordinates (which are all the same as the
 principal unit).
 
-Below is shown two excerpts from the output to `juju status --format yaml`
-after the 'wordpress' charm and the 'rsyslog-forwarder' subordinate charm were
-deployed and a relation added between the two.
+Shown below are two partial excerpts from the output to command
+`juju status --format yaml` after the 'wordpress' charm and the
+'rsyslog-forwarder' subordinate charm were deployed and a relation added
+between the two.
 
 Firstly, the **rsyslog-forwarder** application will show to what application it
 is a subordinate of:

--- a/src/en/authors-subordinate-applications.md
+++ b/src/en/authors-subordinate-applications.md
@@ -94,49 +94,6 @@ The example below shows adding a container relation to a charm.
         scope: container
 ```
 
-## Status of subordinates
-
-The status output contains details about subordinate units under the status of
-the principal application unit that it is sharing the container with. The
-subordinate unit's output matches the formatting of existing unit entries but
-omits machine, public-address and subordinates (which are all the same as the
-principal unit).
-
-The subordinate application is listed in the top level applications dictionary in an
-abbreviated form. The subordinate-to: [] list is added to the application which
-contains the names of all applications this application is subordinate to.
-
-```yaml
-    applications:
-      rsyslog:
-        charm: cs:precise/rsyslog-0
-        exposed: false
-        relations:
-          rsyslog-directory:
-          - wordpress
-        subordinate-to:
-        - wordpress
-      wordpress:
-        charm: cs:precise/wordpress-13
-        exposed: true
-        relations:
-          rsyslog-directory:
-          - rsyslog
-        units:
-          wordpress/0:
-            agent-state: started
-            agent-version: 1.14.1.1
-            machine: "3"
-            open-ports:
-            - 80/tcp
-            public-address: 10.0.3.11
-            subordinates:
-              rsyslog/0:
-                agent-state: started
-                agent-version: 1.14.1.1
-                public-address: 10.0.3.11
-```
-
 ## Usage
 
 Assume the following deployment:
@@ -147,20 +104,53 @@ juju deploy wordpress
 juju add-relation mysql wordpress
 ```
 
-Now we'll create a subordinate rsyslog application:
+Now we'll request a subordinate rsyslog-forwarder application:
 
 ```bash
-juju deploy rsyslog
-juju add-relation rsyslog mysql
-juju add-relation rsyslog wordpress
+juju deploy rsyslog-forwarder
+juju add-relation rsyslog-forwarder mysql
+juju add-relation rsyslog-forwarder wordpress
 ```
 
-This will create a rsyslog application unit inside each of the containers holding
-the mysql and wordpress units. The rsyslog application has a standard client-server
-relation to both wordpress and mysql but these new relationships are implemented
-only between the principal unit and the subordinate unit. A subordinate unit
-may still have standard relations established with any unit in its environment
-as usual.
+This will create a rsyslog-forwarder application unit inside each of the
+containers holding the mysql and wordpress units. The rsyslog-forwarder
+application has a standard client-server relation to both wordpress and mysql
+but these new relationships are implemented only between the principal unit and
+the subordinate unit. A subordinate unit may still have standard relations
+established with any unit in its environment as usual.
+
+## Status of subordinates
+
+The status output contains details about subordinate units under the status of
+the principal application unit that it is sharing the container with. The
+subordinate unit's output matches the formatting of existing unit entries but
+omits machine, public-address and subordinates (which are all the same as the
+principal unit).
+
+Below is shown two excerpts from the output to `juju status --format yaml`
+after the 'wordpress' charm and the 'rsyslog-forwarder' subordinate charm were
+deployed and a relation added between the two.
+
+Firstly, the **rsyslog-forwarder** application will show to what application it
+is a subordinate of:
+
+```yaml
+applications:
+  rsyslog-forwarder:
+    subordinate-to:
+    - wordpress
+```
+
+Secondly, in the units sub-section to the **wordpress** application the
+subordinate unit will be listed:
+
+```yaml
+applications:
+  wordpress:
+    units:
+        subordinates:
+          rsyslog-forwarder/0:
+```
 
 ## Caveats
 


### PR DESCRIPTION
Fixes #620 

:warning: The command `juju add-relation rsyslog-forwarder mysql` will fail:

`ERROR cannot add relation "rsyslog-forwarder:juju-info mysql:juju-info": principal and subordinate applications' series must match`

buy MySQL is not actually required here. The example deployment just looks more authentic with it.