### PR TITLE
Update interface developer docs for Endpoints

### DIFF
--- a/src/en/developer-layers-interfaces.md
+++ b/src/en/developer-layers-interfaces.md
@@ -24,36 +24,66 @@ API.
 ## Terminology
 
 Historically, the term "relation" has been used ambiguously when discussing
-Juju, charms, and applications deployed with Juju using charms.  To make things
+Juju, charms, and applications deployed with Juju using charms. To make things
 more clear and consistent, we use the following terms:
 
-  * "charm" This is the set of code that encapsulates the operational knowledge
+  * A **charm** is the set of code that encapsulates the operational knowledge
     that manages the life-cycle of an application when deployed.
 
-  * "application" This is a deployed instance of a charm.  It is hosted on a
+  * An **application** is a deployed instance of a charm. It is hosted on a
     machine, VM, or container, it has a copy of the charm code, and it is
     managed by a Juju controller.
 
-  * "interface" This is the protocol used by the charm(s) running on two
-    applications to communicate over a relation established between them.
+  * The **interface** is the protocol used by two charms to communicate over a
+    relation between them.
     This protocol is what interface layers codify.
 
-  * "endpoint" This is the name that a charm uses as a connection point at which
-    a relation can be made between two deployed applications.  An endpoint is
-    defined in a charm's `metadata.yaml` and specify a name, a type (one of
-    `requires`, `provides`, or `peers`), and an interface that relations
-    established at the endpoint will use.
+  * An **endpoint** is one charm's connection point at which a relation can be
+    made. An endpoint is defined in a charm's `metadata.yaml` and specify a
+    name, a **role** (one of `requires`, `provides`, or `peers`), and an
+    interface that relations established at the endpoint will use.
 
-  * "relation" This is an established connection between endpoints of two
-    applications.  Relations have a relation ID that is tracked by the Juju
+  * A **relation** is an established connection between endpoints of two
+    applications. Relations have a relation ID that is tracked by the Juju
     controller and relation data associated with each unit of each application
-    involved in the relation.  Relations can only be established between
+    involved in the relation. Relations can only be established between
     endpoints that specify the same interface, and a given endpoint can only
     have one relation to a specific application. However, a given application
     can be related to an application any number of times on different
     endpoints, as long as they specify the same interface, and even to itself
     if it has two endpoints of the same interface (or if the endpoint is of the
     type `peers`).
+
+Here's how these terms map to a charm's `metadata.yaml` and `layer.yaml` file.
+
+```yaml
+# metadata.yaml
+name: mattermost  # Charm name
+# ...
+requires:  # Endpoint role
+    postgres:  # Endpoint name
+        interface: pgsql  # Interface name
+provides:  # Endpoint role
+    website:  # Endpoint name
+        interface: http  # Interface name
+# ...
+```
+
+```yaml
+# layer.yaml
+includes:
+ - 'layer:basic'
+   # ...
+ - 'interface:pgsql'  # This interface layer codifies the `pgsql` protocol. The
+                      # `requires` role of this interface layer will by used by
+                      # the `postgres` endpoint.
+
+ - 'interface:http'  # This interface layer codifies the `http` protocol. The
+                     # `website` endpoint will use the `provides` role of this
+                     # interface.
+repo: https://github.com/tengu-team/layer-mattermost.git
+# ...
+```
 
 ## Design considerations
 
@@ -64,26 +94,21 @@ applications/unit(s) participating in the relationship.
 Common questions to answer:
 
 - What units need to participate in the conversation?
-
 - What data is being sent on the wire?
-
 - Are we sending data that is essentially static to any application connecting
 over this interface?
-
 - How should this data be made available to the requirer?
-
 - What flags should this interface set on the provider?
-
 - What flags should this interface set on the requirer?
 
 For the last couple of considerations, it's important to note that the
 `Endpoint` base class will automatically manage a few flags that are common to
 all interfaces:
 
