### PR TITLE
Add canonical links to latest version

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -1,5 +1,0 @@
-#! /usr/bin/env bash
-
-set -e
-
-talisker.gunicorn.gevent app:app --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ubuntudesign.documentation-builder==1.5.3
+ubuntudesign.documentation-builder==1.6.2

--- a/src/base.tpl
+++ b/src/base.tpl
@@ -15,6 +15,7 @@
     <meta charset="UTF-8" />
     <title>Juju documentation | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% if base_canonical %}<link rel="canonical" href="https://docs.jujucharms.com/{{ base_canonical }}" />{% endif %}
     <link rel="icon" href="https://assets.ubuntu.com/v1/751b08fb-favicon.ico" type="image/x-icon" />
     <style>
       /* Vanilla 1.7.1 + docs styling*/


### PR DESCRIPTION
- Use documentation-builder 1.6.2
- Create local template which added canonical links
- Remove unused `entrypoint` file

QA
--

`./run`

Go to http://localhost:8205, check the site works.

Go to an older version of a page, e.g. http://localhost:8205/2.2/en/tut-lxd. View source, check you see e.g.:

``` html
<link rel="canonical" href="https://docs.jujucharms.com/2.4/en/tut-lxd" />
```

And that the link is correct for the latest version of that document.