### PR TITLE
[2.x] add Go cookies variable

### DIFF
--- a/src/en/reference-environment-variables.md
+++ b/src/en/reference-environment-variables.md
@@ -15,6 +15,16 @@ Use header tags so we can link to these variables individually.
 These variables are available on the juju client in order to change its default
 behavior.
 
+#### GOCOOKIES
+
+The default location of the Go cookies file is `~/.go-cookies`. This
+variable can change that.
+
+Example:
+
+```no-highlight
+GOCOOKIES=/var/lib/landscape/juju-homes/1/.go-cookies
+```
 
 #### JUJU_DATA
 


### PR DESCRIPTION
So just apply this to 2.x?

Fixes #1666 