### PR TITLE
GCE credentials and review

### DIFF
--- a/src/en/clouds-gce.md
+++ b/src/en/clouds-gce.md
@@ -1,0 +1,296 @@
+Title: Using Google GCE with Juju
+
+# Using Google GCE with Juju
+
+Juju already has knowledge of the GCE cloud, which means adding your GCE
+account to Juju is quick and easy.
+
+You can see more specific information on Juju's GCE support (e.g. the
+supported regions) by running:
+
+```bash
+juju show-cloud google
+```
+
+If at any point you believe Juju's information is out of date (e.g. Google just 
+announced support for a new region), you can update Juju's public cloud data by
+running:
+  
+```bash
+juju update-clouds
+```
+
+## Preparing your GCE account
+
+Although Juju knows how GCE works, there are a few tasks you must perform in
+order to integrate your account with Juju. We give an overview of the steps
+here:
+
+ - Using the CLI tool
+ - Assigning permissions
+ - Gathering credential information
+
+!!! Note:
+    The Google Cloud Platform Console (web UI) can also be used to complete the
+    above steps.
+
+### Using the CLI tool
+
+We show how to use the [Cloud SDK tools][gcloud-docs] from Google to manage
+your GCP (Google Cloud Platform) account. In particular, they will allow you to
+collect your GCE credentials, which can then be added to Juju.
+
+Begin by installing the tool in this way:
+
+```bash
+export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
+	| sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt update && sudo apt install google-cloud-sdk
+```
+
+Now initialise your GCE account:
+
+```bash
+gcloud init
+```
+
+Among other things, you will be asked to enter a verification code in order to
+log in to GCP. This code is gained by following a supplied hyperlink.
+
+You will also be given the choice of selecting an existing GCE project or of
+creating a new one.
+
+At the completion of this command a default value for your user, project,
+region, and zone will be set. The following command shows the result:
+
+```bash
+gcloud config list
+```
+
+Sample output:
+
+```no-highlight
+[compute]
+region = us-east1
+zone = us-east1-d
+[core]
+account = javierlarin72@gmail.com
+disable_usage_reporting = True
+project = juju-gce-1225
+```
+
+Projects can be listed like this:
+
+```bash
+gcloud projects list
+```
+
+Output:
+
+```no-highlight
+PROJECT_ID     NAME      PROJECT_NUMBER
+juju-gce-1225  Juju-GCE  525743174537
+```
+
+Information on a particular project can be shown in this way:
+
+```bash
+gcloud projects describe juju-gce-1225
+```
+
+Output:
+
+```no-highlight
+createTime: '2016-02-18T01:00:10.043Z'
+lifecycleState: ACTIVE
+name: Juju-GCE
+projectId: juju-gce-1225
+projectNumber: '525743174537'
+```
+
+The above outputs are what will be used in the remainder of this guide.
+
+See the [gcloud documentation][gcloud-docs] for in-depth coverage of Google's
+Cloud SDK tools.
+
+### Assigning permissions
+
+The credentials you are looking for are not actually associated with your
+user. They are instead linked to a *Compute Engine service account*.
+
+To download such credentials the user, as known to *gcloud*, must have the
+authorisation to do so. This is done by assigning the *role* of 'Service
+Account Key Admin'.
+
+To do this we need to include the project name and the user's email address:
+
+```bash
+gcloud projects add-iam-policy-binding juju-gce-1225 \
+	--member user:javierlarin72@gmail.com \
+	--role roles/iam.serviceAccountKeyAdmin
+```
+
+On a per-project basis, you can list IAM members (user accounts and service
+accounts) and their roles with:
+
+```bash
+gcloud projects get-iam-policy juju-gce-1225
+```
+
+### Managing service accounts
+
+Current service accounts are viewed in this way:
+
+```bash
+gcloud iam service-accounts list
+```
+
+Sample output:
+
+```no-highlight
+NAME                                    EMAIL
+App Engine default service account      blah-gce-1225@appspot.gserviceaccount.com
+Compute Engine default service account  525743174537-compute@developer.gserviceaccount.com
+```
+
+You can create a new service account if you are having trouble identifying an
+existing one or if you want one dedicated to Juju. Here, we will create a new
+one:
+
+```bash
+gcloud iam service-accounts create juju-gce \
+	--display-name "Compute Engine Juju service account"
+```
+
+The list of service accounts now becomes:
+
+```no-highlight
+NAME                                    EMAIL
+App Engine default service account      blah-gce-1225@appspot.gserviceaccount.com
+Compute Engine default service account  525743174537-compute@developer.gserviceaccount.com
+Compute Engine Juju service account     juju-gce@juju-gce-1225.iam.gserviceaccount.com
+```
+
+### Gathering credential information
+
+You are now ready to download credentials for your chosen GCE service account.
+Here we've called the download file `juju-gce.json`:
+
+```bash
+gcloud iam service-accounts keys create juju-gce.json \
+	--iam-account=juju-gce@juju-gce-1225.iam.gserviceaccount.com
+```
+
+Store this file in the Juju client directory (e.g.
+`~/.local/share/juju/juju-gce.json`).
+
+The section [Using environment variables][#using-environment-variables] below
+explains where this data can be stored if you wish to use the
+`autoload-credentials` command to add credentials to Juju.
+
+## Adding credentials
+
+The [Cloud credentials][credentials] page offers a full treatment of credential
+management.
+
+In order to access Google GCE, you will need to add credentials to Juju. This
+can be done in one of three ways.
+
+### Using the interactive method
+
+Armed with the gathered information, you can add credentials with the command:
+
+```bash
+juju add-credential google
+```
+
+The command will interactively prompt you for the information needed for the
+chosen cloud. For the authentication type, choose 'json' and then give the full
+path to the downloaded file.
+
+Alternately, you can use these credentials with [Juju as a Service][jaas] where
+you can deploy charms using a web GUI.
+
+### Using a file
+
+A YAML-formatted file, say `mycreds.yaml`, can be used to store credential
+information for any cloud. This information is then added to Juju by pointing
+the `add-credential` command to the file:
+
+```bash
+juju add-credential myopenstack -f mycreds.yaml
+```
+
+See section [Adding credentials from a file][credentials-adding-from-file] for
+guidance on what such a file looks like.
+
+### Using environment variables
+
+With GCE you have the option of adding credentials using the following
+environment variable that may already be present (and set) on your client
+system:
+
+`CLOUDSDK_COMPUTE_REGION`
+
+In addition, a special variable may contain the path to a JSON-formatted file
+which, in turn, contains credential information:
+
+`GOOGLE_APPLICATION_CREDENTIALS`  
+
+Add this credential information to Juju in this way:
+  
+```bash
+juju autoload-credentials
+```
+
+For any found credentials you will be asked which ones to use and what name to
+store them under.
+
+On Linux systems, the file
+`$HOME/.config/gcloud/application_default_credentials.json` may be used to
+contain credential data and is parsed by the above command as part of the
+scanning process. On Windows systems, the file is
+`%APPDATA%\gcloud\application_default_credentials.json`.
+
+For background information on this method read section
+[Adding credentials from environment variables][credentials-adding-from-variables].
+
+## Creating a controller
+
+You are now ready to create a Juju controller for cloud 'google':
+
+```bash
+juju bootstrap google google-controller
+```
+
+Above, the name given to the new controller is 'google-controller'. GCE will
+provision an instance to run the controller on.
+
+For a detailed explanation and examples of the `bootstrap` command see the
+[Creating a controller][controllers-creating] page.
+
+## Next steps
+
+A controller is created with two models - the 'controller' model, which
+should be reserved for Juju's internal operations, and a model named
+'default', which can be used for deploying user workloads.
+
+See these pages for ideas on what to do next:
+
+ - [Juju models][models]
+ - [Introduction to Juju Charms][charms]
+
+
+<!-- LINKS -->
+
+[jaas]: ./getting-started.md
+[controllers-creating]: ./controllers-creating.md
+[models]: ./models.md
+[charms]: ./charms.md
+[credentials]: ./credentials.md
+[credentials-adding-from-file]: ./credentials.md#adding-credentials-from-a-file
+[credentials-adding-from-variables]: ./credentials.md#adding-credentials-from-environment-variables
+[#using-environment-variables]: #using-environment-variables
+[gcloud-docs]: 

--- a/src/en/clouds-gce.md
+++ b/src/en/clouds-gce.md
@@ -20,10 +20,6 @@ running:
 juju update-clouds
 ```
 
-The instructions on this page make use of the Identity and Access Management
-(IAM) framework to control access to your GCP account. Read Google's
-[Cloud IAM][gce-iam] page for an overview.
-
 ## Preparing your GCE account
 
 Although Juju knows how GCE works, there are a few tasks you must perform in
@@ -31,13 +27,18 @@ order to integrate your account with Juju. We give an overview of the steps
 here:
 
  - Using the CLI tools
- - Assigning permissions
+ - Assigning user permissions
  - Managing service accounts
  - Gathering credential information
+ - Enabling the Compute Engine API
 
 !!! Note:
     The Google [Cloud Platform Console][google-cpc] (web UI) can also be used
     to complete the above steps.
+
+The instructions on this page make use of the Identity and Access Management
+(IAM) framework to control access to your GCP account. Read Google's
+[Cloud IAM][gce-iam] page for an overview.
 
 ### Using the CLI tools
 
@@ -75,7 +76,7 @@ exiting. If it does, re-invoke `gcloud init` and choose option [1] to
 re-initialise.
 
 When you're done, try out the following commands (we created a project called
-'juju-gce-123'):
+'juju-gce-123' during the init phase):
 
 ```bash
 gcloud components list
@@ -87,7 +88,7 @@ gcloud projects describe juju-gce-123
 See the [gcloud command reference][gcloud-commands] for more help with this
 tool.
 
-### Assigning permissions
+### Assigning user permissions
 
 Using the IAM framework, we'll be associating credentials with our project at
 the *Compute Engine service account* level and not at the level of your
@@ -95,7 +96,7 @@ personal user.
 
 To download such credentials, however, your personal user (now known to the CLI
 tool) must have the authorisation to do so. This is done by assigning the
-*role* of 'Service Account Key Admin' to your user (insert your project ID and
+role of 'Service Account Key Admin' to your user (insert your project ID and
 user's email address):
 
 ```bash
@@ -170,6 +171,44 @@ Store this file on the Juju client (e.g. `~/.local/share/juju/juju-gce-sa.json`)
 The section [Using environment variables][#using-environment-variables] below
 explains where this data can be stored if you wish to use the
 `autoload-credentials` command to add credentials to Juju.
+
+### Enabling the Compute Engine API
+
+The Compute Engine API needs to be enabled for your project but this requires 
+your billing account to be first linked to your project.
+
+Your billing (credit card) should have been set up when you registered with
+GCE. To see your billing account number:
+
+```bash
+gcloud alpha billing accounts list
+```
+
+Sample output:
+
+```no-highlight
+ACCOUNT_ID            NAME                OPEN  MASTER_ACCOUNT_ID
+01ACD0-B3D759-187641  My Billing Account  True
+```
+
+Use the account number/ID to link your project:
+
+```bash
+gcloud alpha billing projects link juju-gce-123 --billing-account 01ACD0-B3D759-187641
+```
+
+You can now enable the Compute Engine API for your project (this can take a few
+minutes to complete):
+
+```bash
+gcloud services enable compute.googleapis.com --project juju-gce-123
+```
+
+Verify by listing all currently enabled services/APIs:
+
+```bash
+gcloud services list --project juju-gce-123
+```
 
 ## Adding credentials
 

--- a/src/en/clouds-gce.md
+++ b/src/en/clouds-gce.md
@@ -223,7 +223,8 @@ can be done in one of three ways (as shown below).
     is chiefly relevant in a multi-project (multi-credential) scenario.
 
 Alternately, you can use your credentials with [Juju as a Service][jaas], where
-charms can be deployed using a web GUI.
+charms can be deployed within a graphical environment that comes equipped with
+a ready-made controller.
 
 ### Using the interactive method
 

--- a/src/en/clouds-gce.md
+++ b/src/en/clouds-gce.md
@@ -43,11 +43,9 @@ The instructions on this page make use of the Identity and Access Management
 ### Using the CLI tools
 
 We show how to use the [Cloud SDK tools][google-cloud-sdk-docs] from Google to
-manage your GCP (Google Cloud Platform) account. In particular, they will allow
-you to collect your GCE credentials, which can then be added to Juju.
-
-The tools installation instructions presented here are for Ubuntu/Debian. See
-the link above for how to install on other platforms.
+manage your GCP (Google Cloud Platform) account. The tools installation
+instructions presented here are for Ubuntu/Debian. See the link above for how
+to install on other platforms.
 
 Install the tools in this way:
 
@@ -66,9 +64,9 @@ gcloud init
 ```
 
 Among other things, you will be asked to enter a verification code in order to
-log in to GCP. This code is gained by following a supplied hyperlink, which, in
-turn, will involve you pressing a button on the resulting page allowing Google
-Cloud SDK to access your user's Google account.
+log in to GCP. This code is acquired by following a supplied hyperlink, which,
+in turn, will have you agree on the resulting page to allow Google Cloud SDK to
+access your Google account.
 
 You will be given the choice of selecting an existing GCE project or of
 creating a new one. If creating, pick a unique name to prevent the command from
@@ -76,13 +74,13 @@ exiting. If it does, re-invoke `gcloud init` and choose option [1] to
 re-initialise.
 
 When you're done, try out the following commands (we created a project called
-'juju-gce-123' during the init phase):
+'juju-gce-1' during the init phase):
 
 ```bash
 gcloud components list
 gcloud config list
 gcloud projects list
-gcloud projects describe juju-gce-123
+gcloud projects describe juju-gce-1
 ```
 
 See the [gcloud command reference][gcloud-commands] for more help with this
@@ -92,15 +90,15 @@ tool.
 
 Using the IAM framework, we'll be associating credentials with our project at
 the *Compute Engine service account* level and not at the level of your
-personal user.
+Google user.
 
-To download such credentials, however, your personal user (now known to the CLI
-tool) must have the authorisation to do so. This is done by assigning the
-role of 'Service Account Key Admin' to your user (insert your project ID and
+To download such credentials, however, your user (now known to the CLI tool)
+must have the authorisation to do so. This is done by assigning the role of
+'Service Account Key Admin' to your user (insert your project ID and your
 user's email address):
 
 ```bash
-gcloud projects add-iam-policy-binding juju-gce-123 \
+gcloud projects add-iam-policy-binding juju-gce-1 \
 	--member user:javierlarin72@gmail.com \
 	--role roles/iam.serviceAccountKeyAdmin
 ```
@@ -110,7 +108,7 @@ gcloud projects add-iam-policy-binding juju-gce-123 \
 A project's service accounts are listed in this way:
 
 ```bash
-gcloud iam service-accounts list --project juju-gce-123
+gcloud iam service-accounts list --project juju-gce-1
 ```
 
 You can create a new service account if:
@@ -119,10 +117,10 @@ You can create a new service account if:
  - your project does not yet have any service accounts
  - you want one dedicated to Juju
  
-Here, we will create a new one called 'juju-gce-sa':
+Here, we will create a new one called 'juju-gce-1-sa':
 
 ```bash
-gcloud iam service-accounts create juju-gce-sa \
+gcloud iam service-accounts create juju-gce-1-sa \
 	--display-name "Compute Engine Juju service account"
 ```
 
@@ -130,7 +128,7 @@ For our example project, the list of service accounts is now:
 
 ```no-highlight
 NAME                                    EMAIL
-Compute Engine Juju service account     juju-gce-sa@juju-gce-123.iam.gserviceaccount.com
+Compute Engine Juju service account     juju-gce-1-sa@juju-gce-1.iam.gserviceaccount.com
 ```
 
 We must now give our chosen service account enough permissions so it can do
@@ -138,11 +136,11 @@ what Juju asks of it. The roles of 'Compute Instance Admin (v1)' and 'Compute
 Security Admin' are sufficient:
 
 ```bash
-gcloud projects add-iam-policy-binding juju-gce-123 \
-	--member serviceAccount:juju-gce-sa@juju-gce-123.iam.gserviceaccount.com \
+gcloud projects add-iam-policy-binding juju-gce-1 \
+	--member serviceAccount:juju-gce-1-sa@juju-gce-1.iam.gserviceaccount.com \
 	--role roles/compute.instanceAdmin.v1
-gcloud projects add-iam-policy-binding juju-gce-123 \
-	--member serviceAccount:juju-gce-sa@juju-gce-123.iam.gserviceaccount.com \
+gcloud projects add-iam-policy-binding juju-gce-1 \
+	--member serviceAccount:juju-gce-1-sa@juju-gce-1.iam.gserviceaccount.com \
 	--role roles/compute.securityAdmin
 ```
 
@@ -153,20 +151,20 @@ details.
 Verify the roles now assigned to both your user and your service account:
 
 ```bash
-gcloud projects get-iam-policy juju-gce-123
+gcloud projects get-iam-policy juju-gce-1
 ```
 
 ### Gathering credential information
 
 You are now ready to download credentials for your chosen service account.
-Here we've called the download file `juju-gce-sa.json`:
+Here we've called the download file `juju-gce-1-sa.json`:
 
 ```bash
-gcloud iam service-accounts keys create juju-gce-sa.json \
-	--iam-account=juju-gce-sa@juju-gce-123.iam.gserviceaccount.com
+gcloud iam service-accounts keys create juju-gce-1-sa.json \
+	--iam-account=juju-gce-1-sa@juju-gce-1.iam.gserviceaccount.com
 ```
 
-Store this file on the Juju client (e.g. `~/.local/share/juju/juju-gce-sa.json`).
+Store this file on the Juju client (e.g. `~/.local/share/juju/juju-gce-1-sa.json`).
 
 The section [Using environment variables][#using-environment-variables] below
 explains where this data can be stored if you wish to use the
@@ -194,20 +192,20 @@ ACCOUNT_ID            NAME                OPEN  MASTER_ACCOUNT_ID
 Use the account number/ID to link your project:
 
 ```bash
-gcloud alpha billing projects link juju-gce-123 --billing-account 01ACD0-B3D759-187641
+gcloud alpha billing projects link juju-gce-1 --billing-account 01ACD0-B3D759-187641
 ```
 
 You can now enable the Compute Engine API for your project (this can take a few
 minutes to complete):
 
 ```bash
-gcloud services enable compute.googleapis.com --project juju-gce-123
+gcloud services enable compute.googleapis.com --project juju-gce-1
 ```
 
 Verify by listing all currently enabled services/APIs:
 
 ```bash
-gcloud services list --project juju-gce-123
+gcloud services list --project juju-gce-1
 ```
 
 ## Adding credentials
@@ -217,6 +215,12 @@ management.
 
 In order to access Google GCE, you will need to add credentials to Juju. This
 can be done in one of three ways (as shown below).
+
+!!! Important:
+    The project that gets used by Juju is determined by the service account's
+    credentials used to create a controller. It is therefore recommended that
+    the user-defined credential name strongly reflects the project name. This
+    is chiefly relevent in a multi-project (multi-credential) scenario.
 
 Alternately, you can use your credentials with [Juju as a Service][jaas], where
 charms can be deployed using a web GUI.
@@ -233,7 +237,7 @@ The command will prompt you for information that the chosen cloud needs. An
 example session follows:
 
 ```no-highlight
-Enter credential name: juju-gce-sa
+Enter credential name: juju-gce-1-sa
 
 Auth Types
   jsonfile
@@ -241,9 +245,9 @@ Auth Types
 
 Select auth type [jsonfile]: 
 
-Enter file: ~/.local/share/juju/juju-gce-sa.json
+Enter file: ~/.local/share/juju/juju-gce-1-sa.json
 
-Credential "juju-gce-sa" added locally for cloud "google".`
+Credential "juju-gce-1-sa" added locally for cloud "google".`
 ```
 
 ### Using a file

--- a/src/en/clouds-gce.md
+++ b/src/en/clouds-gce.md
@@ -220,7 +220,7 @@ can be done in one of three ways (as shown below).
     The project that gets used by Juju is determined by the service account's
     credentials used to create a controller. It is therefore recommended that
     the user-defined credential name strongly reflects the project name. This
-    is chiefly relevent in a multi-project (multi-credential) scenario.
+    is chiefly relevant in a multi-project (multi-credential) scenario.
 
 Alternately, you can use your credentials with [Juju as a Service][jaas], where
 charms can be deployed using a web GUI.

--- a/src/en/credentials.md
+++ b/src/en/credentials.md
@@ -141,6 +141,40 @@ credentials:
     peter:
       auth-type: jsonfile
       file: ~/.config/gcloud/application_default_credentials.json
+    juju-gce-sa:
+      auth-type: oauth2
+      project-id: juju-gce-123
+      private-key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCzTFMj0/GvhrcZ
+        3B2584ZdDdsnVuHb7OYo8eqXVLYzXEkby0TMu2gM81LdGp6AeeB3nu5zwAf71YyP
+        erF4s0falNPIyRjDGYV1wWR+mRTbVjYUd/Vuy+KyP0u8UwkktwkP4OFR270/HFOl
+        Kc0rzflag8zdKzRhi7U1dlgkchbkrio148vdaoZZo67nxFVF2IY52I2qGW8VFdid
+        z+B9pTu2ZQKVeEpTVe5XEs3y2Y4zt2DCNu3rJi95AY4VDgVJ5f1rnWf7BwZPeuvp
+        0mXLKzcvD31wEcdE6oAaGu0x0UzKvEB1mR1pPwP6qMHdiJXzkiM9DYylrMzuGL/h
+        VAYjhFQnAgMBAAECggEADTkKkJ10bEt1FjuJ5BYCyYelRLUMALO4RzpZrXUArHz/
+        CN7oYTWykL68VIE+dNJU+Yo6ot99anC8GWclAdyTs5nYnJNbRItafYd+3JwRhU0W
+        vYYZqMtXs2mNMYOC+YNkibIKxYZJ4joGksTboRvJne4TN7Et/1uirr+GtLPn+W/e
+        umXfkpbOTDDAED8ceKKApAn6kLIW98DwHyK0rUzorOgp4DFDX9CjuWC+RG3CFGsk
+        oVOcDuTevJlb9Rowj1S2qYhGjuQVpVD7bcRg5zaSJKS88YbK63DCHZFpXn9JR0Fg
+        Vou9dnc99FdMo5vtHg7Adxh91gdqEvoaF1lHx8Var0q32QDse+spvv7K6/+7G35k
+        3+1gDgF74/uMr/AVrjpoUjmGAuWweXY/vn1MVN2Uld4KPYafkOF8oTuDK5f1fu0d
+        cMEoKRSXQh1NCD3PZWfQt4ypYPzn9R+VBGwnBcPorytlhM9qdLxKKlaHjBlprS6Y
+        Be1z6FO+MqWhFlwPrKH/2uwd4QKBgQDCGESJur9OdEeroBQyYyJF7DnJ/+wHSiOr
+        qzvb9YW1Ddtg1iiKHHZO5FS59/D62kPaGsysCMKxI9FW53TzSxUiTaEG636C5v8J
+        eRdzxX04BNYNzqXbm1agBEjAa7tK8xJAjk0to4zqadUaYZog0uQs2X7Aexj2c9T/
+        HQVLILHjBwKBgD/yuoLNbST+cGbuZl1s2EnTP796xPkkUm3qcUzofzmn6uivz7Qp
+        FMThZhHZ/Der98tra91a4e8fHaUTL5d4eCMeCL1mWXoNMnm02D/ugpEC8yDefi3T
+        xlM/Ed0IEVogcd49tvTvQfrhfbW/6Que/rkLKCoUlAldfIOYkS4YyyTBAoGACCpH
+        L9gYVi+UGEc6skfzWCew4quOfVwEFiO09/LjNhOoJ/G6cNzzqSv32H7yt0rZUeKQ
+        u6f+sL8F/nbsN5PwBqpnXMgpYU5gakCa2Pb05pdlfd00owFs6nxjpxyhG20QVoDm
+        BEZ+FhpvqZVzi2/zw2M+7s/+49dJnZXV9Cwi758CgYAquNdD4RXU96Y2OjTlOSvM
+        THR/zY6IPeO+kCwmBLiQC3cv59gaeOp1a93Mnapet7a2/WZPL2Al7zwnvZYsHc4z
+        nu1acd6D7H/9bb1YPHMNWITfCSNXerJ2idI689ShYjR2sTcDgiOQCzx+dwL9agaC
+        WKjypRHpiAMFbFqPT6W2uA==
+        -----END PRIVATE KEY-----
+      client-id: "206517233375074786882"
+      client-email: juju-gce-sa@juju-gce-123.iam.gserviceaccount.com
   azure:
     peter:
       auth-type: service-principal-secret


### PR DESCRIPTION
resolves #2968 

This has turned into a beast. Possibly a sub-page. But maybe it's fine.

I removed some sample command outputs to keep the page from getting too long.

Due to the immense change I chose to write this on a new page for now (clouds-gce.md).

One important piece that needs clarification is how to tell GCP what project to use by default. With `gcloud` I see a certain project in the "default configuration" but tests show that a different project ends up getting used on GCP. 