### PR TITLE
Update site to use multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,102 @@
+# [os] OS & editor files
+**/Desktop.ini
+**/Thumbs.db
+**/._*
+**/*.DS_Store
+**/*~
+**/\#*\#
+**/.AppleDouble
+**/.LSOverride
+**/.spelling
+**/.vscode
+**/*.swp
+**/.ropeproject
+.idea
+
+# Virtual environment
+env/
+env[23]/
+.env/
+.venv/
+venv/
+.Python
+.envrc
+
+# Data, compiled, build or log files
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+logs/
+lib64/
+parts/
+sdist/
+var/
+_site/
+**/*.*.map
+*.egg-info/
+.installed.cfg
+*.egg
+pip-log.txt
+pip-delete-this-directory.txt
+pids
+*.pid
+*.seed
+.*-metadata
+**/*.sqlite
+**/*.sqlite3
+**/*-cache/
+**/*.log
+**/*.bak
+**/*.manifest
+**/*.spec
+**/__pycache__/
+**/*.py[cod]
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Deliberately ignore certain project files
+# ==
+
+# Readmes
+README.md
+HACKING.md
+
+# The run script
+run
+.docker-project
+.*.hash
+
+# Node is only needed for building, not running
+package.json
+node_modules
+yarn.lock
+
+# Git, travis, docker
+.travis.yml
+docker-compose.yml
+.docker
+
+# Sphinx documentation
+docs/_build/
+
+# Local dependencies
+.bundle/
+node_modules/
+vendor/
+bower_components/
+package-lock.json
+yarn.lock
+bin/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,37 @@
+# syntax=docker/dockerfile:experimental
+
+# Build stage: Build docs
+# ===
+FROM ubuntu:focal AS build-docs
+
+WORKDIR /srv
+ADD . .
+
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools git
+RUN pip3 install --requirement requirements.txt
+RUN /srv/build.sh
+
+# Build the production image
+# ===
 FROM ubuntu:focal
 
 # Set up environment
 ENV LANG C.UTF-8
 WORKDIR /srv
 
-# System dependencies
-RUN apt-get update && apt-get install --yes nginx
+# Install nginx
+RUN apt-get update && apt-get install --no-install-recommends --yes nginx
 
-# Set git commit ID
-ARG BUILD_ID
-RUN test -n "${BUILD_ID}"
-
-# Copy over files
-ADD build .
-ADD nginx.conf /etc/nginx/sites-enabled/default
+# Import code, build assets and mirror list
 ADD redirects.map /etc/nginx/redirects.map
+COPY --from=build-docs srv/build .
+
+ARG BUILD_ID
+ADD nginx.conf /etc/nginx/sites-enabled/default
 RUN sed -i "s/~BUILD_ID~/${BUILD_ID}/" /etc/nginx/sites-enabled/default
 RUN sed -i "s/8205/80/" /etc/nginx/sites-enabled/default
 
 STOPSIGNAL SIGTERM
 
 CMD ["nginx", "-g", "daemon off;"]
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+documentation-builder --template-path src/base.tpl --source-folder src --media-path src/en/media --output-media-path build/en/media --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.jujucharms.com' --search-url 'https://www.ubuntu.com/search' --search-placeholder 'Search Juju docs' --no-link-extensions --build-version-branches --site-root https://jujucharms.com/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "clean": "rm -rf node_modules build yarn-error.log css static/css *.log *.sqlite .extra templates",
     "watch": "watch -p './**/*.md' -c 'yarn run build'",
-    "build": "documentation-builder --template-path src/base.tpl --source-folder src --media-path src/en/media --output-media-path build/en/media --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.jujucharms.com' --search-url 'https://www.ubuntu.com/search' --search-placeholder 'Search Juju docs' --no-link-extensions --build-version-branches --site-root https://jujucharms.com/"
+    "build": "./build.sh"
   },
   "dependencies": {
     "watch-cli": "^0.2.2",


### PR DESCRIPTION
# Done

Update site to use multistage build
Standardize our build process

# QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag conjure-up-docs .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key conjure-up-docs`
- http://localhost:8006/stable/en/
- Make sure it works as usual