### PR TITLE
Describe the root-disk-source constraint available for OpenStack

### DIFF
--- a/1097-using-openstack-with-juju.md
+++ b/1097-using-openstack-with-juju.md
@@ -184,6 +184,14 @@ juju bootstrap <cloud> <controller name> --config network=<network_id> \
 
 For a detailed explanation and examples of the `bootstrap` command see the [Creating a controller](/t/creating-a-controller/1108) page.
 
+## OpenStack-specific features
+
+`v.2.6.4` provides a new constraint: ‘root-disk-source’. This allows operators to specify a Cinder block storage volume that will be used to create instances' root disks:
+
+```text
+juju deploy myapp --constraints root-disk-source=volume
+```
+
 <h2 id="heading--next-steps">Next steps</h2>
 
 A controller is created with two models - the 'controller' model, which should be reserved for Juju's internal operations, and a model named 'default', which can be used for deploying user workloads.

--- a/1160-juju-constraints.md
+++ b/1160-juju-constraints.md
@@ -38,7 +38,7 @@ Disk space on the root drive (MiB). An optional suffix of M/G/T/P is used as per
 - `root-disk-source` (`v.2.5.3`)
 Name of storage object which houses the root disk.
 
-  **Note:** Currently only supported by the vSphere provider. It gives the name of a vSphere datastore.
+  **Note:** Supported by the vSphere and OpenStack providers. For vSphere, specify a datastore. For OpenStack, specify a Cinder block device.
 
 - `tags`
 Comma-delimited tags assigned to the machine. Tags can be positive, denoting an attribute of the machine, or negative (prefixed with "^"), to denote something that the machine does not have.


### PR DESCRIPTION
The `root-disk-source` constraint is currently undocumented for the OpenStack provider. This commit mentions it in the constraints reference and the openstack-cloud pages.