### PR TITLE
Fix typo in juju-coexist install example

### DIFF
--- a/src/en/juju-coexist.md
+++ b/src/en/juju-coexist.md
@@ -25,7 +25,7 @@ apt install juju
 1.x series, you may install that separately:
 
 ```bash
-àpt install juju-1.25
+apt install juju-1.25
 ```
 **OR**, if you wish to run Juju 1.x as the 'primary' Juju (i.e. the version
 the `juju` command points to by default), you can install this package:


### PR DESCRIPTION
Fixes a typo in the juju-coexist install example.