### PR TITLE
CMR concepts and scenarios

### DIFF
--- a/src/en/charms-relations.md
+++ b/src/en/charms-relations.md
@@ -55,13 +55,13 @@ error: ambiguous relation: "mediawiki mysql" could refer to
 ```
 
 The solution is to be explicit when referring to an *endpoint*, where the
-latter has a format of `<application>:<application endpoint>`. In this case,
-the application endpoint is 'db' for both applications but because only the
-mediawiki endpoint is ambiguous (according to the error message), it is not
-necessary to mention the mysql endpoint:
+latter has a format of `<application>:<application endpoint>`. In this case, it
+is 'db' for both applications. However, it is not necessary to specify the
+mysql endpoint because only the mediawiki endpoint is ambiguous (according to
+the error message). Therefore, the command becomes:
 
 ```bash
-juju add-relation mediawiki:db mysql
+juju add-relation mysql mediawiki:db
 ```
 
 !!! Note:

--- a/src/en/charms-relations.md
+++ b/src/en/charms-relations.md
@@ -49,10 +49,21 @@ In some cases, there may be ambiguity about how the applications should connect.
 For example, in the case of specifying a database for the Mediawiki charm.
 
 ```bash
-juju add-relation mediawiki mysql
+juju add-relation mysql mediawiki 
 error: ambiguous relation: "mediawiki mysql" could refer to
   "mediawiki:db mysql:db"; "mediawiki:slave mysql:db"
 ```
+
+The solution is to specify the nature of the relation using the
+relation interface identifier. In this case, we want MySQL to provide the 
+backend database for mediawiki ('db' relation), so this is what we need to 
+enter:
+
+```bash
+juju add-relation mysql mediawiki:db
+```
+
+<!-- REMOVED FROM PR 2248, TO BE REVIEWED LATER
 
 The solution is to be explicit when referring to an *endpoint*, where the
 latter has a format of `<application>:<application endpoint>`. In this case, it
@@ -70,6 +81,8 @@ juju add-relation mysql mediawiki:db
     [Charm Store][charm-store] or by querying the Store with the
     [Charm Tools][charm-tools] (using a command like
     `charm show <application> charm-metadata`).
+
+-->
 
 We can check the output from `juju status` to make sure the correct relationship
 has been established:

--- a/src/en/charms-relations.md
+++ b/src/en/charms-relations.md
@@ -1,4 +1,5 @@
 Title: Managing relationships  
+TODO:  Critical: review required
 
 # Managing relationships
 
@@ -53,14 +54,21 @@ error: ambiguous relation: "mediawiki mysql" could refer to
   "mediawiki:db mysql:db"; "mediawiki:slave mysql:db"
 ```
 
-The solution is to specify the nature of the relation using the
-relation interface identifier. In this case, we want MySQL to provide the 
-backend database for mediawiki ('db' relation), so this is what we need to 
-enter:
+The solution is to be explicit with the ambiguous *interface*, where the latter
+has a format of `<application>:<application endpoint>`. In this case, the
+*endpoint* is 'db' for both but only the mediawiki interface is ambiguous, so
+this is what we can do:
 
 ```bash
 juju add-relation mediawiki:db mysql
 ```
+
+!!! Note:
+    An application endpoint can be discovered by looking at the metadata of the
+    corresponding charm. This can be done by examining the charm on the
+    [Charm Store][charm-store] or by querying the Store with the
+    [Charm Tools][charm-tools] (using a command like
+    `charm show <application> charm-metadata`).
 
 We can check the output from `juju status` to make sure the correct relationship
 has been established:
@@ -116,3 +124,5 @@ Relations can also work across models, even across multiple controllers. See
 <!-- LINKS -->
 
 [models-cmr]: ./models-cmr.html
+[charm-tools]: ./tools-charm-tools.html
+[charm-store]:  https://jujucharms.com

--- a/src/en/charms-relations.md
+++ b/src/en/charms-relations.md
@@ -54,10 +54,11 @@ error: ambiguous relation: "mediawiki mysql" could refer to
   "mediawiki:db mysql:db"; "mediawiki:slave mysql:db"
 ```
 
-The solution is to be explicit with the ambiguous *endpoint*, where the latter
-has a format of `<application>:<application endpoint>`. In this case, the
-application endpoint is 'db' for both but only the mediawiki interface is ambiguous, so
-this is what we can do:
+The solution is to be explicit when referring to an *endpoint*, where the
+latter has a format of `<application>:<application endpoint>`. In this case,
+the application endpoint is 'db' for both applications but because only the
+mediawiki endpoint is ambiguous (according to the error message), it is not
+necessary to mention the mysql endpoint:
 
 ```bash
 juju add-relation mediawiki:db mysql

--- a/src/en/charms-relations.md
+++ b/src/en/charms-relations.md
@@ -1,4 +1,4 @@
-Title: Managing relationships  
+Title: Managing relationships
 TODO:  Critical: review required
 
 # Managing relationships
@@ -50,13 +50,13 @@ For example, in the case of specifying a database for the Mediawiki charm.
 
 ```bash
 juju add-relation mediawiki mysql
-error: ambiguous relation: "mediawiki mysql" could refer to 
+error: ambiguous relation: "mediawiki mysql" could refer to
   "mediawiki:db mysql:db"; "mediawiki:slave mysql:db"
 ```
 
-The solution is to be explicit with the ambiguous *interface*, where the latter
+The solution is to be explicit with the ambiguous *endpoint*, where the latter
 has a format of `<application>:<application endpoint>`. In this case, the
-*endpoint* is 'db' for both but only the mediawiki interface is ambiguous, so
+application endpoint is 'db' for both but only the mediawiki interface is ambiguous, so
 this is what we can do:
 
 ```bash
@@ -110,7 +110,7 @@ juju remove-relation mediawiki mysql
 
 In cases where there is more than one relation between the two applications, it
 is necessary to specify the interface at least once:
-  
+
 ```bash
 juju remove-relation mediawiki mysql:db
 ```

--- a/src/en/models-cmr-scene-1.md
+++ b/src/en/models-cmr-scene-1.md
@@ -34,6 +34,9 @@ juju add-model cmr-model
 juju deploy mysql --constraints "cores=4 mem=16G root-disk=1T"
 ```
 
+!!! Note:
+    The created model is optional. The 'default' model could have been used.
+
 The output to `juju status` will eventually look similar to:
 
 ```no-highlight
@@ -184,11 +187,8 @@ Relation provider  Requirer      Interface  Type     Message
 mysql:db           mediawiki:db  mysql      regular
 ```
 
-As expected, this is very similar to the output we saw with model
-'wordpress-model'.
-
-The new output for model 'cmr-model' is also not surprising. There are now two
-connections to the original offer:
+The new `juju status` output for model 'cmr-model' is not surprising. There are
+now *two* connections to the original offer:
 
 ```no-highlight
 .
@@ -196,6 +196,16 @@ connections to the original offer:
 .
 Offer  Application  Charm  Rev  Connected  Endpoint  Interface  Role
 mysql  mysql        mysql  58   2/2        db        mysql      provider
+```
+
+```bash
+juju offers -m cmr-model
+```
+
+```no-highlight
+Offer  User   Relation id  Status  Endpoint  Interface  Role      Ingress subnets
+mysql  admin  1            joined  db        mysql      provider  54.198.91.120/32
+       admin  2            joined  db        mysql      provider  54.80.49.62/32
 ```
 
 ## Verification

--- a/src/en/models-cmr-scene-1.md
+++ b/src/en/models-cmr-scene-1.md
@@ -1,6 +1,10 @@
 Title: CMR scenario #1
+TODO:  Update 'juju status' output to show release versions
 
 # CMR scenario #1
+
+This page refers to [Cross model relations][models-cmr]. See that page for
+background information.
 
 In this example, we *build* a simple CMR infrastructure in step by step
 fashion, explaining each step along the way. A method of verifying the
@@ -11,12 +15,12 @@ controller; used by the admin user, and consumed by multiple models.
 
 ## Create a controller
 
-Create a controller. Here, the controller (and its model) will use the AWS
-public cloud:
+Create a controller, called 'aws-cmr' here. In this example, the controller
+(and its models) will use the AWS public cloud:
 
 ```bash
-juju add-credentials aws
-juju bootstrap aws aws-cmr-controller
+juju add-credential aws
+juju bootstrap aws aws-cmr
 ```
 
 ## Add the shared model and application
