### PR TITLE
[devel + 2.2] change to signed 2.2.4 windows exe link

### DIFF
--- a/src/en/reference-install.md
+++ b/src/en/reference-install.md
@@ -58,7 +58,7 @@ Alternatively, you can manually install Juju from the following archive:
 ### Windows
 
 A Windows installer is available for Juju and can be found here:
-: [juju-setup-2.2.4.exe](https://launchpad.net/juju/2.2/2.2.4/+download/juju-setup-2.2.4.exe)([md5](https://launchpad.net/juju/2.2/2.2.4/+download/juju-setup-2.2.4.exe/+md5))
+: [juju-setup-2.2.4-signed.exe](https://launchpad.net/juju/2.2/2.2.4/+download/juju-setup-2.2.4-signed.exe)([md5](https://launchpad.net/juju/2.2/2.2.4/+download/juju-setup-2.2.4-signed.exe/+md5))
 {: .instruction }
 
 ### Centos and other Linuxes


### PR DESCRIPTION
Fixes #2121 

 - For 2.3, I will ask Core if they can try to have the signed exe ready for release time.
 - For 2.2, this PR can be backported to it.
 - For 2.1, the same file ([reference-install]( https://github.com/juju/docs/blob/2.1/src/en/reference-install.md)) needs to be updated. **I noticed that this file points to 2.2.1 for all non-Ubuntu platforms.** Is this normal?
 - For 2.0, an update is needed for [reference-releases](https://github.com/juju/docs/blob/2.0/src/en/reference-releases.md) to point to [juju-setup-2.0.4-signed.exe](https://launchpad.net/juju/2.0/2.0.4/+download/juju-setup-2.0.4-signed.exe).
 - For 1.25, no updates are needed (to [reference-releases](https://github.com/juju/docs/blob/1.25/src/en/reference-releases.md)).