### PR TITLE
review & update install page; bonus 2.3.1 release notes

### DIFF
--- a/src/en/reference-install.md
+++ b/src/en/reference-install.md
@@ -1,144 +1,148 @@
 Title: Installing Juju
-TODO:  Review required
 
 # Getting the latest Juju
 
-Juju is available as a client on many platforms and distributions. Find your
-platform below and get started with Juju.
+Juju is available on Ubuntu, various other Linux distributions, macOS, and
+Windows. Development releases are also available for testing. All binary
+releases for all supported platforms are available on Launchpad. Please read on
+for how to install Juju on your chosen platform.
 
-## Version 2.2.6
+## Version 2.3.1
 
-The current stable version of Juju is 2.2.6 and is recommended for everyday
-production use.
-
+The most recent stable version of Juju is 2.3.1. This is the version we
+recommend for production use.
 
 ### Ubuntu
 
-For Ubuntu 16.04 LTS (Xenial) the best way to install Juju is to use snaps
-([see the snapcraft.io site][snapcraft] for more information). With snaps, the
-latest stable release of Juju can be installed with the following command:
-
-     sudo snap install juju --classic
-
-You can check which version of Juju you have installed with
-
-     sudo snap list juju
-
-And update it if necessary with:
-
-     sudo snap refresh juju
-
-Note: you can use the PPA for a stable deb package as well:
+Since Ubuntu 16.04 LTS (Xenial) the recommended way to install Juju is with
+snaps. The latest stable Juju release can be installed with the following
+command:
 
 ```bash
-sudo add-apt-repository --update ppa:juju/stable
+sudo snap install juju --classic
+```
+
+In the above, the 'stable' snap channel is used by default.
+
+The current version of an installed Juju snap is given by:
+
+```bash
+snap list juju
+```
+
+And can be updated with:
+
+```bash
+sudo snap refresh juju
+```
+
+See the [Snapcraft documentation][snapcraft] for more information on snaps. 
+
+Note: You can still use a PPA to get the stable version:
+
+```bash
+sudo add-apt-repository -yu ppa:juju/stable
 sudo apt install juju
 ```
+    
+### CentOS and other Linuxes
+
+Juju can be installed on various Linux distributions via snaps. On Ubuntu 
+snapd comes pre-installed but if you're running something else you'll need to
+visit [Install snapd][snapd-install] to get started.
+
+You can now install Juju with:
+
+```bash
+sudo snap install juju --classic
+```
+
+!!! Note:
+    The `--classic` flag is not supported on all distros. In that case, you'll
+    need to use `--devmode` instead.
+
+For CentOS, you can download Juju from the following archive and install it
+manually:
+
+[**juju-2.3.1-centos7.tar.gz**][juju-centos-2.3.1] ([md5][juju-centos-2.3.1-md5])
+
 ### macOS
 
-The easiest way to install Juju on macOS is with the [brew package
-manager][brew]. With brew installed, simply enter the following into a
-terminal:
+Install Juju on macOS with [Homebrew][homebrew]. Simply enter the following
+into a terminal:
 
 ```bash
-   brew install juju
+brew install juju
 ```
 
-If you previously installed Juju with brew, the package can be
-updated with the following:
+And upgrade Juju with the following:
 
 ```bash
-   brew upgrade juju
+brew upgrade juju
 ```
