### PR TITLE
Update documentation homepage

### DIFF
--- a/src/en/index.md
+++ b/src/en/index.md
@@ -1,0 +1,90 @@
+---
+title: Home
+homepage: true
+---
+
+<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/bd1d8c1d-juju-suru-blue-background.png')">
+    <div class="p-content__row">
+        <h1>Juju Documentation</h1>
+        <p class="p-heading--four">Juju is an open source application modeling tool. It allows you to deploy, configure, scale and operate your software on public and private clouds.</p>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="p-content__row">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting started</h2>
+                <p>Juju works with public cloud, private clouds, and locally with LXD.</p>
+                <p><a href="/en/getting-started">Getting started with Juju&nbsp;&rsaquo;</a></p>
+            </div>
+            <div class="col-6 u-align--right">
+                <img style="border: 0" src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg">
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>What's new</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a href="/en/troubleshooting">Troubleshooting&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/reference-release-notes">Release notes&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/tut-lxd">Using Juju locally (LXD)&nbsp;&rsaquo;</a></li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Explore Juju</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a href="/en/reference-install">Install Juju&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/juju-concepts">Concepts and terms&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/tut-google">Working with controllers and models&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/tut-users">Working with users&nbsp;&rsaquo;</a></li>
+                </ul>
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting support</h2>
+                <ul class="p-list is-split">
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/039628d5-picto-community-orange.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="https://jujucharms.com/community">Community</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/fa38eb81-picto-business-midaubergine.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="https://jujucharms.com/experts">Professional support</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/4ef84d88-picto-quote-warmgrey.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="https://blog.ubuntu.com/tag/juju">Blog</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="http://askubuntu.com/questions/tagged/juju">Ask a question</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/422b612c-picto-forum-warmgrey.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="https://ubuntuforums.org/forumdisplay.php?f=392">Forum</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="http://webchat.freenode.net/?channels=%23juju">Freenode</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Contribute</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a class="p-link--external" href="https://github.com/juju/juju">Help improve Juju</a></li>
+                    <li class="p-list__item--deep"><a class="p-link--external" href="/en/contributing">Help improve the documentation</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/en/metadata.yaml
+++ b/src/en/metadata.yaml
@@ -1,7 +1,11 @@
 navigation:
 
-  - title: About Juju
-    location: about-juju.md
+  - title: Introduction
+    children:
+      - title: Home
+        location: index.md
+      - title: What is Juju?
+        location: about-juju.md
 
   - title: Quick Guides
 


### PR DESCRIPTION
Original design issue [here](https://github.com/ubuntudesign/vanilla-design/issues/220)

## Done

- Added a new homepage at index.md
- Changed sidebar navigation to have an "Introduction" section

**Note: The demo does not show the version dropdown - this is a workaround to get the demo working with documentation-builder. The code in this PR will allow version switching**