### PR TITLE
fix add manual dialog

### DIFF
--- a/src/en/clouds-manual.md
+++ b/src/en/clouds-manual.md
@@ -136,3 +136,4 @@ or [`bootstrap`](#bootstrapping-the-cloud) commands from Juju.
 [models-config]: ./models-config.html
 [placement]: ./charms-deploying.html#deploying-to-specific-machines-and-containers
 [commands]: ./commands.html
+[clouds__specifying-additional-clouds]: ./clouds.html#specifying-additional-clouds

--- a/src/en/clouds-manual.md
+++ b/src/en/clouds-manual.md
@@ -1,4 +1,5 @@
 Title: Adding a manual cloud
+       Critical: Review required (reconcile with add-cloud on clouds.md)
 
 # Using a "Manual" cloud
 
@@ -20,6 +21,13 @@ applications though, with a bit of extra effort.
   - They must be running SSH ([see notes below for CentOS](#additional-centos-notes))
   - You will need a login with sudo privileges on all machines
   - All machines must be able to communicate with each other over the network
+
+## Add a Manual cloud
+
+Use the interactive `add-cloud` command to add your Manual cloud to Juju's list
+of clouds. See the 'Manual' entry under
+[Specifying additional clouds][clouds__specifying-additional-clouds] for
+guidance.
 
 ## Bootstrapping the cloud
 

--- a/src/en/clouds.md
+++ b/src/en/clouds.md
@@ -1,6 +1,8 @@
 Title: Clouds
 TODO:  Needs to explain available auth types for clouds
-       Review required, check command outputs
+       Critical: Review required
+       Bug tracking: https://bugs.launchpad.net/juju/+bug/1749302
+       Bug tracking: https://bugs.launchpad.net/juju/+bug/1749583
   
 # Clouds
 
@@ -162,15 +164,13 @@ expand the relevant section). You can also generate a YAML file.
 
 ^# Manual
 
-   To add a 'manual' cloud, Juju needs to know the name you wish to call it,
-   the IP address (or hostname) used to connect to it, and what remote user
-   account to connect to (over SSH). This last is done by prepending 'user@' to
-   the address/hostname.
+   To add a Manual cloud, Juju needs to know the name you wish to call it, the
+   IP address (or hostname) used to connect to it, and what remote user account
+   to connect to (over SSH). This last is done by prepending 'user@' to the
+   address/hostname.
    
-   In regards to SSH, the user running the Juju client is expected to already
-   be able to connect to the remote host. In particular, an SSH keypair should
-   be available to the user and the corresponding public key should reside in
-   the remote user account.
+   In terms of SSH, the user running the Juju client is expected to already be
+   able to connect to the remote host (either by password or public key).
    
    A sample session looks like this:
 
@@ -192,8 +192,8 @@ expand the relevant section). You can also generate a YAML file.
       Cloud "mycloud" successfully added
       You may bootstrap with 'juju bootstrap mycloud'
 
-   Once completed, you should also remember to add a credential for this cloud before 
-   bootstrapping. See the [documentation on credentials][credentials] for more help.
+   You must now add a credential for this cloud prior to creating a controller
+   (`juju bootstrap`). See the [Credentials][credentials] page for details.
 
 ^# OpenStack
 

--- a/src/en/clouds.md
+++ b/src/en/clouds.md
@@ -162,6 +162,11 @@ expand the relevant section). You can also generate a YAML file.
    Once completed, you should also remember to add a credential for this cloud before 
    bootstrapping. See the [documentation on credentials][credentials] for more help.
 
+   <!-- STORE THIS WORDING FOR AN UPCOMING REVIEW - USE IT FOR ALL CLOUDS
+   You must now add a credential for this cloud prior to creating a controller
+   (`juju bootstrap`). See the [Credentials][credentials] page for details.
+   -->
+   
 ^# Manual
 
    To add a Manual cloud, Juju needs to know the name you wish to call it, the
@@ -191,9 +196,6 @@ expand the relevant section). You can also generate a YAML file.
       
       Cloud "mycloud" successfully added
       You may bootstrap with 'juju bootstrap mycloud'