@@ -27,57 +31,58 @@ servicing several remote applications.
 
 ```bash
 juju add-model cmr-model
-juju deploy mysql --constraints "mem=16G root-disk=1T"
+juju deploy mysql --constraints "cores=4 mem=16G root-disk=1T"
 ```
 
-The output to `juju status` should eventually look similar to:
+The output to `juju status` will eventually look similar to:
 
 ```no-highlight
-Model      Controller          Cloud/Region   Version       SLA
-cmr-model  aws-cmr-controller  aws/us-east-1  2.3-alpha1.1  unsupported
+Model      Controller  Cloud/Region   Version      SLA
+cmr-model  aws-cmr     aws/us-east-1  2.3-beta2.1  unsupported
 
 App    Version  Status  Scale  Charm  Store       Rev  OS      Notes
-mysql  5.7.19   active      1  mysql  jujucharms   57  ubuntu
+mysql  5.7.19   active      1  mysql  jujucharms   58  ubuntu  
 
 Unit      Workload  Agent  Machine  Public address  Ports     Message
-mysql/0*  active    idle   0        23.20.241.57    3306/tcp  Ready
+mysql/0*  active    idle   0        54.81.205.47    3306/tcp  Ready
 
 Machine  State    DNS           Inst id              Series  AZ          Message
-0        started  23.20.241.57  i-065bddb4cf8843540  xenial  us-east-1a  running
+0        started  54.81.205.47  i-0f9f15e276ec3b5c2  xenial  us-east-1a  running
 
-Relation  Provides  Consumes  Type
-cluster   mysql     mysql     peer
+Relation provider  Requirer       Interface  Type  Message
+mysql:cluster      mysql:cluster  mysql-ha   peer
 ```
 
-Now make this MySQL service, and only this service, available to other models
-by referring to interface 'mysql:db' with the `juju offer` command:
+Now make the mysql application, and only that application, available to other
+models by referring to interface 'mysql:db' with the `juju offer` command:
 
 ```bash
 juju offer mysql:db
 ```
 
-The output will include the shared service's endpoint:
+!!! Note:
+    See [Managing relations][charms-relations] for how to determine the
+    interface used in the `juju offer` command.
 
-<!-- Below output is wrong! -->
+The output will include the shared application's endpoint:
 
 ```no-highlight
-Application "mysql" endpoints [db] available at "admin/cmr-model."
+Application "mysql" endpoints [db] available at "admin/cmr-model.mysql"
 ```
 
-Where the endpoint is `admin/cmr-model.mysql`.
+Where the offer URL is `admin/cmr-model.mysql`.
 
-Note that a model's endpoints can be queried with the `juju find-endpoints`
-command:
+All available offer endpoints (per model) can be listed like so:
 
 ```bash
-juju find-endpoints
+juju find-offers
 ```
 
-In this example, the output would like like:
+In this example, the output is:
 
 ```no-highlight
-Store               URL                    Access  Interfaces
-aws-cmr-controller  admin/cmr-model.mysql  admin   mysql:db
+Store    URL                    Access  Interfaces
+aws-cmr  admin/cmr-model.mysql  admin   mysql:db
 ```
 
 ## Add a first consumer model and application
@@ -85,7 +90,7 @@ aws-cmr-controller  admin/cmr-model.mysql  admin   mysql:db
 Add a consumer model and application. The application in this example will
 require a MySQL database and the objective is that it will use the one in the
 shared (CMR) model. The application we've chosen here is WordPress and we'll
-refer to the mysql unit's endpoint in the `juju relate` command:
+refer to the MySQL offer URL in the `juju relate` command:
 
 ```bash
 juju add-model wordpress-model
@@ -94,35 +99,42 @@ juju expose wordpress
 juju relate wordpress:db admin/cmr-model.mysql
 ```
 
+The last command has made use of a *cross model relation*.
+
 The output to `juju status` for this model will eventually settle down to look
 very much like:
 
 ```no-highlight
-Model            Controller          Cloud/Region   Version       SLA
-wordpress-model  aws-cmr-controller  aws/us-east-1  2.3-alpha1.1  unsupported
+Model            Controller  Cloud/Region   Version      SLA
+wordpress-model  aws-cmr     aws/us-east-1  2.3-beta2.1  unsupported
 
-SAAS   Status   Store               URL
-mysql  unknown  aws-cmr-controller  admin/cmr-model.mysql
+SAAS   Status   Store    URL
+mysql  unknown  aws-cmr  admin/cmr-model.mysql
 
 App        Version  Status  Scale  Charm      Store       Rev  OS      Notes
 wordpress           active      1  wordpress  jujucharms    5  ubuntu  exposed
 
 Unit          Workload  Agent  Machine  Public address  Ports   Message
-wordpress/0*  active    idle   0        54.196.30.61    80/tcp
+wordpress/0*  active    idle   0        54.198.91.120   80/tcp  
 
-Machine  State    DNS           Inst id              Series  AZ          Message
-0        started  54.196.30.61  i-0ce70d25f1d08500c  trusty  us-east-1a  running
+Machine  State    DNS            Inst id              Series  AZ          Message
+0        started  54.198.91.120  i-00332775f5f83d886  trusty  us-east-1a  running
 
-Relation      Provides   Consumes   Type
-db            mysql      wordpress  regular
-loadbalancer  wordpress  wordpress  peer
+Relation provider       Requirer                Interface     Type     Message
+mysql:db                wordpress:db            mysql         regular  
+wordpress:loadbalancer  wordpress:loadbalancer  reversenginx  peer
 ```
 
 Notice how the remote MySQL application shows up as a SAAS object. The
-relation is also included in the Relation section.
+relation is also described:
 
-Looking at the `juju status` of the CMR model we see a new entry in the
-Relation section that corresponds to the consuming model relation:
+```no-highlight
+Relation provider       Requirer                Interface     Type     Message
+mysql:db                wordpress:db            mysql         regular
+```
+
+Applying the `juju status` command to the CMR model we see that the offer is
+now connected:
 
 ```bash
 juju status -m cmr-model
@@ -134,13 +146,9 @@ Output:
 .
 .
 .
-Relation  Provides  Consumes                                 Type
-cluster   mysql     mysql                                    peer
-db        mysql     remote-19001893317b486080b99f806797d51f  regular
+Offer  Application  Charm  Rev  Connected  Endpoint  Interface  Role
+mysql  mysql        mysql  58   1/1        db        mysql      provider
 ```
-
-In the above, 'remote-19001893317b486080b99f806797d51f' is the actual name of
-a database that got created. We'll make use of this information later on.
 
 ## Add a second consumer model and application
 
@@ -157,48 +165,44 @@ juju relate mediawiki:db admin/cmr-model.mysql
 The output to `juju status` for this model will eventually become:
 
 ```no-highlight
-Model            Controller          Cloud/Region   Version       SLA
-mediawiki-model  aws-cmr-controller  aws/us-east-1  2.3-alpha1.1  unsupported
+Model            Controller  Cloud/Region   Version      SLA
+mediawiki-model  aws-cmr     aws/us-east-1  2.3-beta2.1  unsupported
 
-SAAS   Status   Store               URL
-mysql  unknown  aws-cmr-controller  admin/cmr-model.mysql
+SAAS   Status   Store    URL
+mysql  unknown  aws-cmr  admin/cmr-model.mysql
 
 App        Version  Status  Scale  Charm      Store       Rev  OS      Notes
 mediawiki  1.19.14  active      1  mediawiki  jujucharms   19  ubuntu  exposed
 
 Unit          Workload  Agent  Machine  Public address  Ports   Message
-mediawiki/0*  active    idle   0        54.224.30.3     80/tcp  Ready
+mediawiki/0*  active    idle   0        54.80.49.62     80/tcp  Ready
 
 Machine  State    DNS          Inst id              Series  AZ          Message
-0        started  54.224.30.3  i-04a4f1613a4224aa0  trusty  us-east-1a  running
+0        started  54.80.49.62  i-0b7530071c6242c19  trusty  us-east-1a  running
 
-Relation  Provides   Consumes  Type
-db        mediawiki  mysql     regular
+Relation provider  Requirer      Interface  Type     Message
+mysql:db           mediawiki:db  mysql      regular
 ```
 
 As expected, this is very similar to the output we saw with model
 'wordpress-model'.
 
