### PR TITLE
edit README.md to indicate obsolete contributor instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Documentation for Juju
 
+**
+THESE INSTRUCTIONS ARE OBSOLETE.
+WORKAROUND: APPLY THE MAAS PROJECT CONTRIBUTOR PAGES TO JUJU:
+
+https://github.com/CanonicalLtd/maas-docs
+
+JUJU DOCUMENTATION WILL ALSO SOON BE MOVING TO DISCOURSE:
+
+https://discourse.jujucharms.com
+**
+
 The documentation is written in Markdown, and then generated into HTML.
 
 The latest version of these docs live at:


### PR DESCRIPTION
Point users to MAAS instructions as a workaround.