### PR TITLE
Revert redirects, and redirect base links

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,18 +1,18 @@
 ~^/(|en/?)?$ /2.4/en/getting-started;
 ~^/devel/en/?$ /devel/en/getting-started;
 
-~^/en/(?<path>.+)$ /2.4/en/${path};
+~^en/(?<path>.+)$ /2.4/en/${path};
 
-# Redirect /stable and /master to correct version
-~^/(stable|master)/?$ /2.4/en/getting-started;
-~^/(stable|master)/en/?$ /2.4/en/getting-started;
-~^/(stable|master)/(?<path>.+)$ /2.4/${path};
+# Redirect /stable to correct version
+~^/stable/?$ /2.4/en/getting-started;
+~^/stable/en/?$ /2.4/en/getting-started;
+~^/stable/(?<path>.+)$ /2.4/${path};
 
 # Redirect pages which don't specify \en\ to the \en\ version
 "~^/(?<version>[0-9-\._]+|devel)/(?<path>(?!en/).+)$" /${version}/en/${path};
 
 # Redirect pages without version or en to /en
-"~^/(?!(?<version>[0-9-\._]+|devel|stable|master|en)/)(?<path>.+)$" /en/${path};
+"~^/(?!([0-9-\._]+|devel|stable|master|en)/)(?<path>.+)$" /2.4/en/${path};
 
 "~^/(?<version>[0-9-\._]+|devel)(/|/index)?$" /${version}/en/getting-started;
 "~^/(?<version>[0-9-\._]+|devel)/(?<language>[a-zA-Z]{2})(/|/index)?$" /${version}/${language}/getting-started;


### PR DESCRIPTION
6cdf8960064d9a97a2a870f2f578206e5ebf909b broke some redirects by changing them all.

This reverts redirects.map to its original state, but preserves the new redirect to redirect e.g. /getting-started to /2.4/en/getting-started.

QA
--

After making sure you have [docker installed](https://docs.docker.com/install/):

``` bash
./run
```

When it's finished:

- go to http://localhost:8205/getting-started and see you end up at http://localhost:8205/2.4/en/getting-started
- check all images load on http://localhost:8205/2.4/en/getting-started (and other pages)
- check http://localhost:8205/2.1/en/developer-getting-started doesn't look completely unstyled

Now check the production docker image:

``` bash
docker build --tag juju-docs --build-arg COMMIT_ID=`git rev-parse --short HEAD` .
docker run --rm -p 80:80 juju-docs  # NB: Check nothing else is running on 80, e.g. microk8s
```

- go to http://localhost/getting-started and see you end up at http://localhost/2.4/en/getting-started
- check all images load on http://localhost/2.4/en/getting-started (and other pages)
- check http://localhost/2.1/en/developer-getting-started doesn't look completely unstyled