-The new output for model 'cmr-model' is also not surprising:
+The new output for model 'cmr-model' is also not surprising. There are now two
+connections to the original offer:
 
 ```no-highlight
 .
 .
 .
-Relation  Provides  Consumes                                 Type
-cluster   mysql     mysql                                    peer
-db        mysql     remote-19001893317b486080b99f806797d51f  regular
-db        mysql     remote-640e658f832c4d1682abb9228823e6d6  regular
+Offer  Application  Charm  Rev  Connected  Endpoint  Interface  Role
+mysql  mysql        mysql  58   2/2        db        mysql      provider
 ```
-
-Clearly, a second database ('remote-640e658f832c4d1682abb9228823e6d6') is now
-present.
 
 ## Verification
 
-Verify that the remote application has responded to the cross model relation by
-creating/preparing the necessary resources. In this example, we log in to the
-mysql unit via SSH, connect to MySQL, and list its databases:
+Verify that the remote application has responded to the two cross model
+relations by creating/preparing the necessary resources. In this example, we
+log in to the mysql unit via SSH, connect to MySQL, and list its databases:
 
 ```bash
 juju ssh -m cmr-model mysql/0
@@ -215,11 +219,18 @@ The output should look similar to:
 | information_schema                      |
 | mysql                                   |
 | performance_schema                      |
-| remote-19001893317b486080b99f806797d51f |
-| remote-640e658f832c4d1682abb9228823e6d6 |
+| remote-9414c94f21db456d822045bb216c3b33 |
+| remote-9cc8d09e87674e3487442a64751eb386 |
 | sys                                     |
 +-----------------------------------------+
 6 rows in set (0.00 sec)
 ```
 
-From the output we can see evidence of the two databases that got created.
+From the output we can see evidence of two databases that got created, one for
+each consumer application.
+
+
+<!-- LINKS -->
+
+[models-cmr]: ./models-cmr.html
+[charms-relations]: ./charms-relations.html

--- a/src/en/models-cmr-scene-1.md
+++ b/src/en/models-cmr-scene-1.md
@@ -44,7 +44,7 @@ Model      Controller  Cloud/Region   Version      SLA
 cmr-model  aws-cmr     aws/us-east-1  2.3-beta2.1  unsupported
 
 App    Version  Status  Scale  Charm  Store       Rev  OS      Notes
-mysql  5.7.19   active      1  mysql  jujucharms   58  ubuntu  
+mysql  5.7.19   active      1  mysql  jujucharms   58  ubuntu
 
 Unit      Workload  Agent  Machine  Public address  Ports     Message
 mysql/0*  active    idle   0        54.81.205.47    3306/tcp  Ready
@@ -93,13 +93,13 @@ aws-cmr  admin/cmr-model.mysql  admin   mysql:db
 Add a consumer model and application. The application in this example will
 require a MySQL database and the objective is that it will use the one in the
 shared (CMR) model. The application we've chosen here is WordPress and we'll
-refer to the MySQL offer URL in the `juju relate` command:
+refer to the MySQL offer URL in the `juju add-relation` command:
 
 ```bash
 juju add-model wordpress-model
 juju deploy wordpress
 juju expose wordpress
-juju relate wordpress:db admin/cmr-model.mysql
+juju add-relation wordpress:db admin/cmr-model.mysql
 ```
 
 The last command has made use of a *cross model relation*.
@@ -118,13 +118,13 @@ App        Version  Status  Scale  Charm      Store       Rev  OS      Notes
 wordpress           active      1  wordpress  jujucharms    5  ubuntu  exposed
 
 Unit          Workload  Agent  Machine  Public address  Ports   Message
-wordpress/0*  active    idle   0        54.198.91.120   80/tcp  
+wordpress/0*  active    idle   0        54.198.91.120   80/tcp
 
 Machine  State    DNS            Inst id              Series  AZ          Message
 0        started  54.198.91.120  i-00332775f5f83d886  trusty  us-east-1a  running
 
 Relation provider       Requirer                Interface     Type     Message
-mysql:db                wordpress:db            mysql         regular  
+mysql:db                wordpress:db            mysql         regular
 wordpress:loadbalancer  wordpress:loadbalancer  reversenginx  peer
 ```
 
@@ -162,7 +162,7 @@ chosen now is MediaWiki.
 juju add-model mediawiki-model
 juju deploy mediawiki
 juju expose mediawiki
-juju relate mediawiki:db admin/cmr-model.mysql
+juju add-relation mediawiki:db admin/cmr-model.mysql
 ```
 
 The output to `juju status` for this model will eventually become:

--- a/src/en/models-cmr-scene-1.md
+++ b/src/en/models-cmr-scene-1.md
@@ -10,32 +10,20 @@ In this example, we *build* a simple CMR infrastructure in step by step
 fashion, explaining each step along the way. A method of verifying the
 deployment is provided at the end.
 
-This scenario describes a MediaWiki deployment, based within the same (LXD)
+This scenario describes a MediaWiki deployment, based within the same
 controller; used by the admin user, and consumed by multiple models.
 
-## Create a controller
+The controller is called 'aws-cmr' and the model name is 'cmr-model'.
 
-Create a controller, called 'aws-cmr' here. In this example, the controller
-(and its models) will use the AWS public cloud:
+## Deploy the application
 
-```bash
-juju add-credential aws
-juju bootstrap aws aws-cmr
-```
-
-## Add the shared model and application
-
-Add the shared CMR model and application in the usual way. Extra resources have
-been requested via constraints, since this shared MySQL should be capable of
-servicing several remote applications.
+Deploy the application in the usual way. Extra resources have been requested
+via constraints, since this shared MySQL should be capable of servicing several
+remote applications.
 
 ```bash
-juju add-model cmr-model
 juju deploy mysql --constraints "cores=4 mem=16G root-disk=1T"
 ```
-
-!!! Note:
-    The created model is optional. The 'default' model could have been used.
 
 The output to `juju status` will eventually look similar to:
 

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -1,4 +1,5 @@
 Title: CMR scenario #2
+TODO:  Update 'juju status' output to show release versions
 
 # CMR scenario #2
 
@@ -17,87 +18,99 @@ controllers, used by a non-admin user, and consumed by a single model.
 The infrastructure is built in this way:
 
 ```bash
-juju bootstrap localhost ctrl1
+juju bootstrap localhost lxd-cmr-1
+juju add-model cmr-model-1
 juju deploy mysql
 juju offer mysql:db
-juju bootstrap localhost ctrl2
+juju bootstrap localhost lxd-cmr-2
+juju add-model cmr-model-2
 juju deploy mediawiki
-juju relate mediawiki:db ctrl1:admin/default.mysql
+juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql
 ```
 
-### Viewing offers summary
+!!! Note:
+    The created models are optional. The 'default' model in each controller
+    could have been used.
 
-Offer summary information shows up in status.
+## juju status
+
+The `juju status` command provides a summary of what offers have been made.
+Here we'll apply it to the model 'cmr-model-1' in the 'lxd-cmr-1' controller:
 
 ```bash
-juju status
+juju status -m lxd-cmr-1:cmr-model-1
 ```
 
 ```no-highlight
-Model    Controller  Cloud/Region   Version       SLA
-default  ianaws      aws/us-east-1  2.3-alpha1.1  unsupported
+Model        Controller  Cloud/Region         Version      SLA
+cmr-model-1  lxd-cmr-1   localhost/localhost  2.3-beta2.1  unsupported
 
 App    Version  Status  Scale  Charm  Store       Rev  OS      Notes
-mysql  5.5.57   active      1  mysql  jujucharms   57  ubuntu  
+mysql  5.7.19   active      1  mysql  jujucharms   58  ubuntu  
 
 Unit      Workload  Agent  Machine  Public address  Ports     Message
-mysql/1*  active    idle   1        54.237.63.211   3306/tcp  Ready
+mysql/0*  active    idle   0        10.87.144.223   3306/tcp  Ready
 
-Machine  State    DNS            Inst id              Series  AZ Message
-1        started  54.237.63.211  i-0e819d97de8943e38  trusty  us-east-1b running
+Machine  State    DNS            Inst id        Series  AZ  Message
+0        started  10.87.144.223  juju-22a641-0  xenial      Running
 
 Offer  Application  Charm  Rev  Connected  Endpoint  Interface  Role
-mysql  mysql        mysql  57   1/1        db        mysql      provider
+mysql  mysql        mysql  58   1/1        db        mysql      provider
 
 Relation provider  Requirer       Interface  Type  Message
-mysql:cluster      mysql:cluster  mysql-ha   peer  
+mysql:cluster      mysql:cluster  mysql-ha   peer
 ```
 