-  * `endpoint.{relation_name}.joined` Set whenever any remote unit joins
-  * `endpoint.{relation_name}.changed` Set whenever any relation data changes
-  * `endpoint.{relation_name}.changed.{field}` Set for each field that changes
-  * `endpoint.{relation_name}.departed` Set whenever any remote unit leaves
+  * `endpoint.{endpoint_name}.joined` Set whenever any remote unit joins
+  * `endpoint.{endpoint_name}.changed` Set whenever any relation data changes
+  * `endpoint.{endpoint_name}.changed.{field}` Set for each field that changes
+  * `endpoint.{endpoint_name}.departed` Set whenever any remote unit leaves
 
 These are mainly intended to be used by the interface layer itself, but can be
 documented as part of the official API that the interface layer exposes.
@@ -137,9 +162,14 @@ version: 1
 repo: https://git.launchpad.net/~bcsaller/charms/+source/http
 ```
 
-#### Writing the provides side
+The HTTP interface has two roles: the `provides` side is for an http-accessible
+webservice and the `requires` is for an application that uses the webservice.
+In this example, the `provides` side is a website and the `requires` side is a
+reverseproxy.
 
-We're now ready to implement the provider interface in `provides.py`.
+#### Creating the `provides` role
+
+We're now ready to implement the `provides` interface in `provides.py`.
 
 ```python
 from charmhelpers.core import hookenv
@@ -147,51 +177,67 @@ from charms.reactive import set_flag, clear_flag
 from charms.reactive import Endpoint
 
 
-class HttpProvides(Endpoint):
-    def configure(self, port, hostname=None):
+class HttpProvides(EndpointInterface):
+    def publish_info(self, port, hostname=None):
         """
-        Configure the HTTP relation by providing a port and optional hostname.
+        Publish the port and hostname of the website over the relationship so
+        it is accessible to the remote units at the other side of the
+        relationship.
 
         If no hostname is provided, the unit's private-address is used.
         """
         for relation in self.relations:
-            relation.send['hostname'] = hostname or hookenv.unit_get('private_address')
-            relation.send['port'] = port
+            relation.to_publish['hostname'] = hostname or hookenv.unit_get('private_address')
+            # Publishing data with `to_publish` is the only way to communicate
+            # with remote units. Flags are local-only, they are not shared with
+            # remote units!
+            relation.to_publish['port'] = port
 ```
 
-!!! Note: You can only "send" data at the relation level. Remember, a relation
-has data associated with each unit in the relation; "sending" data is really
-just setting the local unit's data on the relation. If you need to provide data
-specific to each remote unit, you can use [`send_json`][] to send structured
-data using a dict keyed by the remote unit names.
+!!! Note: Data is send after the hook successfully exits. If any handler
+    crashes, all the flags and the `to_send` dict will be reset to their
+    original position at hook start.
 
-#### Implementing the provides side
+!!! Note: You can only publish data at the relation level. All units of the
+    application at the other end of the relation will see the same data. If you
+    need to provide data specific to each remote unit, you can use a workaround
+    such as publishing a dictionary with the remote unit names as keys and
+    their specific data as values.
 
-With our provider interface written, lets take a look at how we might implement
-this in a charm.
+Now we can use this `provides` endpoint interface in our charm. The first step
+is to define the relation using this interface in `metadata.yaml`.
 
-In our metadata we define a website relation implementing the interface:
 ```yaml
-provides:
-  website:
-    interface: http
+provides:  # This side of the relationship implements the `provides` role
+  website:  # We call our endpoint `website`. All flags of this endpoint will
+            # be prefixed with `endpoint.website.`.
+    interface: http  # The `website` endpoint uses the `provides`
+                     # side of the `http` interface
 ```
 
-And in the reactive class, we will receive the RelationBase object, and invoke
-the configure method:
+Now we can create handlers that react to the flags set by the endpoint. These
+handlers are part of a charm that deploys a webservice. The following handler
+publishes the information about the webservice after the webservice started and
+a relation is established with a charm that wants to use the webservice.
 
 ```python
 from charms.reactive import context
 
