### PR TITLE
Fix links in menu

### DIFF
--- a/src/en/metadata.yaml
+++ b/src/en/metadata.yaml
@@ -333,22 +333,22 @@ navigation:
       - title: metadata.yaml
         location: authors-charm-metadata.md
       - title: Layers and charms.reactive
-        location: https://charmsreactive.readthedocs.io.md
+        location: https://charmsreactive.readthedocs.io
 
         children:
           - title: Decorators
-            location: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.decorators.md
+            location: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.decorators.html
           - title: Flags
-            location: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.flags.md
+            location: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.flags.html
           - title: Triggers
-            location: https://charmsreactive.readthedocs.io/en/latest/triggers.md
+            location: https://charmsreactive.readthedocs.io/en/latest/triggers.html
           - title: Relations
-            location: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.relations.md
+            location: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.relations.html
           - title: Layer.yaml
             location: reference-layer-yaml.md
 
       - title: API docs
-        location: http://godoc.org/github.com/juju/juju/api.md
+        location: http://godoc.org/github.com/juju/juju/api
       - title: Release notes
         location: reference-release-notes.md
       - title: Status values
@@ -363,4 +363,4 @@ navigation:
   - title: Help improve these docs
     location: contributing.md
   - title: Report a docs issue
-    location: https://github.com/juju/docs/issues/new.md
+    location: https://github.com/juju/docs/issues/new


### PR DESCRIPTION
resolves #2891 

Some links were changed by having URL page extensions modified during a [dubious merge](https://github.com/juju/docs/commit/375062c4642816f75cddbf6b0e8b18d4d467afcf#diff-43c3a8463efb86f4037d931844b2deab) back in April.

@degville 
@evilnick 

:warning: Review to ward off MWR.