-
-Alternatively, you can manually install Juju from the following archive:
-: [juju-2.2.6-osx.tar.gz](https://launchpad.net/juju/2.2/2.2.6/+download/juju-2.2.6-osx.tar.gz)([md5](https://launchpad.net/juju/2.2/2.2.6/+download/juju-2.2.6-osx.tar.gz/+md5))
-{: .instruction }
 
 ### Windows
 
 A Windows installer is available for Juju and can be found here:
-: [juju-setup-2.2.6-signed.exe](https://launchpad.net/juju/2.2/2.2.6/+download/juju-setup-2.2.6-signed.exe)([md5](https://launchpad.net/juju/2.2/2.2.6/+download/juju-setup-2.2.6-signed.exe/+md5))
-{: .instruction }
 
-### Centos and other Linuxes
-
-Snaps enable installing the Juju client on an array of Linux distributions.
-Note that the `--classic` flag is not supported on many of them and so you'll
-need to use `--devmode` instead.
-
-See the [span install documentation][snap-install] to get snapd onto your linux and then you
-can install Juju with:
-
-```
- sudo snap install juju --classic
-```
-
-Alternatively, the latest manual install package for Centos is 2.2.6, which
-can be installed from the following archive:
-
-: [juju-2.2.6-centos7.tar.gz](https://launchpad.net/juju/2.2/2.2.6/+download/juju-2.2.6-centos7.tar.gz)([md5](https://launchpad.net/juju/2.2/2.2.6/+download/juju-2.2.6-centos7.tar.gz/+md5))
-{: .instruction }
+[**juju-setup-2.3.1-signed.exe**][juju-win-2.3.1-signed] ([md5][juju-win-2.3.1-signed-md5])
 
 ## Getting development releases
 
-The Juju team regularly puts out alpha, beta, and RC releases during a
-development cycle. We encourage users to please test these versions out with
-their workloads and use cases and [file bugs][bugs] if you hit any issues.
-Remember that while in development, feedback on usability and missing
-functionality is very important so don't just file bugs for things that go
-wrong, but also for things that have an opportunity to be "more right".
+Development releases (alpha, beta, rc) are regularly published and we encourage
+users to test these versions with real workloads and use cases. We kindly ask
+you to [file a bug][juju-new-bug] when encountering an issue. Feedback on
+usability and missing functionality is also very important to us.
 
-!!! Note:
-    The current beta version of Juju is the same as the stable version. This
-    will change as development progresses towards the next release.
+### Using snaps
 
-### Ubuntu
+See [above][anchor__centos-and-other-linuxes] for how to get started with snaps
+if you're running a non-Ubuntu Linux distro.
 
-It is possible to install other versions, including beta releases of
-Juju, via a snap package.
-
-You can update to the non-stable channels of Juju releases by using the snap
-command.
+To install a development release using snaps, instead of the 'stable' channel,
+use the 'beta' channel:
 
 ```bash
-   sudo snap install juju --beta --classic
+sudo snap install juju --beta --classic
 ```
 
-Or you can get a daily build using the edge channel.
+For a cutting edge experience choose the 'edge' channel:
 
 ```bash
-   sudo snap install juju --edge --classic
+sudo snap install juju --edge --classic
 ```
 
-### macOS
-
-On macOS you can get development Juju from the [brew package manager][brew].
-The development releases are put under the `--devel` flag in brew.
+To upgrade or downgrade, use the `refresh` command with a suitable channel.
+Below we install 'edge' and then downgrade to 'beta':
 
 ```bash
-   brew install --devel juju
+sudo snap install juju --edge --classic
+sudo snap refresh juju --beta
 ```
 
-Or you can use the binary built for macOS:
-: [juju-2.2.6-osx.tar.gz](https://launchpad.net/juju/2.2/2.2.6/+download/juju-2.2.6-osx.tar.gz)([md5](https://launchpad.net/juju/2.2/2.2.6/+download/juju-2.2.6-osx.tar.gz/+md5))
-{: .instruction }
+### Other platforms
 
-### Windows
-
-The latest is version 2.2.6 located at:
-: [juju-setup-2.2.6.exe](https://launchpad.net/juju/2.2/2.2.6/+download/juju-setup-2.2.6.exe)([md5](https://launchpad.net/juju/2.2/2.2.6/+download/juju-setup-2.2.6.exe/+md5))
-{: .instruction }
+All development release binaries are published on
+[Launchpad][juju-launchpad-binaries]. Note that leading edge builds are only
+available with snaps (via the 'edge' channel).
 
 ## Building from source
 
-Check out the [Contributing][contributing] documentation in the codebase to walk through
-building Juju from source.
+Refer to the [Contributing][contributing] documentation in the codebase for
+instructions on how to build Juju from source.
 
 
-[brew]: https://brew.sh/
-[bugs]: https://bugs.launchpad.net/juju/
+<!-- LINKS -->
+
+[homebrew]: https://brew.sh/
 [contributing]: https://github.com/juju/juju/blob/develop/CONTRIBUTING.md
-[install]: ./reference-install.html
 [snapcraft]: https://snapcraft.io
-[snap-install]: https://snapcraft.io/docs/core/install
+[snapd-install]: https://snapcraft.io/docs/core/install
+[juju-new-bug]: https://bugs.launchpad.net/juju/+filebug
+[juju-win-2.3.1-signed]: https://launchpad.net/juju/2.3/2.3.1/+download/juju-setup-2.3.1-signed.exe
+[juju-win-2.3.1-signed-md5]: https://launchpad.net/juju/2.3/2.3.1/+download/juju-setup-2.3.1-signed.exe/+md5
+[juju-centos-2.3.1]: https://launchpad.net/juju/2.3/2.3.1/+download/juju-2.3.1-centos7.tar.gz
+[juju-centos-2.3.1-md5]: https://launchpad.net/juju/2.3/2.3.1/+download/juju-2.3.1-centos7.tar.gz/+md5
+[juju-launchpad-binaries]: https://launchpad.net/juju/+series
+
+[anchor__centos-and-other-linuxes]: #centos-and-other-linuxes

--- a/src/en/reference-install.md
+++ b/src/en/reference-install.md
@@ -10,7 +10,7 @@ for how to install Juju on your chosen platform.
 ## Version 2.3.1
 
 The most recent stable version of Juju is 2.3.1. This is the version we
-recommend for production use.
+recommend for production use. See the [Release Notes][release-notes-2].
 
 ### Ubuntu
 
@@ -134,6 +134,7 @@ instructions on how to build Juju from source.
 
 <!-- LINKS -->
 
+[release-notes-2]: ./reference-release-notes.html
 [homebrew]: https://brew.sh/
 [contributing]: https://github.com/juju/juju/blob/develop/CONTRIBUTING.md
 [snapcraft]: https://snapcraft.io

--- a/src/en/reference-release-notes.md
+++ b/src/en/reference-release-notes.md
@@ -2,11 +2,20 @@ Title: Juju Release Notes
 
 # Release Notes History
 
-This section details all the available release notes for the
-2.x stable series of Juju
-(notes for [earlier releases are available here](./reference-release-notes-1.html) ).
+This page details all available release notes for the
+2.x series of Juju. The release notes for the 1.x series are available
+[here](./reference-release-notes-1.html).
 
-The versions covered here are:
+^# Juju 2.3.1
+
+  A new release of Juju is here, 2.3.1. This is primarily a bug fix release
+  which addresses this critical upgrade issue:
+
+  [LP 1737107](https://bugs.launchpad.net/juju/+bug/1737107)
+
+  Note, you may see a spurious message similar to
+  `CRITICAL ********** SetModelAgentVersion: 2.3.1 false` while upgrading. This
+  can be safely ignored and isn't present in 2.3.
 
 ^# Juju 2.3.0
 


### PR DESCRIPTION
 - Complete review of reference-install.md.
 - Update links to binaries (including signed Windows :beer: )
 - [Apparently](https://pastebin.canonical.com/205227/) we don't want people to use the macOS binaries.
 - 2.3.1 release notes included