-The connected counts show the number of active connections to the offer and the
-total number of connections including those suspended.
+In the 'Offer' section, the 'Connected' column shows the number of active
+connections to the offer and the total number of connections/relations
+(including those suspended).
 
-### Viewing offers and any connections
+## juju list-offers
 
-There's also a list-offers command. The summary format shows the same
-information as in status.
+The `juju list-offers` command (alias `juju offers`) shows similar information.
+However, it also allows for several formats, each of which displays different
+kinds of information.
+
+The 'summary' format provides information very similar to that gained via the
+`juju status` command (it adds the offer URL):
 
 ```bash
-juju offers --format summary
+juju list-offers --format summary
 ```
 
 ```no-highlight
-Offer  Application  Charm        Connected  Store   URL 		 Endpoint  Interface  Role
-mysql  mysql        cs:mysql-57  1/1        ianaws  admin/default.mysql  db  	   mysql      provider
+Offer  Application  Charm        Connected  Store      URL                      Endpoint  Interface  Role
+mysql  mysql        cs:mysql-58  1/1        lxd-cmr-1  admin/cmr-model-1.mysql  db        mysql      provider
 ```
 
-The YAML format shows additional information, such as who is allowed to access
-the offer (see managing offer access) and what ingress subnets are required to
-allow traffic from the consuming model.
+The 'yaml' format shows additional information, such as who is allowed to
+access the offer (see managing offer access) and what ingress subnets are
+required to allow traffic from the consuming model:
 
 ```bash
-juju offers --format yaml
+juju list-offers -m lxd-cmr-1:cmr-model-1 --format yaml
 ```
 
 ```no-highlight
 mysql:
   application: mysql
-  store: ianaws
-  charm: cs:mysql-57
-  offer-url: admin/default.mysql
+  store: lxd-cmr-1
+  charm: cs:mysql-58
+  offer-url: admin/cmr-model-1.mysql
   endpoints:
     db:
       interface: mysql
       role: provider
   connections:
-  - source-model-uuid: b9d3db4c-49c9-4802-8269-a9b03216fc34
+  - source-model-uuid: e0aaf3d9-0547-4ec3-8106-75615e48a419
     username: admin
-    relation-id: 2
+    relation-id: 1
     endpoint: db
     status:
       current: joined
-      since: 1 hour ago
+      since: 4 hours ago
     ingress-subnets:
-    - 69.193.151.51/32
+    - 10.87.144.189/32
   users:
     admin:
       display-name: admin
@@ -106,111 +119,98 @@ mysql:
       access: read
 ```
 
-The tabular format (the default) shows each relation (connection) to the offer
-from a consuming model.
+The 'tabular' format (the default) shows each relation (connection) to the
+offer from the consuming model:
 
 ```bash
-juju offers
+juju list-offers -m lxd-cmr-1:cmr-model-1
 ```
 
 ```no-highlight
 Offer  User   Relation id  Status  Endpoint  Interface  Role      Ingress subnets
-mysql  admin  2            joined  db        mysql      provider  69.193.151.51/32
+mysql  admin  1            joined  db        mysql      provider  10.87.144.189/32
 ```
 
-The list offers command can filter the offers included in the result.
+!!! Note:
+This command can also filter what offers are included in the result. Note that,
+for brevity, the scenario model is not specified in the below examples.
 
-All offers for a given application:
+To list all offers for a given application:
+ 
+```bash
+juju list-offers --application mysql
+```
+
+To list all offers for a given interface:
 
 ```bash
-juju offers --application mysql
+juju list-offers --interface mysql
 ```
 
-All offers for a given interface:
+To list all offers for a given user who has created a relation to the offer:
 
 ```bash
-juju offers --interface mysql
+juju list-offers --connected-user <user name>
 ```
 
-All offers for a given user who has related to the offer:
+To list all offers for a given user who can consume the offer:
 
 ```bash
-juju offers --connected-user fred
+juju list-offers --format summary --allowed-consumer <user name> 
 ```
 
-All offers for a given user who can consume the offer:
-
-```bash
-juju offers --format summary --allowed-consumer mary 
-```
-
-The above command is best run with --format summary as the intent is to see,
+The above command is best run with '--format summary' as the intent is to see,
 for a given user, what offers they might relate to, regardless of whether there
 are existing relations (which is what the tabular view shows).
 
-A specific offer:
+To list a specific offer:
 
 ```bash
-juju offers mysql
+juju list-offers mysql
 ```
 
-### Viewing offers details
+## juju show-offer
 
-The show-offer command gives details about a given offer.
+The `juju show-offer` command gives details about a specific offer:
 
 ```bash
-juju show-offer default.mysql
+juju show-offer lxd-cmr-1:admin/cmr-model-1.mysql
 ```
 
 ```no-highlight
-Store   URL                  Access  Description 				   Endpoint  Interface  Role
-ianaws  admin/default.mysql  admin   MySQL is a fast, stable and true multi-user,  db        mysql      provider
-                                     multi-threaded SQL database server. SQL                             
-                                     (Structured Query Language) is the most                             
-                                     popular database query language in the world.                       
-                                     The ma...                                                           
+Store      URL                      Access  Description                                    Endpoint  Interface  Role
+lxd-cmr-1  admin/cmr-model-1.mysql  admin   MySQL is a fast, stable and true multi-user,   db        mysql      provider
+                                            multi-threaded SQL database server. SQL                             
+                                            (Structured Query Language) is the most                             
+                                            popular database query language in the world.                       
+                                            The ma...
 ```
 
-For more details, including which users can access the offer, the YAML
-format.
+Notice how this command takes the offer URL as the argument. The controller
+portion (`lxd-cmr-1`) can be omitted if the current controller contains the
+offer.
+
+For more details, including which users can access the offer, use the 'yaml'
+format:
 
 ```bash
-juju show-offer default.mysql --format yaml
-```
-
-```no-highlight
-ianaws:admin/default.mysql:
-  description: |
-    MySQL is a fast, stable and true multi-user, multi-threaded SQL database
-    server. SQL (Structured Query Language) is the most popular database query
-    language in the world. The main goals of MySQL are speed, robustness and
-    ease of use.
-  access: admin
-  endpoints:
-    db:
-      interface: mysql
-      role: provider
-  users:
-    admin:
-      display-name: admin
-      access: admin
-    everyone@external:
-      access: read
+juju show-offer lxd-cmr-1:admin/cmr-model-1.mysql --format yaml
 ```
 
 A non-admin user with read/consume access can also view an offer's details, but
-they won't see the information for users with access.
+they won't see user ACL information.
 
-## Finding offers to use
+## juju find-offers
 
 Offers can be searched based on various criteria:
-URL (or part thereof)
-offer name
-model name
-interface
 
-The results will show information about the offer, including the level of
-access the user making the query has on each offer.
+ - URL (or part thereof)
+ - offer name
+ - model name
+ - interface
+
+The results will show information about the offer, including the access level
+the user making the query has on each offer.
 
 To find all offers on a specified controller:
 
@@ -272,7 +272,7 @@ To find offers with "sql" in the name:
 juju find-offers --offer sql ian:
 ```
 
-### Relating to offers from behind a firewall
+## Relating to offers from behind a firewall
 
 Sometimes, the consuming application is deployed behind a firewall where NAT is
 used, such that traffic egresses via a different address/network to that on

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -41,12 +41,14 @@ Here we'll apply it to the model 'cmr-model-1' in the 'lxd-cmr-1' controller:
 juju status -m lxd-cmr-1:cmr-model-1
 ```
 
+Output:
+
 ```no-highlight
 Model        Controller  Cloud/Region         Version      SLA
 cmr-model-1  lxd-cmr-1   localhost/localhost  2.3-beta2.1  unsupported
 
 App    Version  Status  Scale  Charm  Store       Rev  OS      Notes
-mysql  5.7.19   active      1  mysql  jujucharms   58  ubuntu  
+mysql  5.7.19   active      1  mysql  jujucharms   58  ubuntu
 
 Unit      Workload  Agent  Machine  Public address  Ports     Message
 mysql/0*  active    idle   0        10.87.144.223   3306/tcp  Ready
@@ -78,6 +80,8 @@ The 'summary' format provides information very similar to that gained via the
 juju list-offers --format summary
 ```
 