+# `website` is the endpoint name as defined in `metadata.yaml`
 @when('endpoint.website.joined')
-def configure_website():
-    context.endpoints.website.configure(80)
+@when('my-webservice.started')
+def publish_website_info():
+    # Retrieve the Endpoint object. This object will be an instance of the
+    # HttpProvides class defined above.
+    website = endpoint_from_flag('endpoint.website.joined')
+    website.publish_info(80)
 ```
 
 
-#### Writing the requires side
+#### Creating the `requires` role
 
-We're now ready to implement the requirer interface in `requires.py`
+We're now ready to implement the `requires` role of this interface in
+`requires.py`.
 
 ```python
 from charms.reactive import when_any, when_not
@@ -199,24 +245,27 @@ from charms.reactive import set_flag, clear_flag
 from charms.reactive import Endpoint
 
 
-class HttpRequires(Endpoint):
-    @when_any('endpoint.{relation_name}.changed.hostname',
-              'endpoint.{relation_name}.changed.port')
+class HttpRequires(EndpointInterface):
+    # {endpoint_name} will be filled in by the reactive framework. This is the
+    # name of the endpoint as defined in `metadata.yaml`
+    @when_any('endpoint.{endpoint_name}.changed.hostname',
+              'endpoint.{endpoint_name}.changed.port')
     def new_website(self):
         # Detect changes to the hostname or port field on any remote unit
         # and translate that into the new-website flag. Then, clear the
         # changed field flags so that we can detect further changes.
-        set_flag(self.flag('endpoint.{relation_name}.new-website'))
-        clear_flag(self.flag('endpoint.{relation_name}.changed.hostname'))
-        clear_flag(self.flag('endpoint.{relation_name}.changed.port'))
+        set_flag(self.flag('endpoint.{endpoint_name}.new-website'))
+        clear_flag(self.flag('endpoint.{endpoint_name}.changed.hostname'))
+        clear_flag(self.flag('endpoint.{endpoint_name}.changed.port'))
 
-    @when_not('endpoint.{relation_name}.joined')
+    @when_not('endpoint.{endpoint_name}.joined')
     def broken(self):
-        clear_flag(self.flag('endpoint.{relation_name}.new-website'))
+        clear_flag(self.flag('endpoint.{endpoint_name}.new-website'))
 
     def websites(self):
         """
-        Get the list of websites that were provided.
+        Get the list of websites that remote units have published over all the
+        relationships connected to this endpoint.
 
         Returns a list of dicts, where each dict contains the hostname (address)
         and the port (as a string) that the website is listening on, as well as
@@ -228,11 +277,19 @@ class HttpRequires(Endpoint):
                     'hostname': '10.1.1.1',
                     'port': '80',
                     'relation_id': 'reverseproxy:1',
-                    'unit_name': 'myblog/0',
+                    'remote_unit_name': 'myblog/0',
                 },
             ]
         """
         websites = []
+        #
+        # Multiple relations can connect to the same endpoint. All relations
+        # of the same endpoint will be handled by the same EndpointInterface
+        # class.
+        #
+        # Loop over all units of all relations connected to this enpoint,
+        # read the port and hostname they published, add them to a dict and
+        # return that information.
         for relation in self.relations:
             for unit in relation.units:
                 hostname = unit.received['hostname']
@@ -243,7 +300,7 @@ class HttpRequires(Endpoint):
                     'hostname': hostname,
                     'port': port,
                     'relation_id': relation.relation_id,
-                    'unit_name': unit.unit_name,
+                    'remote_unit_name': unit.unit_name,
                 })
         return websites
 ```
@@ -256,12 +313,8 @@ means that you can update your interface layer to handle changes in things like
 the encoding or key names in a backwards compatible way without requiring all
 charms that use the interface to know about or implement that logic.
 
-#### Implementing the requires side
-
-With our requirer interface written, lets take a look at how we might implement
-this in a charm.
-
-In our metadata we define a reverseproxy relation implementing the interface:
+Now we can use this `requires` endpoint interface in our charm. The first step
+is to define the relation using this interface in `metadata.yaml`.
 
 ```yaml
 requires:
