### PR TITLE
Add default redirects from devel and stable

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,6 +1,9 @@
 (|en/?)?: /en/getting-started
+(|devel/en/?)?: /devel/en/getting-started
 
 # Redirect /stable to correct version
+(|stable/?)?: /2.3/en/getting-started
+(|stable/en/?)?: /2.3/en/getting-started
 stable/?(?P<path>.*): /2.3/{path}
 
 #en/(?P<page>.+): /2.3/en/{page}


### PR DESCRIPTION
Added redirects from:
- `/devel/en/` to `/devel/en/getting-started`
- `/stable/` to `/2.3/en/getting-started`
- `/stable/en/` to `/2.3/en/getting-started`

Fixes https://github.com/juju/docs/issues/2724