+Output:
+
 ```no-highlight
 Offer  Application  Charm        Connected  Store      URL                      Endpoint  Interface  Role
 mysql  mysql        cs:mysql-58  1/1        lxd-cmr-1  admin/cmr-model-1.mysql  db        mysql      provider
@@ -90,6 +94,8 @@ required to allow traffic from the consuming model:
 ```bash
 juju list-offers -m lxd-cmr-1:cmr-model-1 --format yaml
 ```
+
+Output:
 
 ```no-highlight
 mysql:
@@ -126,17 +132,20 @@ offer from the consuming model:
 juju list-offers -m lxd-cmr-1:cmr-model-1
 ```
 
+Output:
+
 ```no-highlight
 Offer  User   Relation id  Status  Endpoint  Interface  Role      Ingress subnets
 mysql  admin  1            joined  db        mysql      provider  10.87.144.189/32
 ```
 
 !!! Note:
-This command can also filter what offers are included in the result. Note that,
-for brevity, the scenario model is not specified in the below examples.
+    This command can also filter what offers are included in the result. Note
+    that, for brevity, the scenario model is not specified in the below
+    examples.
 
 To list all offers for a given application:
- 
+
 ```bash
 juju list-offers --application mysql
 ```
@@ -156,7 +165,7 @@ juju list-offers --connected-user <user name>
 To list all offers for a given user who can consume the offer:
 
 ```bash
-juju list-offers --format summary --allowed-consumer <user name> 
+juju list-offers --format summary --allowed-consumer <user name>
 ```
 
 The above command is best run with '--format summary' as the intent is to see,
@@ -177,12 +186,14 @@ The `juju show-offer` command gives details about a specific offer:
 juju show-offer lxd-cmr-1:admin/cmr-model-1.mysql
 ```
 
+Output:
+
 ```no-highlight
 Store      URL                      Access  Description                                    Endpoint  Interface  Role
 lxd-cmr-1  admin/cmr-model-1.mysql  admin   MySQL is a fast, stable and true multi-user,   db        mysql      provider
-                                            multi-threaded SQL database server. SQL                             
-                                            (Structured Query Language) is the most                             
-                                            popular database query language in the world.                       
+                                            multi-threaded SQL database server. SQL
+                                            (Structured Query Language) is the most
+                                            popular database query language in the world.
                                             The ma...
 ```
 
@@ -191,11 +202,7 @@ portion (`lxd-cmr-1`) can be omitted if the current controller contains the
 offer.
 
 For more details, including which users can access the offer, use the 'yaml'
-format:
-
-```bash
-juju show-offer lxd-cmr-1:admin/cmr-model-1.mysql --format yaml
-```
+format.
 
 A non-admin user with read/consume access can also view an offer's details, but
 they won't see user ACL information.
@@ -207,33 +214,36 @@ Offers can be searched based on various criteria:
  - URL (or part thereof)
  - offer name
  - model name
- - interface
+ - interface name
 
-The results will show information about the offer, including the access level
-the user making the query has on each offer.
+The results will show information about the offer, including the ACL
+permissions (of the user making the query).
 
-To find all offers on a specified controller:
-
-```bash
-juju find-offers ian:
-```
-
-```no-highlight
-Store  URL                         Access  Interfaces
-ian    admin/default.hosted-mysql  admin   mysql:db
-ian    admin/default.mysql-admin   admin   mysql-root:db-admin, mysql:db
-ian    admin/default.postgresql    admin   pgsql:db
-```
-
-As with the list-offers command, the YAML output will show extra information,
-including users who can access the offer (if an admin makes the query).
+To find all offers on controller `lxd-cmr-1`:
 
 ```bash
-juju find-offers --offer hosted-mysql --format yaml
+juju find-offers lxd-cmr-1:
 ```
 
+Output:
+
 ```no-highlight
-ian:admin/default.hosted-mysql:
+Store      URL                      Access  Interfaces
+lxd-cmr-1  admin/cmr-model-1.mysql  admin   mysql:db
+```
+
+The 'yaml' format will display extra information, including users who can
+access the offer (if an admin is making the query). Below we show this, in
+addition to searching by offer name:
+
+```bash
+juju find-offers lxd-cmr-1: --offer mysql --format yaml
+```
+
+Output:
+
+```no-highlight
+lxd-cmr-1:admin/cmr-model-1.mysql:
   access: admin
   endpoints:
     db:
@@ -247,45 +257,28 @@ ian:admin/default.hosted-mysql:
       access: read
 ```
 
-To find offers in a specified model:
+To find offers in model `cmr-model-1` on controller `lxd-cmr-1`:
 
 ```bash
-juju find-offers admin/default
-juju find-offers ian:admin/default
-```
-
-To find offers with a specified interface on the current controller:
-
-```bash
-juju find-offers --interface mysql
-```
-
-To find offers with a specified interface on a specific controller:
-
-```bash
-juju find-offers --interface mysql ian:
-```
-
-To find offers with "sql" in the name:
-
-```bash
-juju find-offers --offer sql ian:
+juju find-offers lxd-cmr-1:admin/cmr-model-1
 ```
 
 ## Relating to offers from behind a firewall
 
-Sometimes, the consuming application is deployed behind a firewall where NAT is
-used, such that traffic egresses via a different address/network to that on
-which the consuming application is hosted.
+When the consuming model is behind a NAT firewall its traffic will typically
+exit (egress) that firewall with a modified address/network. In this case, the
+`--via` option can be used with the `juju relate` command to ensure that the
+traffic can return successfully to the consuming application. This option
+provides the offering model the information it needs to create the necessary
+firewall rules.
 
-In this case, the relate --via option is used to inform the offering side so
-that the correct firewall rules can be set up.
+For example,
 
 ```bash
 juju relate mediawiki:db ian:admin/default.mysql --via 69.32.56.0/8
 ```
 
-The --via value is a comma separated list of subnets in CIDR notation. This
+The `--via` value is a comma separated list of subnets in CIDR notation. This
 includes the /32 case where a single NATed IP address is used for egress.
 
 It's also possible to set up egress subnets as a model configuration value so
@@ -336,7 +329,7 @@ juju offers --connected-user fred
 All offers for a given user who can consume the offer:
 
 ```bash
-juju offers --format summary --allowed-consumer mary 
+juju offers --format summary --allowed-consumer mary
 ```
 
 The above command is best run with --format summary as the intent is to see,

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -275,71 +275,18 @@ firewall rules.
 For example,
 
 ```bash
-juju relate mediawiki:db ian:admin/default.mysql --via 69.32.56.0/8
+juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.0/8
 ```
 
 The `--via` value is a comma separated list of subnets in CIDR notation. This
 includes the /32 case where a single NATed IP address is used for egress.
 
 It's also possible to set up egress subnets as a model configuration value so
-that all cross model relations use those subnets without needing to use the
+that all cross model relations use those subnets without the need of the
 `--via` option.
 
 ```bash
 juju model-config egress-subnets=69.32.56.0/8
-```
-
-## Inspecting relations to an offer
-
-The offers command is used to see all connections to one more offers.
-
-```bash
-juju offers mysql
-```
-
-```no-highlight
-Offer  User   Relation id  Status  Endpoint  Interface  Role      Ingress subnets
-mysql  admin  2            joined  db        mysql      provider  69.193.151.51/32
-```
-
-The (default) tabular view shows the connected user and ingress subnets in user
-with that connection. Use the YAML output to see extra detail such as the UUID
-of the consuming model.
-
-The list offers command can filter the offers included in the result.
-
-All offers for a given application:
-
-```bash
-juju offers --application mysql
-```
-
-All offers for a given interface:
-
-```bash
-juju offers --interface mysql
-```
-
-All offers for a given user who has related to the offer:
-
-```bash
-juju offers --connected-user fred
-```
-
-All offers for a given user who can consume the offer:
-
-```bash
-juju offers --format summary --allowed-consumer mary
-```
-
-The above command is best run with --format summary as the intent is to see,
-for a given user, what offers they might relate to, regardless of whether there
-are existing relations (which is what the tabular view shows).
-
-A specific offer:
-
-```bash
-juju offers mysql
 ```
 
 

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -88,8 +88,8 @@ mysql  mysql        cs:mysql-58  1/1        lxd-cmr-1  admin/cmr-model-1.mysql  
 ```
 
 The 'yaml' format shows additional information, such as who is allowed to
-access the offer (see managing offer access) and what ingress subnets are
-required to allow traffic from the consuming model:
+access the offer and what ingress subnets are required to allow traffic from
+the consuming model:
 
 ```bash
 juju list-offers -m lxd-cmr-1:cmr-model-1 --format yaml
