### PR TITLE
update charm helpers documentation url

### DIFF
--- a/src/en/developer-getting-started.md
+++ b/src/en/developer-getting-started.md
@@ -242,7 +242,7 @@ promulgation.
 [getting-started]:    ./getting-started.html 
 [charm-tools]:        ./tools-charm-tools.html
 [charm-helpers]:      ./tools-charm-helpers.html
-[charm-helper-docs]:  http://pythonhosted.org/charmhelpers/
+[charm-helper-docs]:  https://charm-helpers.readthedocs.io/
 [interface-layers]:   ./developer-layers-interfaces.html
 [vanilla]:            http://vanillaforums.org
 [charms-local]:       ./charms-deploying.html#deploying-from-a-local-charm

--- a/src/en/developer-layers.md
+++ b/src/en/developer-layers.md
@@ -5,7 +5,7 @@ Title: Layers for charm authoring
 When creating a charm, you always have the option of doing it the traditional
 way by creating each hook, implementing each side of the interface you need for
 each relation your charm requires or provides, manage the dependencies, such as
-[charm-helpers](https://pythonhosted.org/charmhelpers/), that your charm uses,
+[charm-helpers](https://charm-helpers.readthedocs.io/), that your charm uses,
 et cetera. What you really want to do, however, is focus on *your* charm. So,
 why not leverage the reusable work of others and keep your charm code as minimal
 and tightly focused as possible?
@@ -45,7 +45,7 @@ The basic layer provides the minimum needed to use the
 * Wheelhouse support for management of python dependencies.
 * Hook decorators so the code can react to Juju Hooks.
 * Logic decorators for bash and python code (@when, @when_not, @when_any, etc).
-* A python library named [charmhelpers](https://pythonhosted.org/charmhelpers/)
+* A python library named [charmhelpers](https://charm-helpers.readthedocs.io/)
   to make writing charm code easier
 
 The most useful base layers are actually a type of runtime layer. For example,

--- a/src/en/tools-charm-helpers.md
+++ b/src/en/tools-charm-helpers.md
@@ -15,4 +15,4 @@ providing a rich collection of helpful utilities for:
 
 For instructions on installing and using Charm Helpers, along with
 examples and complete API documentation, please refer to the official
-[package documentation](http://pythonhosted.org/charmhelpers/).
+[package documentation](https://charm-helpers.readthedocs.io/).


### PR DESCRIPTION
The original url http://pythonhosted.org/charmhelpers/ is now `404 Not Found`. Update the url according to the README information of [this repository of charm-helpers](https://github.com/juju/charm-helpers).