### PR TITLE
Add ProxyFix as a middleware to set the WSGI scheme ffor X-Forwarded-Proto

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import re
 
 # External packages
 import flask
+from werkzeug.contrib.fixers import ProxyFix
 
 # Local packages
 import routing
@@ -16,6 +17,7 @@ app = flask.Flask(
     static_folder=os.path.join(base_dir, 'static'),
     template_folder=os.path.join(base_dir, 'build'),
 )
+app.wsgi_app = ProxyFix(app.wsgi_app)
 app.config['EXTRA_MEDIA_DIR'] = os.path.join(base_dir, 'build', 'en', 'media')
 
 permanent_redirects_path = app.config.get(


### PR DESCRIPTION
The issue is that images are redirected within the app via Flask. Flask is not aware its served over HTTPS so redirects are unsecure. Resulting in an orange lock in the browser. 

I am not sure of a good way to test this locally.

Please review @nottrobin @WillMoggridge