@@ -265,28 +265,13 @@ juju find-offers lxd-cmr-1:admin/cmr-model-1
 
 ## Relating to offers from behind a firewall
 
-When the consuming model is behind a NAT firewall its traffic will typically
-exit (egress) that firewall with a modified address/network. In this case, the
-`--via` option can be used with the `juju relate` command to ensure that the
-traffic can return successfully to the consuming application. This option
-provides the offering model the information it needs to create the necessary
-firewall rules.
+Let the consuming model in this scenario be protected by a firewall that NATs
+all outgoing traffic to the single IPv4 address of 69.32.56.10/32.
 
-For example,
+Now request to the offering side to allow this address to contact the offer:
 
 ```bash
-juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.0/8
-```
-
-The `--via` value is a comma separated list of subnets in CIDR notation. This
-includes the /32 case where a single NATed IP address is used for egress.
-
-It's also possible to set up egress subnets as a model configuration value so
-that all cross model relations use those subnets without the need of the
-`--via` option.
-
-```bash
-juju model-config egress-subnets=69.32.56.0/8
+juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.10/32
 ```
 
 

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -28,10 +28,6 @@ juju deploy mediawiki
 juju add-relation mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql
 ```
 
-!!! Note:
-    The created models are optional. The 'default' model in each controller
-    could have been used.
-
 ## juju status
 
 The `juju status` command provides a summary of what offers have been made.

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -2,6 +2,9 @@ Title: CMR scenario #2
 
 # CMR scenario #2
 
+This page refers to [Cross model relations][models-cmr]. See that page for
+background information.
+
 In this example, we *supply* a CMR infrastructure "out of the box" with a few
 nimble commands and then proceed to query, poke, analyse, and finally extend it
 by exploring multi-user functionality and firewall concerns.
@@ -168,7 +171,7 @@ ianaws  admin/default.mysql  admin   MySQL is a fast, stable and true multi-user
                                      The ma...                                                           
 ```
 
-For more details, including which users can access the offer, the the YAML
+For more details, including which users can access the offer, the YAML
 format.
 
 ```bash
@@ -222,7 +225,7 @@ ian    admin/default.mysql-admin   admin   mysql-root:db-admin, mysql:db
 ian    admin/default.postgresql    admin   pgsql:db
 ```
 
-As with the list-offers command, the YAMl output will show extra information,
+As with the list-offers command, the YAML output will show extra information,
 including users who can access the offer (if an admin makes the query).
 
 ```bash
@@ -285,9 +288,9 @@ juju relate mediawiki:db ian:admin/default.mysql --via 69.32.56.0/8
 The --via value is a comma separated list of subnets in CIDR notation. This
 includes the /32 case where a single NATed IP address is used for egress.
 
-It's also possible to set up egress subnets as a model config value so that all
-cross model relations use those subnets without needing to use the --via
-option.
+It's also possible to set up egress subnets as a model configuration value so
+that all cross model relations use those subnets without needing to use the
+`--via` option.
 
 ```bash
 juju model-config egress-subnets=69.32.56.0/8
@@ -345,3 +348,8 @@ A specific offer:
 ```bash
 juju offers mysql
 ```
+
+
+<!-- LINKS -->
+
+[models-cmr]: ./models-cmr.html

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -276,12 +276,11 @@ juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.10/32
 
 This will work providing the offering side did not previously set up a
 whitelist of addresses (or subnets) that *does not* include the above address.
-That is, it *will* work out if this had been done:
+That is, it *will* work if this had been done:
 
 ```bash
-juju set-firewall-rule juju-application-offer --whitelist 69.32.56.10/8
+juju set-firewall-rule juju-application-offer --whitelist 69.32.56.0/8
 ```
-
 
 
 <!-- LINKS -->

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -274,6 +274,15 @@ Now request to the offering side to allow this address to contact the offer:
 juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.10/32
 ```
 
+This will work providing the offering side did not previously set up a
+whitelist of addresses (or subnets) that *does not* include the above address.
+That is, it *will* work out if this had been done:
+
+```bash
+juju set-firewall-rule juju-application-offer --whitelist 69.32.56.10/8
+```
+
+
 
 <!-- LINKS -->
 

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -8,7 +8,7 @@ background information.
 
 In this example, we *supply* a CMR infrastructure "out of the box" with a few
 nimble commands and then proceed to query, poke, analyse, and finally extend it
-by exploring multi-user functionality and firewall concerns.
+by addressing firewall concerns.
 
 This scenario describes a MediaWiki deployment, based upon multiple (LXD)
 controllers, used by a non-admin user, and consumed by a single model.
@@ -67,9 +67,9 @@ In the 'Offer' section, the 'Connected' column shows the number of active
 connections to the offer and the total number of connections/relations
 (including those suspended).
 
-## juju list-offers
+## juju offers
 
-The `juju list-offers` command (alias `juju offers`) shows similar information.
+The `juju offers` command (alias `juju list-offers`) shows similar information.
 However, it also allows for several formats, each of which displays different
 kinds of information.
 
@@ -77,7 +77,7 @@ The 'summary' format provides information very similar to that gained via the
 `juju status` command (it adds the offer URL):
 
 ```bash
-juju list-offers --format summary
+juju offers --format summary
 ```
 
 Output:
@@ -92,7 +92,7 @@ access the offer and what ingress subnets are required to allow traffic from
 the consuming model:
 
 ```bash
-juju list-offers -m lxd-cmr-1:cmr-model-1 --format yaml
+juju offers -m lxd-cmr-1:cmr-model-1 --format yaml
 ```
 
 Output:
@@ -129,7 +129,7 @@ The 'tabular' format (the default) shows each relation (connection) to the
 offer from the consuming model:
 
 ```bash
-juju list-offers -m lxd-cmr-1:cmr-model-1
+juju offers -m lxd-cmr-1:cmr-model-1
 ```
 
 Output:
@@ -147,25 +147,25 @@ mysql  admin  1            joined  db        mysql      provider  10.87.144.189/
 To list all offers for a given application:
 
 ```bash
-juju list-offers --application mysql
+juju offers --application mysql
 ```
 
 To list all offers for a given interface:
 
 ```bash
-juju list-offers --interface mysql
+juju offers --interface mysql
 ```
 
 To list all offers for a given user who has created a relation to the offer:
 
 ```bash
-juju list-offers --connected-user <user name>
+juju offers --connected-user <user name>
 ```
 
 To list all offers for a given user who can consume the offer:
 
 ```bash
-juju list-offers --format summary --allowed-consumer <user name>
+juju offers --format summary --allowed-consumer <user name>
 ```
 
 The above command is best run with '--format summary' as the intent is to see,
@@ -175,7 +175,7 @@ are existing relations (which is what the tabular view shows).
 To list a specific offer:
 
 ```bash
-juju list-offers mysql
+juju offers mysql
 ```
 
 ## juju show-offer
@@ -260,7 +260,7 @@ lxd-cmr-1:admin/cmr-model-1.mysql:
 To find offers in model `cmr-model-1` on controller `lxd-cmr-1`:
 
 ```bash
-juju find-offers lxd-cmr-1:admin/cmr-model-1
+juju find-offers lxd-cmr-1:cmr-model-1
 ```
 
 ## Relating to offers from behind a firewall
@@ -268,18 +268,17 @@ juju find-offers lxd-cmr-1:admin/cmr-model-1
 Let the consuming model in this scenario be protected by a firewall that NATs
 all outgoing traffic to the single IPv4 address of 69.32.56.10/32.
 
-Now request to the offering side to allow this address to contact the offer:
+Here, the admin on the offering side decided to create a whitelist consisting
+of a range of addresses known to cover the consuming side:
+
+```bash
+juju set-firewall-rule juju-application-offer --whitelist 69.32.0.0/16
+```
+
+Now request to have the single NAT address contact the offer:
 
 ```bash
 juju add-relation mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.10/32