-
-   You must now add a credential for this cloud prior to creating a controller
-   (`juju bootstrap`). See the [Credentials][credentials] page for details.
 
 ^# OpenStack
 

--- a/src/en/clouds.md
+++ b/src/en/clouds.md
@@ -197,6 +197,9 @@ expand the relevant section). You can also generate a YAML file.
       Cloud "mycloud" successfully added
       You may bootstrap with 'juju bootstrap mycloud'
 
+   A Juju-added credential is not required. The ability for Juju to make an SSH
+   connection is all that's needed.
+
 ^# OpenStack
 
    To add an OpenStack cloud, Juju needs to know the endpoints to connect to, the 

--- a/src/en/clouds.md
+++ b/src/en/clouds.md
@@ -1,5 +1,6 @@
 Title: Clouds
 TODO:  Needs to explain available auth types for clouds
+       Review required, check command outputs
   
 # Clouds
 
@@ -131,7 +132,7 @@ get them recognised is to use the `add-cloud` command in its interactive mode.
 This will ask a series of questions based on the type of cloud you are trying
 to add. Currently Juju can add MAAS, OpenStack, Oracle, vSphere and manual
 clouds in this way - each is detailed below (click on the triangle or name to
-expand the relevant section). You can also generate a YAML file
+expand the relevant section). You can also generate a YAML file.
 
 ^# MAAS
 
@@ -161,26 +162,35 @@ expand the relevant section). You can also generate a YAML file
 
 ^# Manual
 
-   To add a 'manual' cloud, Juju only needs to know the name you wish to call it, and 
-   the network address used to connect to it. A sample session looks like this:
-       
+   To add a 'manual' cloud, Juju needs to know the name you wish to call it,
+   the IP address (or hostname) used to connect to it, and what remote user
+   account to connect to (over SSH). This last is done by prepending 'user@' to
+   the address/hostname.
+   
+   In regards to SSH, the user running the Juju client is expected to already
+   be able to connect to the remote host. In particular, an SSH keypair should
+   be available to the user and the corresponding public key should reside in
+   the remote user account.
+   
+   A sample session looks like this:
+
        juju add-cloud
-  
+
        Cloud Types
         maas
         manual
         openstack
         oracle
         vsphere
-
-       Select cloud type: maas
-
-       Enter a name for your maas cloud: mainmaas
-
-       Enter the API endpoint url: http://maas.example.org:5240/MAAS/api/2.0
-
-      Cloud "mainmaas" successfully added
-      You may bootstrap with 'juju bootstrap mainmaas'
+      
+      Select cloud type: manual
+      
+      Enter a name for your manual cloud: mycloud
+      
+      Enter the controller's hostname or IP address: noah@10.143.211.93
+      
+      Cloud "mycloud" successfully added
+      You may bootstrap with 'juju bootstrap mycloud'
 
    Once completed, you should also remember to add a credential for this cloud before 
    bootstrapping. See the [documentation on credentials][credentials] for more help.

--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -8,11 +8,6 @@ itself. We use the term *credentials* to describe the tokens or keys or secrets
 used - a set of credentials is represented by a _credential name_ that is used
 to refer to those credentials in subsequent commands.
 
-!!! Important:
-    This page assumes that you have already created a controller for your
-    cloud (`juju bootstrap` command). If this is not the case, please see
-    [Creating a controller][controllers-creating] first.
-
 Juju selects a credential according to how many credentials are defined. If you
 have only one credential, or if a credential is labelled 'default', then this
 is the credential that will be used by Juju. When multiple credentials are
@@ -231,4 +226,3 @@ juju remove-credential aws bob
 [clouds-oracle]: ./help-oracle.html
 [clouds-openstack]: ./help-openstack.html
 [clouds-vmware]: ./help-vmware.html
-[controllers-creating]: ./controllers-creating.html


### PR DESCRIPTION
resolves #2445 

A wording refresh at the bottom of the Manual entry for add-cloud. I intend to use this wording in the other entries during an upcoming review of the clouds.md page.

An erroneous admonishment was removed from the credentials.md page (source: PR #2044).