### PR TITLE
Correct parameter name for upgrade-charm

### DIFF
--- a/src/en/authors-hook-errors.md
+++ b/src/en/authors-hook-errors.md
@@ -23,7 +23,7 @@ When a unit agent sets an error status, it stops running hooks and relinquishes
 control over the charm directory. This means that it's generally safe to `juju
 ssh` into the unit and use it as though you were the sole administrator; juju
 will only take back control of the directory when explicitly requested, in
-response to either `juju resolved` or `juju upgrade-charm --force`.
+response to either `juju resolved` or `juju upgrade-charm --force-units`.
 
   - `juju resolved` causes the unit to unblock itself and continue as though the
     hook had completed successfully. The ideal charm will be aware of this
@@ -37,12 +37,13 @@ response to either `juju resolved` or `juju upgrade-charm --force`.
     command, is your main entry point for investigating an error in detail. If the
     hook fails again when retried, it will set an error as before and wait again
     for user resolution.
-  - `juju upgrade-charm --force` merges into the charm directory the contents of
-    the newer charm version, and continues blocking in the original hook error
-    state. Each time a new upgrade is forced, the charm directory is rolled back
-    to the state from which it was originally upgraded before proceeding; this means
-    that a forced upgrade back to the original charm will always be a no-op,
-    regardless of what other upgrade attempts have been made in the interim.
+  - `juju upgrade-charm --force-units` merges into the charm directory the
+    contents of the newer charm version, and continues blocking in the original
+    hook error state. Each time a new upgrade is forced, the charm directory is
+    rolled back to the state from which it was originally upgraded before
+    proceeding; this means that a forced upgrade back to the original charm
+    will always be a no-op, regardless of what other upgrade attempts have been
+    made in the interim.
 
 Once you have issued one of the above commands, the charm directory should once
 again be treated as inaccessible.

--- a/src/en/charms-deploying.md
+++ b/src/en/charms-deploying.md
@@ -139,14 +139,14 @@ the charm to install:
 ```bash
 juju add-machine --series yakkety
 Machine 1 added.
-juju deploy mycharm --to 1 --force
+juju deploy mycharm --to 1 --series yakkety --force
 ```
 
-It may be required to use `--force` when upgrading charms. For example, in a
-case where an application is initially deployed using a charm that supports
-`precise` and `trusty`. If a new version of the charm is released that only
-supports `trusty` and `xenial` then it will be allowed to upgrade applications
-deployed on `precise`, but only using `--force-series`, like this:
+It may be required to use `--force-series` when upgrading charms. For example,
+in a case where an application is initially deployed using a charm that
+supports `precise` and `trusty`. If a new version of the charm is released that
+only supports `trusty` and `xenial` then it will be allowed to upgrade
+applications deployed on `precise`, but only using `--force-series`, like this:
 
 ```bash
 juju upgrade-charm mycharm --force-series

--- a/src/en/developer-upgrade-charm.md
+++ b/src/en/developer-upgrade-charm.md
@@ -46,12 +46,12 @@ taken place.
 
 This is quite a tight restriction, but nonetheless valuable, so long as you can
 guarantee it will run. However, it's important to understand that the upgrade-
-charm accepts a `--force` flag: a forced charm upgrade will upgrade even units
-that are currently in an [error](./authors-hook-errors.html) state, at the cost
-of skipping the `upgrade-charm` hook for those units.
+charm accepts a `--force-units` flag: a forced charm upgrade will upgrade even
+units that are currently in an [error](./authors-hook-errors.html) state, at
+the cost of skipping the `upgrade-charm` hook for those units.
 
 This is useful for charm authors who want to push a new version of a failed
-hook (they can `upgrade-charm --force` and then `resolved` to run it
+hook (they can `upgrade-charm --force-units` and then `resolved` to run it
 immediately without otherwise disturbing the system); but it's potentially
 dangerous if abused. We recommend that use of the feature be restricted to charm
 authors while developing their own charms, and that it's not sensible to devote


### PR DESCRIPTION
Commit c25f9fc623cec183195b3cf6bb8604bee1c5f7ea changed the parameter
--force to --force-units.

Update documentation to reflect this.