-```
-
-This will work providing the offering side did not previously set up a
-whitelist of addresses (or subnets) that *does not* include the above address.
-That is, it *will* work if this had been done:
-
-```bash
-juju set-firewall-rule juju-application-offer --whitelist 69.32.56.0/8
 ```
 
 

--- a/src/en/models-cmr-scene-2.md
+++ b/src/en/models-cmr-scene-2.md
@@ -25,7 +25,7 @@ juju offer mysql:db
 juju bootstrap localhost lxd-cmr-2
 juju add-model cmr-model-2
 juju deploy mediawiki
-juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql
+juju add-relation mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql
 ```
 
 !!! Note:
@@ -271,7 +271,7 @@ all outgoing traffic to the single IPv4 address of 69.32.56.10/32.
 Now request to the offering side to allow this address to contact the offer:
 
 ```bash
-juju relate mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.10/32
+juju add-relation mediawiki:db lxd-cmr-1:admin/cmr-model-1.mysql --via 69.32.56.10/32
 ```
 
 This will work providing the offering side did not previously set up a

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -4,11 +4,7 @@ Title: Cross Model Relations
 
 Introduced terms "shared model" and "consumer model".
 
-How to determine a unit's interface (e.g. mysql:db)?
-
 Need to add links from other pages.
-
-Also 'show-endpoints' and 'offers' (admin sees more).
 
 -->
 
@@ -243,10 +239,10 @@ as the application proxy, resulting in all relations being removed.
 
 The following CMR scenarios will be examined:
 
