### PR TITLE
Limit getting-started redirect to 1.25

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,21 +1,24 @@
-~^/(|en/?)?$ /2.4/en/getting-started;
-~^/devel/en/?$ /devel/en/getting-started;
+~^/(|en/?)?$ /2.4/en/;
+~^/devel/en/?$ /devel/en/;
 
 ~^en/(?<path>.+)$ /2.4/en/${path};
 
 # Redirect /stable to correct version
-~^/stable/?$ /2.4/en/getting-started;
-~^/stable/en/?$ /2.4/en/getting-started;
+~^/stable/?$ /2.4/en/;
+~^/stable/en/?$ /2.4/en/;
 ~^/stable/(?<path>.+)$ /2.4/${path};
 
 # Redirect pages which don't specify \en\ to the \en\ version
-"~^/(?<version>[0-9-\._]+|devel)/(?<path>(?!en/).+)$" /${version}/en/${path};
+"~^/(?<version>[0-9-\._]+|devel)/(?<path>(?!en/?).+)$" /${version}/en/${path};
 
 # Redirect pages without version or en to /en
 "~^/(?!([0-9-\._]+|devel|stable|master|en)/)(?<path>.+)$" /2.4/en/${path};
 
-"~^/(?<version>[0-9-\._]+|devel)(/|/index)?$" /${version}/en/getting-started;
-"~^/(?<version>[0-9-\._]+|devel)/(?<language>[a-zA-Z]{2})(/|/index)?$" /${version}/${language}/getting-started;
+# Redirect 1.25 docs index to getting-started page
+"~^/1\.25(/|/index)?$" /1.25/en/getting-started;
+"~^/1\.25/(?<language>[a-zA-Z]{2})(/|/index)?$" /1.25/${language}/getting-started;
+
+# Redirect old media paths
 "~^/(?<version>[0-9-\._]+|devel)/en/media/(?<filename>.+)$" /en/media/${filename};
 
 # Redirect help-google to clouds-gce


### PR DESCRIPTION
Prevent the `/` and `/index` from redirecting to `/get-started`, except for 1.25 docs which don't have an index home page.
This removes the getting started page from the `/stable` redirects as well

http://localhost:8205/2.4/en/ should not redirect

http://localhost:8205/1.25/en/ should redirect to http://localhost:8205/2.4/en/getting-started