@@ -269,19 +322,27 @@ requires:
     interface: http
 ```
 
-And in our reactive file, we implement it as so:
+Now we can create handlers that react to the flags set by the endpoint. This
+handler is part of a charm that deploys a reverseproxy. The handler logs the
+published information of all the connected webservices.
 
 ```python
 from charms.reactive import when
 from charms.reactive import clear_flag
 from charms.reactive import context
 
-
+# `reverseproxy` is the endpoint name as defined in `metadata.yaml`
 @when('endpoint.reverseproxy.new-website')
 def update_reverse_proxy_config():
-    for website in context.endpoints.reverseproxy.websites():
-        hookenv.log('New website: {}:{}'.format(
+    # Retrieve the Endpoint object. This object will be an instance of the
+    # HttpRequires class defined above.
+    reverseproxy = endpoint_from_flag('endpoint.reverseproxy.new-website')
+    # Note that `reverseproxy.websites()` returns _all_ websites, not just
+    # the website that triggered the `endpoint.reverseproxy.new-website` flag.
+    for website in reverseproxy.websites():
+        hookenv.log('Website: {}:{}'.format(
             website['hostname'],
             website['port']))
+        # ...
     clear_flag('endpoint.reverseproxy.new-website')
 ```

--- a/src/en/developer-layers-interfaces.md
+++ b/src/en/developer-layers-interfaces.md
@@ -177,7 +177,7 @@ from charms.reactive import set_flag, clear_flag
 from charms.reactive import Endpoint
 
 
-class HttpProvides(EndpointInterface):
+class HttpProvides(Endpoint):
     def publish_info(self, port, hostname=None):
         """
         Publish the port and hostname of the website over the relationship so
@@ -245,7 +245,7 @@ from charms.reactive import set_flag, clear_flag
 from charms.reactive import Endpoint
 
 
-class HttpRequires(EndpointInterface):
+class HttpRequires(Endpoint):
     # {endpoint_name} will be filled in by the reactive framework. This is the
     # name of the endpoint as defined in `metadata.yaml`
     @when_any('endpoint.{endpoint_name}.changed.hostname',
@@ -254,13 +254,13 @@ class HttpRequires(EndpointInterface):
         # Detect changes to the hostname or port field on any remote unit
         # and translate that into the new-website flag. Then, clear the
         # changed field flags so that we can detect further changes.
-        set_flag(self.flag('endpoint.{endpoint_name}.new-website'))
-        clear_flag(self.flag('endpoint.{endpoint_name}.changed.hostname'))
-        clear_flag(self.flag('endpoint.{endpoint_name}.changed.port'))
+        set_flag(self.expand_name('endpoint.{endpoint_name}.new-website'))
+        clear_flag(self.expand_name('endpoint.{endpoint_name}.changed.hostname'))
+        clear_flag(self.expand_name('endpoint.{endpoint_name}.changed.port'))
 
     @when_not('endpoint.{endpoint_name}.joined')
     def broken(self):
-        clear_flag(self.flag('endpoint.{endpoint_name}.new-website'))
+        clear_flag(self.expand_name('endpoint.{endpoint_name}.new-website'))
 
     def websites(self):
         """
@@ -284,7 +284,7 @@ class HttpRequires(EndpointInterface):
         websites = []
         #
         # Multiple relations can connect to the same endpoint. All relations
-        # of the same endpoint will be handled by the same EndpointInterface
+        # of the same endpoint will be handled by the same Endpoint
         # class.
         #
         # Loop over all units of all relations connected to this enpoint,


### PR DESCRIPTION
These changes update the interface developer docs to use the new Endpoint style for writing interface layers.  This PR is dependent on juju-solutions/charms.reactive#123 and must not be merged until then.