### PR TITLE
Redirect paths without /en or a version

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,15 +1,18 @@
 ~^/(|en/?)?$ /2.4/en/getting-started;
 ~^/devel/en/?$ /devel/en/getting-started;
 
-~^en/(?<path>.+)$ /2.4/en/${path};
+~^/en/(?<path>.+)$ /2.4/en/${path};
 
-# Redirect /stable to correct version
-~^/stable/?$ /2.4/en/getting-started;
-~^/stable/en/?$ /2.4/en/getting-started;
-~^/stable/(?<path>.+)$ /2.4/${path};
+# Redirect /stable and /master to correct version
+~^/(stable|master)/?$ /2.4/en/getting-started;
+~^/(stable|master)/en/?$ /2.4/en/getting-started;
+~^/(stable|master)/(?<path>.+)$ /2.4/${path};
 
 # Redirect pages which don't specify \en\ to the \en\ version
 "~^/(?<version>[0-9-\._]+|devel)/(?<path>(?!en/).+)$" /${version}/en/${path};
+
+# Redirect pages without version or en to /en
+"~^/(?!(?<version>[0-9-\._]+|devel|stable|master|en)/)(?<path>.+)$" /en/${path};
 
 "~^/(?<version>[0-9-\._]+|devel)(/|/index)?$" /${version}/en/getting-started;
 "~^/(?<version>[0-9-\._]+|devel)/(?<language>[a-zA-Z]{2})(/|/index)?$" /${version}/${language}/getting-started;


### PR DESCRIPTION
Fixes: #2970. Might be better as a reference rather than a complete solution.