### PR TITLE
Remove tut-google from menu

### DIFF
--- a/src/en/metadata.yaml
+++ b/src/en/metadata.yaml
@@ -16,8 +16,6 @@ navigation:
         location: whats-new.md
       - title: Using Juju locally (LXD)
         location: tut-lxd.md
-      - title: Controllers and Models
-        location: tut-google.md
       - title: Sharing and Users
         location: tut-users.md
 


### PR DESCRIPTION
This is supposed to be a tutorial that demonstrates how to manage controllers and models. It also contains a lot of good web UI material. Half of it covers how to work with the GCE cloud but the latest overhaul of the central GCE page covers this very well. I will open an issue where the remaining good material can be recycled into a tutorial that assumes a working cloud.