### PR TITLE
remove review item from nav

### DIFF
--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -178,7 +178,6 @@
             <ul class="sub">
                 <li><a href="authors-charm-store.html#submitting-a-new-charm">Submit a charm</a></li>
                 <li><a href="authors-charm-policy.html">Charm store policy</a></li>
-                <li><a href="charm-review-process.html">Charm review process</a></li>
                 <li><a href="authors-charm-best-practice.html">Best practices</a></li>
                 <li><a href="authors-charm-icon.html">Charm Icons</a></li>
             </ul>


### PR DESCRIPTION
Recall that the review process has gone away but, for now, the review page remains. This PR is to simply remove a link to it from the menu.