### PR TITLE
Include links to charms.reactive docs in "reference" menu

### DIFF
--- a/src/navigation.tpl
+++ b/src/navigation.tpl
@@ -201,8 +201,16 @@
         <li><a href="reference-charm-hooks.html">Juju Charm Hooks</a></li>
         <li><a href="reference-environment-variables.html">Juju environment variables</a></li>
         <li><a href="reference-hook-tools.html">Juju Hook Tools</a></li>
-        <li><a href="reference-layer-yaml.html">Layer.yaml</a></li>
         <li><a href="authors-charm-metadata.html">metadata.yaml</a></li>
+        <li class="section"><a class="header" href="https://charmsreactive.readthedocs.io">Layers and charms.reactive</a>
+            <ul class="sub">
+                <li><a href="https://charmsreactive.readthedocs.io/en/latest/charms.reactive.decorators.html">Decorators</a></li>
+                <li><a href="https://charmsreactive.readthedocs.io/en/latest/charms.reactive.flags.html">Flags</a></li>
+                <li><a href="https://charmsreactive.readthedocs.io/en/latest/triggers.html">Triggers</a></li>
+                <li><a href="https://charmsreactive.readthedocs.io/en/latest/charms.reactive.relations.html">Relations</a></li>
+                <li><a href="reference-layer-yaml.html">Layer.yaml</a></li>
+            </ul>
+        </li>
         <li><a href="http://godoc.org/github.com/juju/juju/api">API docs</a></li>
         <li><a href="reference-release-notes.html">Release notes</a></li>
         <li><a href="reference-status.html">Status values</a></li>


### PR DESCRIPTION
This PR adds a bunch of links to the `charms.reactive` API docs.

The item is called `Layers and charms.reactive` because people might not realize that layers are a part of `charms.reactive`.