-- [Scenario #1][scenario-1]  
+- [Scenario #1][scenario-1]
   A MediaWiki deployment, based within the **same** controller, used by the
   **admin** user, but consumed by **multiple** models.
-- [Scenario #2][scenario-2]  
+- [Scenario #2][scenario-2]
   A MediaWiki deployment, based within **multiple** controllers, used by a
   **non-admin** user, and consumed by a **single** model.
 

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -1,13 +1,9 @@
 Title: Cross Model Relations
+TODO:  Consider adding scenario #3: different cloud types
 
 <!--
 
-Introduced terms "shared model" and "consumer model".
-
 Need to add links from other pages.
-
-Mention as use case models based in different clouds. Consider another scenario
-like this.
 
 -->
 
@@ -20,7 +16,8 @@ clouds.
 
 CMR addresses the case where one may wish to centralize services within one
 model and share them with disparate models. One can imagine models dedicated to
-tasks such as service monitoring, block storage, and database backends.
+tasks such as service monitoring, block storage, and database backends. Another
+use case would be when you are simply using different cloud types.
 
 The commands related specifically to this subject are:
 
@@ -163,28 +160,22 @@ Offers which have been consumed show up in `juju status` in the SAAS section.
 
 ### Relations and firewalls
 
-The (intended) consumer application may be deployed behind a NAT firewall, such
-that traffic exits (egresses) its network with a different address/network
-assigned.
-
-In this case, the relate `--via` option is used to inform the offering side so
-that the correct firewall rules can be set up.
+When the consuming model is behind a NAT firewall its traffic will typically
+exit (egress) that firewall with a modified address/network. In this case, the
+`--via` option can be used with the `juju relate` command to request the
+firewall on the offering side to allow this traffic. This option specifies the
+NATed address (or network) in CIDR notation:
 
 `juju relate <application> <offer url> --via <cidr subnet>`
 
-The `--via` value is a comma separated list of subnets in CIDR notation. This
-includes the /32 case where a single NATed IP address is used for egress.
-
-It's possible to set up egress subnets as a model configuration value so that
-all cross model relations use those subnets without the need of the `--via`
-option.
+It's possible to set this up in advance at the model level in this way:
 
 `juju model-config egress-subnets=<cidr subnet>`
 
-The above command is applied to the **consuming** model.
+To be clear, the above command is applied to the **consuming** model.
 
-However, an administrator can control what incoming traffic (ingress) is
-allowed to contact the offering model by whitelisting subnets:
+However, an administrator can control what incoming traffic is allowed to
+contact the offering model by whitelisting subnets:
 
 `juju set-firewall-rule juju-application-offer --whitelist <cidr subnet>`
 

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -244,10 +244,10 @@ as the application proxy, resulting in all relations being removed.
 
 The following CMR scenarios will be examined:
 
-- [Scenario #1][scenario-1]
+- [Scenario #1][scenario-1]  
   A MediaWiki deployment, based within the **same** controller, used by the
   **admin** user, but consumed by **multiple** models.
-- [Scenario #2][scenario-2]
+- [Scenario #2][scenario-2]  
   A MediaWiki deployment, based within **multiple** controllers, used by a
   **non-admin** user, and consumed by a **single** model.
 

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -1,6 +1,7 @@
 Title: Cross Model Relations
 TODO:  Add scenario #3: different cloud types
-       Add commands to a scenario: grant|revoke, suspend|resume
+       Add commands to a scenario: grant|revoke, suspend|resume, remove-offer
+       Bug tracking: https://pad.lv/1726945
 
 <!--
 
@@ -23,34 +24,34 @@ use case would be when you are simply using different cloud types.
 The commands related specifically to this subject are:
 
 [`consume`][commands-consume]
-: Adds a remote offer to a model without relating to it.
+: Links an offer to a model. Does not relate to it.
 
 [`find-offers`][commands-find-offers]
-: Finds offered application endpoints.
+: Finds URLs and endpoints of available offers.
 
 [`list-firewall-rules`][commands-list-firewall-rules]
-: Prints the firewall rules.
-
-[`list-offers`][commands-list-offers]
-: Lists shared endpoints.
+: Lists the firewall rules.
 
 [`offer`][commands-offer]
-: Offers application endpoints for use in other models.
+: Creates an offer.
+
+[`offers`][commands-offers]
+: Lists connected (related to) offers.
 
 [`remove-offer`][commands-remove-offer]
-: Removes one or more offers.
+: Removes an offer.
 
 [`resume-relation`][commands-resume-relation]
-: Resumes a suspended relation to an application offer.
+: Resumes a suspended relation to an offer.
 
 [`set-firewall-rule`][commands-set-firewall-rule]
 : Sets a firewall rule.
 
 [`show-offer`][commands-show-offer]
-: Shows offered applications' endpoints details.
+: Shows details of connected (related to) offers.
 
 [`suspend-relation`][commands-suspend-relation]
-: Suspends a relation to an application offer.
+: Suspends a relation to an offer.
 
 See [Models][models] and [Managing relations][charms-relations] for beginner
 information on those topics.
@@ -58,6 +59,9 @@ information on those topics.
 This page presents the **concepts** behind cross model relations as well as
 two example **scenarios** that aim to reinforce those concepts through
 practical usage.
+
+!!! Note:
+    The functionality of CMR is not exposed in the GUI at this time.
 
 ## Concepts
 
@@ -135,12 +139,12 @@ their model and establish a relation to the offer by way of its URL.
 The controller part of the URL is optional if the other model resides in
 the same controller.
 
-`juju relate <application>[:<application endpoint>] <offer url>[:<offer endpoint>]`
+`juju add-relation <application>[:<application endpoint>] <offer url>[:<offer endpoint>]`
 
 Specifying the endpoint for the application and the offer is analogous to
 normal relations. They can be added but are often unnecessary:
 
-`juju relate <application> <offer url>`
+`juju add-relation <application> <offer url>`
 
 When an offer is related to, a proxy application is made in the consuming
 model, named after the offer.
@@ -151,11 +155,11 @@ information due to rejected ingress, or if the relation is suspended etc.
 
 An offer can be consumed without relating to it. This workflow sets up the
 proxy application in the consuming model and creates a user-defined alias for
-the offer. This latter is what's used to relate to. Having an offer alias can
-avoid a namespsce conflict with a pre-existing application.
+the offer. This latter is what's used to subsequently relate to. Having an
+offer alias can avoid a namespace conflict with a pre-existing application.
 
-`juju consume <offer url> <offer alias>`
-`juju relate <application> <offer alias>`
+`juju consume <offer url> <offer alias>`  
+`juju add-relation <application> <offer alias>`
 
 Offers which have been consumed show up in `juju status` in the SAAS section.
 
@@ -167,7 +171,7 @@ exit (egress) that firewall with a modified address/network. In this case, the
 firewall on the offering side to allow this traffic. This option specifies the
 NATed address (or network) in CIDR notation:
 
-`juju relate <application> <offer url> --via <cidr subnet>`
+`juju add-relation <application> <offer url> --via <cidr subnet>`
 
 It's possible to set this up in advance at the model level in this way:
 
@@ -191,7 +195,7 @@ The above command is applied to the **offering** model.
 
 <!--
 To see what ingress is currently in use by relations to an offer, use the
-list-offers command (below).
+offers command (below).
 
 To see what firewall rules have currently been defined, use the list
 firewall-rules command.
@@ -224,7 +228,7 @@ A suspended relation is resumed by an admin on the offering side:
 `juju resume-relation <id1>`
 
 !!! Note:
-    Command `juju list-offers` lists the relation ids.
+    Command `juju offers` provides the relation ids.
 
 ### Removing relations
 
@@ -258,7 +262,7 @@ The following CMR scenarios will be examined:
 [commands-consume]: ./commands.html#consume
 [commands-find-offers]: ./commands.html#find-offers
 [commands-list-firewall-rules]: ./commands.html#list-firewall-rules
-[commands-list-offers]: ./commands.html#list-offers
+[commands-offers]: ./commands.html#offers
 [commands-offer]: ./commands.html#offer
 [commands-remove-offer]: ./commands.html#remove-offer
 [commands-resume-relation]: ./commands.html#resume-relation

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -1,5 +1,6 @@
 Title: Cross Model Relations
-TODO:  Consider adding scenario #3: different cloud types
+TODO:  Add scenario #3: different cloud types
+       Add commands to a scenario: grant|revoke, suspend|resume
 
 <!--
 

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -3,12 +3,6 @@ TODO:  Add scenario #3: different cloud types
        Add commands to a scenario: grant|revoke, suspend|resume, remove-offer
        Bug tracking: https://pad.lv/1726945
 
-<!--
-
-Need to add links from other pages.
-
--->
-
 # Cross Model Relations
 
 Cross Model Relations (CMR) allow applications in different models to be
@@ -48,7 +42,7 @@ The commands related specifically to this subject are:
 : Sets a firewall rule.
 
 [`show-offer`][commands-show-offer]
-: Shows details of connected (related to) offers.
+: Shows details for a connected (related to) offer.
 
 [`suspend-relation`][commands-suspend-relation]
 : Suspends a relation to an offer.

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -1,9 +1,6 @@
 Title: Cross Model Relations
-TODO:  Critical: Put back and continue the example scenarios
 
 <!--
-
-Commands 'find-endpoints' and 'offer' are not yet available in commands.md.
 
 Introduced terms "shared model" and "consumer model".
 
@@ -12,10 +9,6 @@ How to determine a unit's interface (e.g. mysql:db)?
 Need to add links from other pages.
 
 Also 'show-endpoints' and 'offers' (admin sees more).
-
-Multi CMR controllers are now allowed it seems.
-
-See wallyworld
 
 -->
 
@@ -65,11 +58,9 @@ The commands related specifically to this subject are:
 See [Models][models] and [Managing relations][charms-relations] for beginner
 information on those topics.
 
-<!--
 This page presents the **concepts** behind cross model relations as well as
 two example **scenarios** that aim to reinforce those concepts through
 practical usage.
--->
 
 ## Concepts
 
@@ -82,18 +73,31 @@ The idea of an *offer* is key to understanding CMR. Nevertheless, it is quite
 easy to grasp. An offer is simply an application that is making itself
 available to a consumer application.
 
-An *endpoint* is at either end of the server:client connection. There is
-therefore what is known as a *provides* endpoint (for the service end) and a
-*requires* endpoint (for the client end). The latter can also be called a
+An *endpoint* is at either end of the server/client connection and is tacked
+on to qualify the offer:
+
+`offer_name:endpoint`
+
+An offer endpoint can be thought of as being analogous to an application
+endpoint. An offer also stems from an application endpoint. Here is how an
+offer is created:
+
+`juju offer <application>:<application endpoint>`
+
+<!--
+
+There is therefore what is known as a *provides* endpoint (for the service end)
+and a *requires* endpoint (for the client end). The latter can also be called a
 *target* endpoint.
 
-An offer consists of one (or more) endpoints for a given application and
-is expressed as a URL. It is of the form:
+-->
 
-`controller:user/model.offername`
+Although an offer may have multiple endpoints it is always expressed as a
+single URL:
 
-To be clear, even if an offer has multiple endpoints, it is identified by a
-single URL.
+`[<controller>:]<user>/<model.offer_name>`
+
+If the 'controller' portion is omitted the current controller is assumed.
 
 ### Managing offers
 
@@ -117,7 +121,7 @@ that offer to be suspended. If the consume access is granted anew, each relation
 will need to be individually resumed. Suspending and resuming relations are
 explained in more detail later.
 
-## Relating to offers
+### Relating to offers
 
 If a user has consume access to an offer, they can deploy an application in
 their model and establish a relation to the offer by way of its URL.
@@ -151,7 +155,7 @@ Offers which have been consumed show up in status under the SAAS block.
 
 -->
 
-## Relations and firewalls
+### Relations and firewalls
 
 The (intended) consumer application may be deployed behind a NAT firewall, such
 that traffic egresses through a different address/network to that on which the
@@ -170,7 +174,7 @@ cross model relations use those subnets without the need of the `--via` option.
 
 `juju model-config egress-subnets=<cidr subnet>`
 
-## Restricting ingress to the offering model
+### Restricting ingress to the offering model
 
 As we have seen, it's possible for a consuming application to ask for ingress
 via an arbitrary subnet. To allow control over what ingress can be applied to
@@ -211,50 +215,48 @@ juju-application-offer  103.37.0.0/16
     cutover applies is cloud specific.
 -->
 
-## Suspending and resuming relations
+### Suspending and resuming relations
 
-Individual relations to an offer may be temporarily suspended, causing the
-consuming application to no longer have access to the offer.
+A relation to an offer may be temporarily suspended, causing the consuming
+application to no longer have access to the offer:
 
-Relations are suspended by specifying (space separated) ids. Command
-`juju list-offers` will expose these relation ids.
+`juju suspend-relation <id1>`
 
-`juju suspend-relation <id1 [id2 ...]>`
+A suspended relation is resumed by an admin on the offering side:
 
-Suspended relations are resumed by an admin on the offering side:
+`juju resume-relation <id1>`
 
-`juju resume-relation <id1 [id2 ...]>`
+!!! Note:
+    Command `juju list-offers` lists the relation ids.
 
-## Removing relations
+### Removing relations
 
 To remove a relation entirely:
 
-`juju remove-relation <id1 [id2 ...]>`
+`juju remove-relation <id1>`
 
 Removing a relation on the offering side will trigger a removal on the
 consuming side. A relation can also be removed from the consuming side, as well
 as the application proxy, resulting in all relations being removed.
 
-<!--
-
 ## Example scenarios
 
 The following CMR scenarios will be examined:
 
-- [Scenario #1](./models-cmr-scene-1.html)  
+- [Scenario #1][scenario-1]  
   A MediaWiki deployment, based within the **same** controller, used by the
   **admin** user, but consumed by **multiple** models.
-- [Scenario #2](./models-cmr-scene-2.html)  
+- [Scenario #2][scenario-2]  
   A MediaWiki deployment, based within **multiple** controllers, used by a
   **non-admin** user, and consumed by a **single** model.
-
--->
 
 
 <!-- LINKS -->
 
 [models]: ./models.html
 [charms-relations]: ./charms-relations.html
+[scenario-1]: ./models-cmr-scene-1.html
+[scenario-2]: ./models-cmr-scene-2.html
 
 [commands-consume]: ./commands.html#consume
 [commands-find-offers]: ./commands.html#find-offers

--- a/src/en/models-cmr.md
+++ b/src/en/models-cmr.md
@@ -24,7 +24,7 @@ use case would be when you are simply using different cloud types.
 The commands related specifically to this subject are:
 
 [`consume`][commands-consume]
-: Links an offer to a model. Does not relate to it.
+: Accepts an offer to a model but does not relate to it.
 
 [`find-offers`][commands-find-offers]
 : Finds URLs and endpoints of available offers.


### PR DESCRIPTION
 - This is presented in an unorthodox manner.
   - One page has concepts and simplified command syntax.
   - Two pages present scenarios that give more practical usage.
   - Once stuff settles down I'm willing to refactor.
 - Another pass of the commands (and their outputs) will be necessary prior to 2.3 release. If the model or controller names are too long I can change them at this time.
 - The links to the scenarios are not obvious. Is this another style fail?
 - Another scenario should be added soon (TODO).

fixes #2225 