### PR TITLE
update charm review & promulgation

### DIFF
--- a/src/en/charm-promulgation.md
+++ b/src/en/charm-promulgation.md
@@ -1,0 +1,18 @@
+Title: Charm promulgation
+
+# Charm promulgation
+
+To promulgate a Juju charm a member of the
+[~charmers][launchpad-group-charmers] Launchpad group will:
+
+1. Download the proposed charm (`charm pull`).
+1. Perform static analysis on the charm (`charm proof`).
+1. Ensure the charm has a bugs-url and homepage (`charm set`).
+1. If steps 2 or 3 fails, the charm author will be asked to make changes.
+1. Promulgate the charm (`charm promulgate`).
+1. Grant write access to the promulgated charm (`charm grant`).
+
+
+<!-- LINKS -->
+
+[launchpad-group-charmers]: https://launchpad.net/~charmers

--- a/src/en/charm-review-process.md
+++ b/src/en/charm-review-process.md
@@ -1,9 +1,9 @@
-Title: Charm review process  
+Title: Charm Review Process
 
 # Charm Review Process
 
-Reviewing a Juju Charm is a process that can easily be broken down into
-the following parts:
+Reviewing a Juju Charm is a process that can easily be broken down into the
+following parts:
 
 1. Identifying what to review
 1. Setting up a branch of the charm

--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -180,21 +180,33 @@ tests in Python.
 For more information about writing tests please refer to the
 [charm testing guide documentation][charm testing].
 
-## Having your charm reviewed
+## Publishing your charm
 
-Once the charm is complete you can 
-[submit the charm for review][charm-review].
-If it passes, it will appear in the recommended section of the 
-Juju Charm Store (reviews may take some time to complete). Charms in the 
-recommended section must follow Charm Store policy and best practices for
-charms. These recommended charms have a shorter namespace on the 
-Charm Store website, and are listed higher in search results on 
-[https://jujucharms.com][store].
+When you are done writing your charm and you want to make it available to
+others you will need to make a *promulgation request*. This is informally done
+via the [Juju users mailing list][mailing-list-juju].
+
+The '#juju' IRC channel on Freenode and the above mailing list remain excellent
+resources for questions and comments regarding charm development and charm
+promulgation.
+
+### Promulgation notes
+
+- The [Charm promulgation][charm-promulgation] page contains information on what
+  happens once the request is made.
+
+- It is the responsibility of the charm author (and maintainer) to test
+  their charm to ensure it is of good quality and is secure.
+
+- Promulgation to the top level namespace of the Charm Store does not imply
+  an endorsement by Canonical.
+
+- Charm authors are encouraged to use their personal or group namespace.
 
 
 <!-- LINKS -->
 
-[store]:              https://jujucharms.com/
+[charm-store]: https://jujucharms.com/
 [getting-started]:    ./getting-started.html 
 [charm-tools]:        ./tools-charm-tools.html
 [charm-helpers]:      ./tools-charm-helpers.html
@@ -206,6 +218,7 @@ Charm Store website, and are listed higher in search results on
 [bundletester]:       https://github.com/juju-solutions/bundletester
 [charm testing]:      ./developer-testing.html
 [interfaces]:         http://interfaces.juju.solutions/
-[charm-review]: ./charm-review-process.html
+[charm-promulgation]: ./charm-promulgation.html
 [reactive]: https://en.wikipedia.org/wiki/Reactive_programming
 [charmsreactive]: http://pythonhosted.org/charms.reactive/
+[mailing-list-juju]: https://lists.ubuntu.com/mailman/listinfo/juju

--- a/src/en/reference-reviewers.md
+++ b/src/en/reference-reviewers.md
@@ -22,8 +22,7 @@ and thus lighten the development workload on everyone.
 - You're not obliged to deal with all the open patches. We appreciate what you do do.
 - You can prioritize whichever you think best achieves the goal of helping
   people enjoy getting things done in Juju. That might be the newest ones,
-neglected patches, easy patches, or those from new contributors. The [Review
-Queue](http://review.juju.solutions) sorts by age.
+neglected patches, easy patches, or those from new contributors.
 - If you are unfamiliar with the package, make sure you review everything you can, it's not necessarily your job to merge/promulgate it. If, after you did your review, you can get the contributor in touch with somebody who knows the codebase better, you already helped out a lot.
 - Consider blogging about a particularly nice contribution. This will not only make the contributor feel valued, but also inspire others with a good example of great work.
 - Encourage contributors to apply for ~charmers if you think they're ready.
@@ -38,8 +37,6 @@ You can see the currently pending requests at:
 
 - [https://bugs.launchpad.net/charms/+bugs?field.subscriber=charmers](https://bugs.launchpad.net/charms/+bugs?field.subscriber=charmers)
 - [https://bugs.launchpad.net/charms/+bugs?field.subscriber=charmers&field.component=3&field.component=4](https://bugs.launchpad.net/charms/+bugs?field.subscriber=charmers&field.component=3&field.component=4)
-- The [Review Queue](http://review.juju.solutions/) at
-<http://review.juju.solutions/> 
 
 ### Updating the store with new Charms
 

--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -93,7 +93,7 @@
                 <li><a href="developer-getting-started.html#designing-your-charm">Designing your Charm</a></li>
                 <li><a href="developer-getting-started.html#writing-your-charm">Writing your Charm</a></li>
                 <li><a href="developer-getting-started.html#testing-your-charm">Testing your Charm</a></li>
-                <li><a href="developer-getting-started.html#having-your-charm-reviewed">Having your charm reviewed</a></li>
+                <li><a href="developer-getting-started.html#publishing-your-charm">Publishing your charm</a></li>
             </ul>
         </li>
         <li class="section"><a class="header" href="developer-event-cycle.html">Event Cycle</a>


### PR DESCRIPTION
Fixes #2145 

It seems there is no more review process for new charms.

I kept the original charm-review-process.md file just in case and created a new page called charm-promulgation.md. We can remove the old file once things have settled down.

I do not know how the author is supposed to make sure their charm "is of good quality and is secure".

I do not see any current instructions pointing authors to the (now defunct) review queue. I don't know how they ever used the old process to begin with, unless they stumbled upon the link (to the review queue site) amidst the old review instructions (not meant for authors).