### PR TITLE
Add show-credentials command and refactor a bit

### DIFF
--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -170,11 +170,16 @@ There are several management tasks that can be done related to credentials.
 
 ### Listing credentials
 
-You can display what credentials are **available** to the Juju client by
-running the command:
+When credentials are added to Juju they become available to use on a controller
+and its models. There are therefore two categories of credentials: those that
+are available and those that are currently in use.
+
+#### Available
+
+You can display what credentials are available by running the command:
 
 ```bash
-juju credentials
+juju list-credentials
 ```
 
 Sample output:
@@ -182,7 +187,7 @@ Sample output:
 <!-- JUJUVERSION: 2.0.0-genericlinux-amd64 -->
 <!-- JUJUCOMMAND: juju credentials -->
 ```no-highlight
-Cloud      Credentials
+Cloud   Credentials
 aws     bob*, carol
 google  wayne
 ```
@@ -190,16 +195,29 @@ google  wayne
 The asterisk '*' denotes the default credential, which will be used for the
 named cloud unless another is specified.
 
-For YAML output that includes detailed credential information, including
-secrets like access keys and passwords:
+To reveal actual authentication material (e.g. passwords, keys):
 
 ```bash
-juju credentials --format yaml --show-secrets
+juju list-credentials --format yaml --show-secrets
 ```
 
-The YAML output will be similar to our 'mycreds.yaml' sample above.
+Sample output:
 
-To see what credentials are **in use** by a model (here the 'default' model):
+```no-highlight
+local-credentials:
+  aws:
+    bob:
+      auth-type: access-key
+      access-key: AKIAXZUYGB6UED2GNC5A
+      secret-key: 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
+```
+
+Notice how the output says 'local-credentials', meaning they are stored on
+the local Juju client.
+
+#### In use
+
+To see what credentials are in use by a model (here the 'default' model):
 
 ```bash
 juju show-model default
@@ -220,6 +238,32 @@ default:
 
 The `models --format yaml` command also shows this information, albeit for all
 models.
+
+The above commands do not display authentication material. To view the active
+credentials, including the cloud name, credential names, and the names of
+models:
+
+```bash
+juju show-credentials --show-secrets
+```
+
+Sample output:
+
+```no-highlight
+controller-credentials:
+  aws:
+    bob:
+      content:
+        auth-type: access-key
+        access-key: AKIAXZUYGB6UED2GNC5A
+        secret-key: StB2bmL1+tX+VX7neVgy/3JosJAwOcBIO53nyCVp
+      models:
+        controller: admin
+        default: admin
+```
+
+Notice how the output says 'controller-credentials', meaning they are stored on
+the controller.
 
 ### Setting default credentials
 

--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -265,6 +265,8 @@ controller-credentials:
 Notice how the output says 'controller-credentials', meaning they are stored on
 the controller.
 
+The `show-credentials` command queries the controller to get its information.
+
 ### Setting default credentials
 
 You can set the default credential for a cloud:


### PR DESCRIPTION
resolves #2468 

I'm not sure if `show-credentials` actually interrogates a controller to determine its output (or it is merely "remembered" locally). This is important for those who are upgrading to 2.4. I've asked.